### PR TITLE
feat: add data layer and filter wiring

### DIFF
--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -121,14 +121,14 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
 **Goal**: Create robust data layer with local storage persistence
 
 ### Tasks
-- [ ] **3.1** Transaction Store (TDD)
+- [x] **3.1** Transaction Store (TDD) ✅
   - ✅ Write tests for transaction CRUD operations
   - ✅ Write tests for duplicate detection
   - ✅ Write tests for merging multiple imports
   - ✅ Implement transaction store with Zustand or Context
   - ✅ Add LocalStorage persistence
 
-- [ ] **3.2** Data Aggregation Service (TDD)
+- [x] **3.2** Data Aggregation Service (TDD) ✅
   - ✅ Write tests for grouping by category
   - ✅ Write tests for grouping by month/date
   - ✅ Write tests for currency conversion utilities
@@ -136,7 +136,7 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
   - ✅ Implement aggregation functions
   - ✅ Add memoization for performance
 
-- [ ] **3.3** Filter & Search Engine (TDD)
+- [x] **3.3** Filter & Search Engine (TDD) ✅
   - ✅ Write tests for date range filtering
   - ✅ Write tests for category filtering
   - ✅ Write tests for amount range filtering
@@ -296,21 +296,24 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
 
 ---
 
-## Current Heat: HEAT 3
+## Current Heat: HEAT 4
 **Status**: IN PROGRESS 🔥
 **Completed**:
 - 2.1 - Define Category System (TDD) ✅
 - 2.2 - Build Merchant Pattern Matcher (TDD) ✅
 - 2.3 - Transaction Categorizer (TDD) ✅
 - 2.4 - Manual Category Override (TDD) ✅
-**Next Task**: 3.1 - Transaction Store (TDD)
+- 3.1 - Transaction Store (TDD) ✅
+- 3.2 - Data Aggregation Service (TDD) ✅
+- 3.3 - Filter & Search Engine (TDD) ✅
+**Next Task**: 4.1 - Layout & Navigation (TDD)
 
 ---
 
 ## Progress Tracking
 - [x] Heat 1: Foundation & CSV Parser ✅
 - [ ] Heat 2: Category Inference Engine
-- [ ] Heat 3: Data Models & State Management
+- [x] Heat 3: Data Models & State Management ✅
 - [ ] Heat 4: Dashboard & Visualizations
 - [ ] Heat 5: Advanced Features & Polish
 - [ ] Heat 6: Currency & Insights

--- a/src/services/aggregator/aggregation.test.ts
+++ b/src/services/aggregator/aggregation.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateRunningBalance,
+  calculateTotals,
+  convertAmount,
+  groupByCategory,
+  groupByDate,
+  groupByMonth,
+} from './aggregation'
+import type { Transaction } from '../../models'
+import { Category } from '../../models'
+
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
+  return {
+    id,
+    date: new Date('2025-01-01T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+describe('Aggregation - groupByCategory', () => {
+  it('summarizes income and expenses per category', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        category: Category.Groceries,
+        amount: 10,
+        currency: 'USD',
+        type: 'debit',
+      }),
+      makeTransaction('tx-2', {
+        category: Category.Groceries,
+        amount: 5,
+        currency: 'USD',
+        type: 'credit',
+      }),
+      makeTransaction('tx-3', {
+        amount: 20,
+        currency: 'UYU',
+        type: 'debit',
+      }),
+    ]
+
+    const grouped = groupByCategory(transactions)
+
+    expect(grouped[Category.Groceries].expense.USD).toBe(10)
+    expect(grouped[Category.Groceries].income.USD).toBe(5)
+    expect(grouped[Category.Groceries].net.USD).toBe(-5)
+    expect(grouped[Category.Groceries].count).toBe(2)
+
+    expect(grouped[Category.Uncategorized].expense.UYU).toBe(20)
+    expect(grouped[Category.Uncategorized].count).toBe(1)
+  })
+
+  it('memoizes results by array reference', () => {
+    const transactions = [makeTransaction('tx-1')]
+
+    const first = groupByCategory(transactions)
+    const second = groupByCategory(transactions)
+    const third = groupByCategory([...transactions])
+
+    expect(first).toBe(second)
+    expect(first).not.toBe(third)
+  })
+})
+
+describe('Aggregation - groupByMonth', () => {
+  it('groups transactions by year-month', () => {
+    const transactions = [
+      makeTransaction('tx-1', { date: new Date('2025-01-05T00:00:00.000Z') }),
+      makeTransaction('tx-2', { date: new Date('2025-01-20T00:00:00.000Z') }),
+      makeTransaction('tx-3', { date: new Date('2025-02-01T00:00:00.000Z') }),
+    ]
+
+    const grouped = groupByMonth(transactions)
+
+    expect(grouped['2025-01'].count).toBe(2)
+    expect(grouped['2025-02'].count).toBe(1)
+  })
+})
+
+describe('Aggregation - groupByDate', () => {
+  it('groups transactions by date', () => {
+    const transactions = [
+      makeTransaction('tx-1', { date: new Date('2025-01-05T00:00:00.000Z') }),
+      makeTransaction('tx-2', { date: new Date('2025-01-05T00:00:00.000Z') }),
+      makeTransaction('tx-3', { date: new Date('2025-01-06T00:00:00.000Z') }),
+    ]
+
+    const grouped = groupByDate(transactions)
+
+    expect(grouped['2025-01-05'].count).toBe(2)
+    expect(grouped['2025-01-06'].count).toBe(1)
+  })
+})
+
+describe('Aggregation - totals', () => {
+  it('calculates totals across all transactions', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        amount: 10,
+        type: 'debit',
+        currency: 'USD',
+      }),
+      makeTransaction('tx-2', {
+        amount: 5,
+        type: 'credit',
+        currency: 'USD',
+      }),
+      makeTransaction('tx-3', {
+        amount: 7,
+        type: 'credit',
+        currency: 'UYU',
+      }),
+    ]
+
+    const totals = calculateTotals(transactions)
+
+    expect(totals.expense.USD).toBe(10)
+    expect(totals.income.USD).toBe(5)
+    expect(totals.net.USD).toBe(-5)
+    expect(totals.income.UYU).toBe(7)
+  })
+})
+
+describe('Aggregation - currency conversion', () => {
+  it('converts amounts using a provided rate', () => {
+    expect(convertAmount(100, 'USD', 'UYU', 40)).toBe(4000)
+  })
+
+  it('returns same amount when currencies match', () => {
+    expect(convertAmount(100, 'USD', 'USD', 40)).toBe(100)
+  })
+
+  it('throws when rate is invalid', () => {
+    expect(() => convertAmount(10, 'USD', 'UYU', 0)).toThrow()
+  })
+})
+
+describe('Aggregation - running balance', () => {
+  it('calculates running balance in chronological order', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        date: new Date('2025-01-03T00:00:00.000Z'),
+        amount: 10,
+        type: 'debit',
+        currency: 'USD',
+      }),
+      makeTransaction('tx-2', {
+        date: new Date('2025-01-01T00:00:00.000Z'),
+        amount: 5,
+        type: 'credit',
+        currency: 'USD',
+      }),
+    ]
+
+    const result = calculateRunningBalance(transactions, 'USD', 100)
+
+    expect(result).toEqual([
+      { id: 'tx-2', balance: 105 },
+      { id: 'tx-1', balance: 95 },
+    ])
+  })
+})

--- a/src/services/aggregator/aggregation.ts
+++ b/src/services/aggregator/aggregation.ts
@@ -1,0 +1,155 @@
+import type { Currency, Transaction } from '../../models'
+import { Category } from '../../models'
+
+export interface CurrencyTotals {
+  USD: number
+  UYU: number
+}
+
+export interface SummaryTotals {
+  income: CurrencyTotals
+  expense: CurrencyTotals
+  net: CurrencyTotals
+  count: number
+}
+
+function emptyCurrencyTotals(): CurrencyTotals {
+  return { USD: 0, UYU: 0 }
+}
+
+function emptySummary(): SummaryTotals {
+  return {
+    income: emptyCurrencyTotals(),
+    expense: emptyCurrencyTotals(),
+    net: emptyCurrencyTotals(),
+    count: 0,
+  }
+}
+
+function toDateKey(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getUTCDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function toMonthKey(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0')
+  return `${year}-${month}`
+}
+
+function applyTransaction(summary: SummaryTotals, tx: Transaction): void {
+  const currency = tx.currency
+  if (tx.type === 'credit') {
+    summary.income[currency] += tx.amount
+    summary.net[currency] += tx.amount
+  } else {
+    summary.expense[currency] += tx.amount
+    summary.net[currency] -= tx.amount
+  }
+  summary.count += 1
+}
+
+function memoizeByReference<TInput extends object, TResult>(
+  fn: (input: TInput) => TResult
+): (input: TInput) => TResult {
+  const cache = new WeakMap<TInput, TResult>()
+
+  return (input: TInput) => {
+    const cached = cache.get(input)
+    if (cached) {
+      return cached
+    }
+    const result = fn(input)
+    cache.set(input, result)
+    return result
+  }
+}
+
+export const groupByCategory = memoizeByReference(
+  (transactions: Transaction[]) => {
+    const grouped: Record<string, SummaryTotals> = {}
+
+    transactions.forEach((tx) => {
+      const category = tx.category ?? Category.Uncategorized
+      if (!grouped[category]) {
+        grouped[category] = emptySummary()
+      }
+      applyTransaction(grouped[category], tx)
+    })
+
+    return grouped
+  }
+)
+
+export const groupByMonth = memoizeByReference(
+  (transactions: Transaction[]) => {
+    const grouped: Record<string, SummaryTotals> = {}
+
+    transactions.forEach((tx) => {
+      const key = toMonthKey(tx.date)
+      if (!grouped[key]) {
+        grouped[key] = emptySummary()
+      }
+      applyTransaction(grouped[key], tx)
+    })
+
+    return grouped
+  }
+)
+
+export const groupByDate = memoizeByReference(
+  (transactions: Transaction[]) => {
+    const grouped: Record<string, SummaryTotals> = {}
+
+    transactions.forEach((tx) => {
+      const key = toDateKey(tx.date)
+      if (!grouped[key]) {
+        grouped[key] = emptySummary()
+      }
+      applyTransaction(grouped[key], tx)
+    })
+
+    return grouped
+  }
+)
+
+export const calculateTotals = memoizeByReference(
+  (transactions: Transaction[]) => {
+    const totals = emptySummary()
+    transactions.forEach((tx) => applyTransaction(totals, tx))
+    return totals
+  }
+)
+
+export function convertAmount(
+  amount: number,
+  from: Currency,
+  to: Currency,
+  rate: number
+): number {
+  if (from === to) {
+    return amount
+  }
+  if (!Number.isFinite(rate) || rate <= 0) {
+    throw new Error('Conversion rate must be a positive number.')
+  }
+  return amount * rate
+}
+
+export function calculateRunningBalance(
+  transactions: Transaction[],
+  currency: Currency,
+  startingBalance = 0
+): Array<{ id: string; balance: number }> {
+  const sorted = [...transactions]
+    .filter((tx) => tx.currency === currency)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+
+  let balance = startingBalance
+  return sorted.map((tx) => {
+    balance += tx.type === 'credit' ? tx.amount : -tx.amount
+    return { id: tx.id, balance }
+  })
+}

--- a/src/services/filters/filters.test.ts
+++ b/src/services/filters/filters.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyFilters,
+  sortTransactions,
+  matchesText,
+} from './filters'
+import type { Transaction } from '../../models'
+import { Category } from '../../models'
+
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
+  return {
+    id,
+    date: new Date('2025-01-01T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+describe('Filter engine', () => {
+  it('filters by date range', () => {
+    const transactions = [
+      makeTransaction('tx-1', { date: new Date('2025-01-01T00:00:00.000Z') }),
+      makeTransaction('tx-2', { date: new Date('2025-01-10T00:00:00.000Z') }),
+      makeTransaction('tx-3', { date: new Date('2025-02-01T00:00:00.000Z') }),
+    ]
+
+    const result = applyFilters(transactions, {
+      dateFrom: new Date('2025-01-05T00:00:00.000Z'),
+      dateTo: new Date('2025-01-31T00:00:00.000Z'),
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-2'])
+  })
+
+  it('filters by categories', () => {
+    const transactions = [
+      makeTransaction('tx-1', { category: Category.Groceries }),
+      makeTransaction('tx-2', { category: Category.Shopping }),
+    ]
+
+    const result = applyFilters(transactions, {
+      categories: [Category.Groceries],
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-1'])
+  })
+
+  it('filters by amount range', () => {
+    const transactions = [
+      makeTransaction('tx-1', { amount: 5 }),
+      makeTransaction('tx-2', { amount: 15 }),
+      makeTransaction('tx-3', { amount: 30 }),
+    ]
+
+    const result = applyFilters(transactions, {
+      amountMin: 10,
+      amountMax: 20,
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-2'])
+  })
+
+  it('filters by text search', () => {
+    const transactions = [
+      makeTransaction('tx-1', { description: 'Devoto Supermercado' }),
+      makeTransaction('tx-2', { description: 'Netflix' }),
+    ]
+
+    const result = applyFilters(transactions, {
+      query: 'devoto',
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-1'])
+  })
+
+  it('filters by currency', () => {
+    const transactions = [
+      makeTransaction('tx-1', { currency: 'USD' }),
+      makeTransaction('tx-2', { currency: 'UYU' }),
+    ]
+
+    const result = applyFilters(transactions, {
+      currencies: ['USD'],
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-1'])
+  })
+
+  it('can combine filters', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        description: 'Devoto',
+        amount: 10,
+        currency: 'USD',
+        category: Category.Groceries,
+      }),
+      makeTransaction('tx-2', {
+        description: 'Devoto',
+        amount: 30,
+        currency: 'USD',
+        category: Category.Groceries,
+      }),
+    ]
+
+    const result = applyFilters(transactions, {
+      amountMax: 20,
+      query: 'devoto',
+      categories: [Category.Groceries],
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-1'])
+  })
+
+  it('memoizes by reference', () => {
+    const transactions = [makeTransaction('tx-1')]
+    const filters = { query: 'transaction' }
+
+    const first = applyFilters(transactions, filters)
+    const second = applyFilters(transactions, filters)
+    const third = applyFilters([...transactions], filters)
+
+    expect(first).toBe(second)
+    expect(first).not.toBe(third)
+  })
+})
+
+describe('Sort engine', () => {
+  it('sorts by date descending by default', () => {
+    const transactions = [
+      makeTransaction('tx-1', { date: new Date('2025-01-01T00:00:00.000Z') }),
+      makeTransaction('tx-2', { date: new Date('2025-01-05T00:00:00.000Z') }),
+    ]
+
+    const result = sortTransactions(transactions)
+    expect(result.map((tx) => tx.id)).toEqual(['tx-2', 'tx-1'])
+  })
+
+  it('sorts by amount ascending', () => {
+    const transactions = [
+      makeTransaction('tx-1', { amount: 20 }),
+      makeTransaction('tx-2', { amount: 5 }),
+    ]
+
+    const result = sortTransactions(transactions, {
+      field: 'amount',
+      direction: 'asc',
+    })
+    expect(result.map((tx) => tx.id)).toEqual(['tx-2', 'tx-1'])
+  })
+})
+
+describe('Text match helper', () => {
+  it('matches on normalized description', () => {
+    expect(matchesText('Devoto Supermercado', 'devoto')).toBe(true)
+  })
+})

--- a/src/services/filters/filters.ts
+++ b/src/services/filters/filters.ts
@@ -1,0 +1,117 @@
+import type { Currency, Transaction } from '../../models'
+import { normalizeMerchantName } from '../categorizer/merchant-patterns'
+
+export interface FilterOptions {
+  dateFrom?: Date
+  dateTo?: Date
+  categories?: string[]
+  amountMin?: number
+  amountMax?: number
+  query?: string
+  currencies?: Currency[]
+}
+
+export type SortField = 'date' | 'amount' | 'description'
+
+export interface SortOptions {
+  field?: SortField
+  direction?: 'asc' | 'desc'
+}
+
+function memoizeByReference<TInput extends object, TResult>(
+  fn: (input: TInput, options?: FilterOptions) => TResult
+): (input: TInput, options?: FilterOptions) => TResult {
+  const cache = new WeakMap<TInput, Map<string, TResult>>()
+
+  return (input, options = {}) => {
+    let byOptions = cache.get(input)
+    const key = JSON.stringify(options)
+
+    if (!byOptions) {
+      byOptions = new Map()
+      cache.set(input, byOptions)
+    }
+
+    const cached = byOptions.get(key)
+    if (cached) {
+      return cached
+    }
+
+    const result = fn(input, options)
+    byOptions.set(key, result)
+    return result
+  }
+}
+
+export function matchesText(text: string, query: string): boolean {
+  if (!query) {
+    return true
+  }
+  const normalizedQuery = normalizeMerchantName(query)
+  const normalizedText = normalizeMerchantName(text)
+  return normalizedText.includes(normalizedQuery)
+}
+
+export const applyFilters = memoizeByReference(
+  (transactions: Transaction[], options: FilterOptions = {}) => {
+    const {
+      dateFrom,
+      dateTo,
+      categories,
+      amountMin,
+      amountMax,
+      query,
+      currencies,
+    } = options
+
+    return transactions.filter((tx) => {
+      if (dateFrom && tx.date < dateFrom) {
+        return false
+      }
+      if (dateTo && tx.date > dateTo) {
+        return false
+      }
+      if (categories && categories.length > 0) {
+        if (!tx.category || !categories.includes(tx.category)) {
+          return false
+        }
+      }
+      if (typeof amountMin === 'number' && tx.amount < amountMin) {
+        return false
+      }
+      if (typeof amountMax === 'number' && tx.amount > amountMax) {
+        return false
+      }
+      if (query && !matchesText(tx.description, query)) {
+        return false
+      }
+      if (currencies && currencies.length > 0) {
+        if (!currencies.includes(tx.currency)) {
+          return false
+        }
+      }
+
+      return true
+    })
+  }
+)
+
+export function sortTransactions(
+  transactions: Transaction[],
+  options: SortOptions = {}
+): Transaction[] {
+  const { field = 'date', direction = 'desc' } = options
+  const multiplier = direction === 'asc' ? 1 : -1
+
+  return [...transactions].sort((a, b) => {
+    if (field === 'amount') {
+      return (a.amount - b.amount) * multiplier
+    }
+
+    if (field === 'description') {
+      return a.description.localeCompare(b.description) * multiplier
+    }
+
+    return (a.date.getTime() - b.date.getTime()) * multiplier
+  })
+}

--- a/src/stores/transaction-store.test.ts
+++ b/src/stores/transaction-store.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createTransactionStore } from './transaction-store'
+import type { Transaction } from '../models'
+
+function makeTransaction(id: string, overrides: Partial<Transaction> = {}) {
+  const base: Transaction = {
+    id,
+    date: new Date('2025-01-01T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+  }
+
+  return { ...base, ...overrides }
+}
+
+describe('Transaction Store - CRUD', () => {
+  let store: ReturnType<typeof createTransactionStore>
+
+  beforeEach(() => {
+    store = createTransactionStore({ persist: false })
+  })
+
+  it('starts with no transactions', () => {
+    expect(store.getState().transactions).toHaveLength(0)
+  })
+
+  it('adds a transaction', () => {
+    const tx = makeTransaction('tx-1')
+    store.getState().addTransaction(tx)
+
+    expect(store.getState().transactions).toHaveLength(1)
+    expect(store.getState().transactions[0].id).toBe('tx-1')
+  })
+
+  it('updates a transaction by id', () => {
+    const tx = makeTransaction('tx-1')
+    store.getState().addTransaction(tx)
+
+    store.getState().updateTransaction('tx-1', {
+      description: 'Updated',
+      category: 'shopping',
+    })
+
+    const updated = store.getState().transactions[0]
+    expect(updated.description).toBe('Updated')
+    expect(updated.category).toBe('shopping')
+  })
+
+  it('removes a transaction by id', () => {
+    store.getState().addTransaction(makeTransaction('tx-1'))
+    store.getState().addTransaction(makeTransaction('tx-2'))
+
+    store.getState().removeTransaction('tx-1')
+
+    expect(store.getState().transactions).toHaveLength(1)
+    expect(store.getState().transactions[0].id).toBe('tx-2')
+  })
+
+  it('clears all transactions', () => {
+    store.getState().addTransaction(makeTransaction('tx-1'))
+    store.getState().addTransaction(makeTransaction('tx-2'))
+
+    store.getState().clearTransactions()
+
+    expect(store.getState().transactions).toHaveLength(0)
+  })
+
+  it('replaces transactions with setTransactions', () => {
+    store.getState().addTransaction(makeTransaction('tx-1'))
+
+    const next = [makeTransaction('tx-2'), makeTransaction('tx-3')]
+    store.getState().setTransactions(next)
+
+    expect(store.getState().transactions).toHaveLength(2)
+    expect(store.getState().transactions[0].id).toBe('tx-2')
+  })
+})
+
+describe('Transaction Store - Duplicates and Merge', () => {
+  let store: ReturnType<typeof createTransactionStore>
+
+  beforeEach(() => {
+    store = createTransactionStore({ persist: false })
+  })
+
+  it('detects duplicate ids against existing transactions', () => {
+    store.getState().setTransactions([
+      makeTransaction('tx-1'),
+      makeTransaction('tx-2'),
+    ])
+
+    const duplicates = store.getState().findDuplicateIds([
+      makeTransaction('tx-2'),
+      makeTransaction('tx-3'),
+    ])
+
+    expect(duplicates).toEqual(['tx-2'])
+  })
+
+  it('merges new transactions without duplicating existing ones', () => {
+    store.getState().setTransactions([
+      makeTransaction('tx-1'),
+      makeTransaction('tx-2'),
+    ])
+
+    const result = store.getState().mergeTransactions([
+      makeTransaction('tx-2'),
+      makeTransaction('tx-3'),
+    ])
+
+    expect(result.duplicates).toHaveLength(1)
+    expect(result.added).toHaveLength(1)
+    expect(store.getState().transactions.map((tx) => tx.id)).toEqual([
+      'tx-1',
+      'tx-2',
+      'tx-3',
+    ])
+  })
+})
+
+describe('Transaction Store - Persistence', () => {
+  const storageKey = 'tatu:test:transactions'
+  let store: ReturnType<typeof createTransactionStore>
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    store = createTransactionStore({ persist: true, storageKey })
+  })
+
+  it('persists transactions to localStorage', () => {
+    store.getState().addTransaction(makeTransaction('tx-1'))
+
+    const raw = window.localStorage.getItem(storageKey)
+    expect(raw).toBeTruthy()
+
+    const parsed = JSON.parse(raw ?? '{}')
+    expect(parsed.state.transactions).toHaveLength(1)
+    expect(parsed.state.transactions[0].id).toBe('tx-1')
+  })
+
+  it('rehydrates transactions from localStorage', async () => {
+    const stored = {
+      state: {
+        transactions: [
+          {
+            ...makeTransaction('tx-1'),
+            date: '2025-01-02T00:00:00.000Z',
+          },
+        ],
+      },
+      version: 0,
+    }
+    window.localStorage.setItem(storageKey, JSON.stringify(stored))
+
+    store = createTransactionStore({ persist: true, storageKey })
+    await store.persist.rehydrate()
+
+    expect(store.getState().transactions).toHaveLength(1)
+    expect(store.getState().transactions[0].id).toBe('tx-1')
+    expect(store.getState().transactions[0].date).toBeInstanceOf(Date)
+  })
+})

--- a/src/stores/transaction-store.ts
+++ b/src/stores/transaction-store.ts
@@ -1,0 +1,174 @@
+import { createStore } from 'zustand/vanilla'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import type { Transaction } from '../models'
+
+const DEFAULT_STORAGE_KEY = 'tatu:transactions'
+
+interface TransactionStoreState {
+  transactions: Transaction[]
+}
+
+interface TransactionStoreActions {
+  addTransaction: (transaction: Transaction) => void
+  addTransactions: (transactions: Transaction[]) => {
+    added: Transaction[]
+    duplicates: Transaction[]
+  }
+  updateTransaction: (
+    id: string,
+    updates: Partial<Transaction>
+  ) => void
+  removeTransaction: (id: string) => void
+  clearTransactions: () => void
+  setTransactions: (transactions: Transaction[]) => void
+  findDuplicateIds: (transactions: Transaction[]) => string[]
+  mergeTransactions: (transactions: Transaction[]) => {
+    added: Transaction[]
+    duplicates: Transaction[]
+  }
+}
+
+export type TransactionStore = TransactionStoreState & TransactionStoreActions
+
+interface TransactionStoreOptions {
+  persist?: boolean
+  storageKey?: string
+}
+
+function hasLocalStorage(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+function normalizeTransactions(transactions: Transaction[]): Transaction[] {
+  return transactions.map((tx) => {
+    const date =
+      tx.date instanceof Date ? tx.date : new Date(tx.date as unknown as string)
+    return { ...tx, date }
+  })
+}
+
+function createTransactionStoreState(
+  set: (fn: (state: TransactionStoreState) => TransactionStoreState) => void,
+  get: () => TransactionStoreState
+): TransactionStore {
+  return {
+    transactions: [],
+    addTransaction: (transaction) =>
+      set((state) => ({
+        transactions: [...state.transactions, transaction],
+      })),
+    addTransactions: (transactions) => {
+      const added: Transaction[] = []
+      const duplicates: Transaction[] = []
+
+      set((state) => {
+        const existingIds = new Set(state.transactions.map((tx) => tx.id))
+        const next = [...state.transactions]
+
+        transactions.forEach((tx) => {
+          if (existingIds.has(tx.id)) {
+            duplicates.push(tx)
+          } else {
+            existingIds.add(tx.id)
+            added.push(tx)
+            next.push(tx)
+          }
+        })
+
+        return { transactions: next }
+      })
+
+      return { added, duplicates }
+    },
+    updateTransaction: (id, updates) =>
+      set((state) => ({
+        transactions: state.transactions.map((tx) =>
+          tx.id === id ? { ...tx, ...updates } : tx
+        ),
+      })),
+    removeTransaction: (id) =>
+      set((state) => ({
+        transactions: state.transactions.filter((tx) => tx.id !== id),
+      })),
+    clearTransactions: () =>
+      set(() => ({
+        transactions: [],
+      })),
+    setTransactions: (transactions) =>
+      set(() => ({
+        transactions,
+      })),
+    findDuplicateIds: (transactions) => {
+      const existingIds = new Set(get().transactions.map((tx) => tx.id))
+      const duplicates = new Set<string>()
+
+      transactions.forEach((tx) => {
+        if (existingIds.has(tx.id)) {
+          duplicates.add(tx.id)
+        }
+      })
+
+      return Array.from(duplicates)
+    },
+    mergeTransactions: (transactions) => {
+      const added: Transaction[] = []
+      const duplicates: Transaction[] = []
+
+      set((state) => {
+        const existingIds = new Set(state.transactions.map((tx) => tx.id))
+        const next = [...state.transactions]
+
+        transactions.forEach((tx) => {
+          if (existingIds.has(tx.id)) {
+            duplicates.push(tx)
+          } else {
+            existingIds.add(tx.id)
+            added.push(tx)
+            next.push(tx)
+          }
+        })
+
+        return { transactions: next }
+      })
+
+      return { added, duplicates }
+    },
+  }
+}
+
+export function createTransactionStore(options: TransactionStoreOptions = {}) {
+  const { persist: shouldPersist = true, storageKey = DEFAULT_STORAGE_KEY } =
+    options
+
+  if (shouldPersist && hasLocalStorage()) {
+    return createStore<TransactionStore>()(
+      persist(
+        (set, get) => createTransactionStoreState(set, get),
+        {
+          name: storageKey,
+          storage: createJSONStorage(() => window.localStorage),
+          partialize: (state) => ({ transactions: state.transactions }),
+          merge: (persistedState, currentState) => {
+            const persisted = persistedState as
+              | Partial<TransactionStoreState>
+              | undefined
+
+            return {
+              ...currentState,
+              ...persisted,
+              transactions: normalizeTransactions(
+                persisted?.transactions ?? []
+              ),
+            }
+          },
+        }
+      )
+    )
+  }
+
+  return createStore<TransactionStore>()((set, get) =>
+    createTransactionStoreState(set, get)
+  )
+}
+
+export const transactionStore = createTransactionStore()


### PR DESCRIPTION
## Summary
- add a transaction store with CRUD, duplicate handling, and persistence
- implement aggregation utilities for category/month/date totals and running balance
- build filter/search/sort engine with memoization
- wire store + filters + aggregation into the UI (table, counts, totals)
- update Heat 3 status on the project board

## Testing
- npm test -- --run src/stores/transaction-store.test.ts
- npm test -- --run src/services/aggregator/aggregation.test.ts
- npm test -- --run src/services/filters/filters.test.ts
- npm test -- --run