### PR TITLE
feat: add category overrides and editor

### DIFF
--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -95,15 +95,15 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
   - ✅ Integrate into credit card and bank account parsers
   - ✅ Update UI to display categories with icons
 
-- [ ] **2.3** Transaction Categorizer (TDD)
-  - [ ] Write tests for auto-categorization logic
-  - [ ] Write tests for income detection (credits, salary)
-  - [ ] Write tests for transfer detection
-  - [ ] Write tests for fee detection
-  - [ ] Implement categorization service
-  - [ ] Add confidence scores for categorizations
+- [x] **2.3** Transaction Categorizer (TDD) ✅
+  - ✅ Write tests for auto-categorization logic
+  - ✅ Write tests for income detection (credits, salary)
+  - ✅ Write tests for transfer detection
+  - ✅ Write tests for fee detection
+  - ✅ Implement categorization service
+  - ✅ Add confidence scores for categorizations
 
-- [ ] **2.4** Manual Category Override (TDD)
+- [x] **2.4** Manual Category Override (TDD) ✅
   - ✅ Write tests for user category assignments
   - ✅ Write tests for persisting user preferences
   - ✅ Implement override functionality
@@ -296,12 +296,14 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
 
 ---
 
-## Current Heat: HEAT 2
+## Current Heat: HEAT 3
 **Status**: IN PROGRESS 🔥
 **Completed**:
 - 2.1 - Define Category System (TDD) ✅
 - 2.2 - Build Merchant Pattern Matcher (TDD) ✅
-**Next Task**: 2.3 - Transaction Categorizer (TDD)
+- 2.3 - Transaction Categorizer (TDD) ✅
+- 2.4 - Manual Category Override (TDD) ✅
+**Next Task**: 3.1 - Transaction Store (TDD)
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { FileUpload } from './components/FileUpload'
 import { ParsedDataDisplay } from './components/ParsedDataDisplay'
 import { parseCSV } from './services/parsers'
 import type { ParsedData } from './models'
+import { Category } from './models'
+import { setMerchantCategoryOverride } from './services/categorizer/category-overrides'
 
 function App() {
   const [parsedData, setParsedData] = useState<ParsedData | null>(null)
@@ -30,6 +32,35 @@ function App() {
     setError(null)
   }
 
+  const handleCategoryChange = (
+    transactionId: string,
+    nextCategory: Category
+  ) => {
+    setParsedData((current) => {
+      if (!current) {
+        return current
+      }
+
+      const updatedTransactions = current.transactions.map((tx) => {
+        if (tx.id !== transactionId) {
+          return tx
+        }
+
+        setMerchantCategoryOverride(tx.description, nextCategory)
+        return {
+          ...tx,
+          category: nextCategory,
+          categoryConfidence: 1,
+        }
+      })
+
+      return {
+        ...current,
+        transactions: updatedTransactions,
+      }
+    })
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="container mx-auto px-4 py-8 max-w-7xl">
@@ -54,7 +85,11 @@ function App() {
             </div>
           </div>
         ) : parsedData ? (
-          <ParsedDataDisplay data={parsedData} onReset={handleReset} />
+          <ParsedDataDisplay
+            data={parsedData}
+            onReset={handleReset}
+            onCategoryChange={handleCategoryChange}
+          />
         ) : (
           <div>
             <FileUpload onFileSelect={handleFileSelect} />

--- a/src/components/ParsedDataDisplay.test.tsx
+++ b/src/components/ParsedDataDisplay.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ParsedDataDisplay } from './ParsedDataDisplay'
+import { Category } from '../models'
+import type { ParsedData } from '../models'
+import { clearAllCategoryOverrides } from '../services/categorizer/category-overrides'
+
+const sampleData: ParsedData = {
+  fileType: 'credit_card',
+  fileName: 'sample.csv',
+  parsedAt: new Date('2025-01-01T00:00:00.000Z'),
+  metadata: {
+    cliente: 'Test User',
+    numeroTarjeta: 'XXXX-1234',
+    alias: 'Visa',
+    tipoProducto: 'Tarjeta de credito',
+    fechaCorte: '01/01/2025',
+    fechaVencimiento: '10/01/2025',
+    limiteCreditoUSD: '0,00',
+    limiteCreditoUYU: '0,00',
+    saldoAnteriorUSD: '0,00',
+    saldoAnteriorUYU: '0,00',
+    pagoMinimoUSD: '0,00',
+    pagoMinimoUYU: '0,00',
+    pagoContadoUSD: '0,00',
+    pagoContadoUYU: '0,00',
+    montoVencidoUSD: '0,00',
+    montoVencidoUYU: '0,00',
+    periodoDesde: '01/01/2025',
+    periodoHasta: '31/01/2025',
+  },
+  transactions: [
+    {
+      id: 'tx-1',
+      date: new Date('2025-01-02T00:00:00.000Z'),
+      description: 'Devoto Supermercado',
+      amount: 120,
+      currency: 'UYU',
+      type: 'debit',
+      source: 'credit_card',
+      category: Category.Groceries,
+      categoryConfidence: 0.8,
+      rawData: {},
+    },
+  ],
+}
+
+describe('ParsedDataDisplay', () => {
+  beforeEach(() => {
+    clearAllCategoryOverrides()
+  })
+
+  it('calls onCategoryChange when selecting a new category', async () => {
+    const user = userEvent.setup()
+    const onCategoryChange = vi.fn()
+
+    render(
+      <ParsedDataDisplay
+        data={sampleData}
+        onReset={() => undefined}
+        onCategoryChange={onCategoryChange}
+      />
+    )
+
+    await act(async () => {
+      await user.click(screen.getByTestId('category-pill-tx-1'))
+    })
+
+    const option = await screen.findByTestId(
+      `category-option-${Category.Shopping}-tx-1`
+    )
+
+    await act(async () => {
+      await user.click(option)
+    })
+
+    await waitFor(() => {
+      expect(onCategoryChange).toHaveBeenCalledWith(
+        'tx-1',
+        Category.Shopping
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('category-menu-tx-1')).toBeNull()
+    })
+  })
+})

--- a/src/services/categorizer/category-overrides.test.ts
+++ b/src/services/categorizer/category-overrides.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getMerchantCategoryOverride,
+  setMerchantCategoryOverride,
+  clearMerchantCategoryOverride,
+  listMerchantCategoryOverrides,
+  clearAllCategoryOverrides,
+} from './category-overrides'
+import { Category } from '../../models'
+
+describe('Category Overrides', () => {
+  beforeEach(() => {
+    clearAllCategoryOverrides()
+  })
+
+  it('should set and get overrides using normalized merchant name', () => {
+    setMerchantCategoryOverride('  Devoto Supermercado ', Category.Shopping)
+
+    expect(getMerchantCategoryOverride('devoto supermercado')).toBe(
+      Category.Shopping
+    )
+  })
+
+  it('should clear an override', () => {
+    setMerchantCategoryOverride('Farmashop', Category.Healthcare)
+    clearMerchantCategoryOverride('Farmashop')
+
+    expect(getMerchantCategoryOverride('Farmashop')).toBeNull()
+  })
+
+  it('should list overrides', () => {
+    setMerchantCategoryOverride('Antel', Category.Utilities)
+    setMerchantCategoryOverride('Netflix', Category.Entertainment)
+
+    const overrides = listMerchantCategoryOverrides()
+    expect(Object.keys(overrides)).toHaveLength(2)
+    expect(overrides['antel'].category).toBe(Category.Utilities)
+  })
+
+  it('should persist overrides in localStorage', () => {
+    setMerchantCategoryOverride('PedidosYa', Category.Restaurants)
+
+    const stored = window.localStorage.getItem('tatu:categoryOverrides')
+    expect(stored).toBeTruthy()
+    expect(getMerchantCategoryOverride('PedidosYa')).toBe(Category.Restaurants)
+  })
+})

--- a/src/services/categorizer/category-overrides.ts
+++ b/src/services/categorizer/category-overrides.ts
@@ -1,0 +1,95 @@
+import { Category } from '../../models'
+import { normalizeMerchantName } from './merchant-patterns'
+
+const STORAGE_KEY = 'tatu:categoryOverrides'
+
+interface CategoryOverride {
+  category: Category
+  updatedAt: string
+}
+
+type CategoryOverrides = Record<string, CategoryOverride>
+
+function hasLocalStorage(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+function loadOverrides(): CategoryOverrides {
+  if (!hasLocalStorage()) {
+    return {}
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as CategoryOverrides
+    return parsed || {}
+  } catch {
+    return {}
+  }
+}
+
+function saveOverrides(overrides: CategoryOverrides): void {
+  if (!hasLocalStorage()) {
+    return
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides))
+}
+
+export function getMerchantCategoryOverride(
+  merchantName: string
+): Category | null {
+  const normalized = normalizeMerchantName(merchantName)
+  if (!normalized) {
+    return null
+  }
+
+  const overrides = loadOverrides()
+  return overrides[normalized]?.category ?? null
+}
+
+export function setMerchantCategoryOverride(
+  merchantName: string,
+  category: Category
+): void {
+  const normalized = normalizeMerchantName(merchantName)
+  if (!normalized) {
+    return
+  }
+
+  const overrides = loadOverrides()
+  overrides[normalized] = {
+    category,
+    updatedAt: new Date().toISOString(),
+  }
+  saveOverrides(overrides)
+}
+
+export function clearMerchantCategoryOverride(merchantName: string): void {
+  const normalized = normalizeMerchantName(merchantName)
+  if (!normalized) {
+    return
+  }
+
+  const overrides = loadOverrides()
+  if (overrides[normalized]) {
+    delete overrides[normalized]
+    saveOverrides(overrides)
+  }
+}
+
+export function listMerchantCategoryOverrides(): CategoryOverrides {
+  return loadOverrides()
+}
+
+export function clearAllCategoryOverrides(): void {
+  if (!hasLocalStorage()) {
+    return
+  }
+
+  window.localStorage.removeItem(STORAGE_KEY)
+}

--- a/src/services/categorizer/transaction-categorizer.test.ts
+++ b/src/services/categorizer/transaction-categorizer.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { categorizeTransaction } from './transaction-categorizer'
+import {
+  clearAllCategoryOverrides,
+  setMerchantCategoryOverride,
+} from './category-overrides'
+import { Category } from '../../models'
+
+describe('Transaction Categorizer', () => {
+  beforeEach(() => {
+    clearAllCategoryOverrides()
+  })
+  it('should categorize fees with high confidence', () => {
+    const result = categorizeTransaction(
+      'COMISION POR COSTO PRODUCTO COMISION COSTO PRODUCTO',
+      'debit'
+    )
+
+    expect(result.category).toBe(Category.Fees)
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9)
+  })
+
+  it('should categorize transfers for outgoing transfers', () => {
+    const result = categorizeTransaction(
+      'TRANSFERENCIA ENVIADA 754934TT55557465 TRF. PLAZA',
+      'debit'
+    )
+
+    expect(result.category).toBe(Category.Transfer)
+    expect(result.confidence).toBeGreaterThanOrEqual(0.85)
+  })
+
+  it('should categorize transfers for card payments', () => {
+    const result = categorizeTransaction(
+      'PAGO ELECTRONICO TARJETA CREDITO',
+      'debit'
+    )
+
+    expect(result.category).toBe(Category.Transfer)
+  })
+
+  it('should categorize income when credit matches income keywords', () => {
+    const result = categorizeTransaction(
+      'CR. PAGO SUELDOS 20251106_0610426 SETA WORKSHOP SRL',
+      'credit'
+    )
+
+    expect(result.category).toBe(Category.Income)
+    expect(result.confidence).toBeGreaterThanOrEqual(0.85)
+  })
+
+  it('should fall back to merchant patterns for debits', () => {
+    const result = categorizeTransaction('Devoto Supermercado', 'debit')
+
+    expect(result.category).toBe(Category.Groceries)
+    expect(result.confidence).toBeGreaterThan(0)
+  })
+
+  it('should return Uncategorized when no match is found', () => {
+    const result = categorizeTransaction('Random Unknown Merchant', 'debit')
+
+    expect(result.category).toBe(Category.Uncategorized)
+    expect(result.confidence).toBe(0)
+  })
+
+  it('should return Uncategorized for empty descriptions', () => {
+    const result = categorizeTransaction('', 'debit')
+
+    expect(result.category).toBe(Category.Uncategorized)
+    expect(result.confidence).toBe(0)
+  })
+
+  it('should prioritize fees over transfers', () => {
+    const result = categorizeTransaction('COMISION TRANSFERENCIA', 'debit')
+
+    expect(result.category).toBe(Category.Fees)
+  })
+
+  it('should use manual overrides when available', () => {
+    setMerchantCategoryOverride('Devoto Supermercado', Category.Shopping)
+
+    const result = categorizeTransaction('Devoto Supermercado', 'debit')
+    expect(result.category).toBe(Category.Shopping)
+    expect(result.confidence).toBe(1)
+  })
+})

--- a/src/services/categorizer/transaction-categorizer.ts
+++ b/src/services/categorizer/transaction-categorizer.ts
@@ -1,0 +1,85 @@
+import { Category, TransactionType } from '../../models'
+import { getMerchantCategory, normalizeMerchantName } from './merchant-patterns'
+import { getMerchantCategoryOverride } from './category-overrides'
+
+const FEE_KEYWORDS = [
+  'comision',
+  'cargo',
+  'fee',
+  'interes',
+  'mantenimiento',
+  'costo producto',
+]
+
+const TRANSFER_KEYWORDS = [
+  'transferencia',
+  'trf',
+  'transf',
+  'pago supernet',
+  'pago electronico tarjeta credito',
+  'pago tarjeta credito',
+]
+
+const INCOME_KEYWORDS = [
+  'sueldo',
+  'salario',
+  'nomina',
+  'haberes',
+  'pago sueldos',
+  'deposito',
+]
+
+function matchesAny(normalized: string, keywords: string[]): boolean {
+  return keywords.some((keyword) => normalized.includes(keyword))
+}
+
+/**
+ * Categorize a transaction using rule-based detection and merchant patterns.
+ */
+export function categorizeTransaction(
+  description: string,
+  type: TransactionType
+): {
+  category: Category
+  confidence: number
+} {
+  const normalized = normalizeMerchantName(description)
+
+  if (!normalized) {
+    return {
+      category: Category.Uncategorized,
+      confidence: 0,
+    }
+  }
+
+  const override = getMerchantCategoryOverride(normalized)
+  if (override) {
+    return {
+      category: override,
+      confidence: 1,
+    }
+  }
+
+  if (matchesAny(normalized, FEE_KEYWORDS)) {
+    return {
+      category: Category.Fees,
+      confidence: 0.95,
+    }
+  }
+
+  if (matchesAny(normalized, TRANSFER_KEYWORDS)) {
+    return {
+      category: Category.Transfer,
+      confidence: 0.9,
+    }
+  }
+
+  if (type === 'credit' && matchesAny(normalized, INCOME_KEYWORDS)) {
+    return {
+      category: Category.Income,
+      confidence: 0.9,
+    }
+  }
+
+  return getMerchantCategory(description)
+}

--- a/src/services/parsers/bank-account-parser.ts
+++ b/src/services/parsers/bank-account-parser.ts
@@ -11,7 +11,7 @@ import {
   parseSantanderDate,
   generateTransactionId,
 } from './utils'
-import { getMerchantCategory } from '../categorizer/merchant-patterns'
+import { categorizeTransaction } from '../categorizer/transaction-categorizer'
 
 /**
  * Parse a Santander bank account CSV file (USD or UYU)
@@ -154,8 +154,8 @@ function parseTransactions(
       .join(' ')
       .trim()
 
-    // Auto-categorize based on description
-    const { category, confidence } = getMerchantCategory(description)
+    // Auto-categorize based on transaction details
+    const { category, confidence } = categorizeTransaction(description, type)
 
     const transaction: Transaction = {
       id: generateTransactionId(

--- a/src/services/parsers/credit-card-parser.ts
+++ b/src/services/parsers/credit-card-parser.ts
@@ -10,7 +10,7 @@ import {
   parseSantanderDate,
   generateTransactionId,
 } from './utils'
-import { getMerchantCategory } from '../categorizer/merchant-patterns'
+import { categorizeTransaction } from '../categorizer/transaction-categorizer'
 
 /**
  * Parse a Santander credit card CSV file
@@ -158,9 +158,10 @@ function parseTransactions(
       (currency === 'USD' && dolaresAmount < 0) ||
       (currency === 'UYU' && pesosAmount < 0)
 
-    // Auto-categorize based on merchant name
-    const { category, confidence } = getMerchantCategory(
-      rawTransaction.descripcion
+    // Auto-categorize based on transaction details
+    const { category, confidence } = categorizeTransaction(
+      rawTransaction.descripcion,
+      isCredit ? 'credit' : 'debit'
     )
 
     const transaction: Transaction = {


### PR DESCRIPTION
## Summary
- add rule-based transaction categorizer and merchant overrides
- update parsers to use categorizer and add click-to-edit category menu
- remove auto category option and refresh tests + project board

## Testing
- npm test -- --run