### PR TITLE
feat: add dashboard overview summary

### DIFF
--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -170,7 +170,7 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
   - ✅ Implement upload UI with visual feedback
   - ✅ Handle multiple file selection
 
-- [ ] **4.3** Dashboard Overview (TDD)
+- [x] **4.3** Dashboard Overview (TDD) ✅
   - ✅ Write tests for summary cards (total income, expenses, balance)
   - ✅ Write tests for multi-currency display
   - ✅ Implement summary components
@@ -306,7 +306,7 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
 - 3.1 - Transaction Store (TDD) ✅
 - 3.2 - Data Aggregation Service (TDD) ✅
 - 3.3 - Filter & Search Engine (TDD) ✅
-**Next Task**: 4.3 - Dashboard Overview (TDD)
+**Next Task**: 4.4 - Charts & Visualizations (TDD)
 
 ---
 

--- a/src/components/DashboardOverview.test.tsx
+++ b/src/components/DashboardOverview.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { DashboardOverview } from './DashboardOverview'
+import type { Transaction } from '../models'
+
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
+  return {
+    id,
+    date: new Date('2025-03-10T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+describe('DashboardOverview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders summary totals with multi-currency values', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        amount: 100,
+        type: 'credit',
+        currency: 'USD',
+      }),
+      makeTransaction('tx-2', {
+        amount: 40,
+        type: 'debit',
+        currency: 'USD',
+      }),
+      makeTransaction('tx-3', {
+        amount: 50,
+        type: 'debit',
+        currency: 'UYU',
+      }),
+    ]
+
+    render(<DashboardOverview transactions={transactions} />)
+
+    expect(screen.getByText('Total Income')).toBeInTheDocument()
+    expect(screen.getByText('Total Expenses')).toBeInTheDocument()
+    expect(screen.getByText('Net')).toBeInTheDocument()
+
+    expect(screen.getByText('100.00 USD / 0.00 UYU')).toBeInTheDocument()
+    expect(screen.getByText('40.00 USD / 50.00 UYU')).toBeInTheDocument()
+    expect(screen.getByText('60.00 USD / -50.00 UYU')).toBeInTheDocument()
+  })
+
+  it('emits date range for last month selection', async () => {
+    const onPeriodChange = vi.fn()
+    const now = new Date('2025-03-15T00:00:00.000Z')
+
+    render(
+      <DashboardOverview
+        transactions={[]}
+        onPeriodChange={onPeriodChange}
+        now={now}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Last month'))
+
+    await waitFor(() => {
+      const [range] = onPeriodChange.mock.calls.at(-1) ?? []
+      expect(range.dateFrom.toISOString()).toBe('2025-02-01T00:00:00.000Z')
+      expect(range.dateTo.toISOString()).toBe('2025-02-28T23:59:59.999Z')
+    })
+  })
+
+  it('emits date range for custom selection', async () => {
+    const onPeriodChange = vi.fn()
+    const now = new Date('2025-03-15T00:00:00.000Z')
+
+    render(
+      <DashboardOverview
+        transactions={[]}
+        onPeriodChange={onPeriodChange}
+        now={now}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Custom'))
+
+    const startInput = screen.getByTestId('period-start')
+    const endInput = screen.getByTestId('period-end')
+
+    fireEvent.change(startInput, { target: { value: '2025-03-05' } })
+    fireEvent.change(endInput, { target: { value: '2025-03-20' } })
+
+    await waitFor(() => {
+      const [range] = onPeriodChange.mock.calls.at(-1) ?? []
+      expect(range.dateFrom.toISOString()).toBe('2025-03-05T00:00:00.000Z')
+      expect(range.dateTo.toISOString()).toBe('2025-03-20T23:59:59.999Z')
+    })
+  })
+})

--- a/src/components/DashboardOverview.tsx
+++ b/src/components/DashboardOverview.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useMemo, useState } from 'react'
+import { calculateTotals } from '../services/aggregator/aggregation'
+import type { Transaction } from '../models'
+
+type PeriodOption = 'this_month' | 'last_month' | 'custom'
+
+interface DashboardOverviewProps {
+  transactions: Transaction[]
+  onPeriodChange?: (range: { dateFrom?: Date; dateTo?: Date }) => void
+  now?: Date
+}
+
+function toUtcDateStart(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+function toUtcDateEnd(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(Date.UTC(year, month - 1, day, 23, 59, 59, 999))
+}
+
+function getMonthRange(date: Date): { dateFrom: Date; dateTo: Date } {
+  const year = date.getUTCFullYear()
+  const month = date.getUTCMonth()
+  const dateFrom = new Date(Date.UTC(year, month, 1))
+  const dateTo = new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999))
+  return { dateFrom, dateTo }
+}
+
+function getLastMonthRange(date: Date): { dateFrom: Date; dateTo: Date } {
+  const year = date.getUTCFullYear()
+  const month = date.getUTCMonth() - 1
+  const dateFrom = new Date(Date.UTC(year, month, 1))
+  const dateTo = new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999))
+  return { dateFrom, dateTo }
+}
+
+function formatTotals(usd: number, uyu: number): string {
+  return `${usd.toFixed(2)} USD / ${uyu.toFixed(2)} UYU`
+}
+
+export function DashboardOverview({
+  transactions,
+  onPeriodChange,
+  now,
+}: DashboardOverviewProps) {
+  const [period, setPeriod] = useState<PeriodOption>('this_month')
+  const [customStart, setCustomStart] = useState('')
+  const [customEnd, setCustomEnd] = useState('')
+
+  const totals = useMemo(() => calculateTotals(transactions), [transactions])
+  const referenceDate = useMemo(() => now ?? new Date(), [now])
+
+  useEffect(() => {
+    if (!onPeriodChange) {
+      return
+    }
+
+    if (period === 'this_month') {
+      onPeriodChange(getMonthRange(referenceDate))
+      return
+    }
+
+    if (period === 'last_month') {
+      onPeriodChange(getLastMonthRange(referenceDate))
+      return
+    }
+
+    const dateFrom = customStart ? toUtcDateStart(customStart) : undefined
+    const dateTo = customEnd ? toUtcDateEnd(customEnd) : undefined
+    onPeriodChange({ dateFrom, dateTo })
+  }, [period, customStart, customEnd, onPeriodChange, referenceDate])
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-gray-400 dark:text-gray-500">
+            Overview
+          </p>
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            Financial Summary
+          </h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className={`rounded-full px-4 py-2 text-xs font-semibold ${
+              period === 'this_month'
+                ? 'bg-gray-900 text-white'
+                : 'border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300'
+            }`}
+            onClick={() => setPeriod('this_month')}
+          >
+            This month
+          </button>
+          <button
+            type="button"
+            className={`rounded-full px-4 py-2 text-xs font-semibold ${
+              period === 'last_month'
+                ? 'bg-gray-900 text-white'
+                : 'border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300'
+            }`}
+            onClick={() => setPeriod('last_month')}
+          >
+            Last month
+          </button>
+          <button
+            type="button"
+            className={`rounded-full px-4 py-2 text-xs font-semibold ${
+              period === 'custom'
+                ? 'bg-gray-900 text-white'
+                : 'border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300'
+            }`}
+            onClick={() => setPeriod('custom')}
+          >
+            Custom
+          </button>
+        </div>
+      </div>
+
+      {period === 'custom' ? (
+        <div className="flex flex-col gap-2 md:flex-row md:items-center">
+          <input
+            type="date"
+            value={customStart}
+            onChange={(event) => setCustomStart(event.target.value)}
+            data-testid="period-start"
+            className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-700 dark:text-gray-200"
+          />
+          <span className="text-sm text-gray-400">to</span>
+          <input
+            type="date"
+            value={customEnd}
+            onChange={(event) => setCustomEnd(event.target.value)}
+            data-testid="period-end"
+            className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-700 dark:text-gray-200"
+          />
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-2xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+          <p className="text-xs font-semibold text-gray-400">Total Income</p>
+          <p className="mt-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formatTotals(totals.income.USD, totals.income.UYU)}
+          </p>
+        </div>
+        <div className="rounded-2xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+          <p className="text-xs font-semibold text-gray-400">Total Expenses</p>
+          <p className="mt-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formatTotals(totals.expense.USD, totals.expense.UYU)}
+          </p>
+        </div>
+        <div className="rounded-2xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+          <p className="text-xs font-semibold text-gray-400">Net</p>
+          <p className="mt-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formatTotals(totals.net.USD, totals.net.UYU)}
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/ParsedDataDisplay.test.tsx
+++ b/src/components/ParsedDataDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ParsedDataDisplay } from './ParsedDataDisplay'
 import { Category } from '../models'
@@ -55,9 +55,21 @@ describe('ParsedDataDisplay', () => {
     const user = userEvent.setup()
     const onCategoryChange = vi.fn()
 
+    const now = new Date()
+    const data = {
+      ...sampleData,
+      parsedAt: now,
+      transactions: [
+        {
+          ...sampleData.transactions[0],
+          date: now,
+        },
+      ],
+    }
+
     render(
       <ParsedDataDisplay
-        data={sampleData}
+        data={data}
         onReset={() => undefined}
         onCategoryChange={onCategoryChange}
       />
@@ -75,15 +87,7 @@ describe('ParsedDataDisplay', () => {
       await user.click(option)
     })
 
-    await waitFor(() => {
-      expect(onCategoryChange).toHaveBeenCalledWith(
-        'tx-1',
-        Category.Shopping
-      )
-    })
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('category-menu-tx-1')).toBeNull()
-    })
+    expect(onCategoryChange).toHaveBeenCalledWith('tx-1', Category.Shopping)
+    expect(screen.queryByTestId('category-menu-tx-1')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
Adds the dashboard overview summary cards and period selector, wiring period
changes into transaction filtering. Completes Heat 4.3.

## Heat/Sprint
Heat 4: Dashboard & Visualizations

## Changes
- `src/components/DashboardOverview.tsx` add summary cards and period selector
- `src/components/ParsedDataDisplay.tsx` integrate overview and period filters
- `src/components/DashboardOverview.test.tsx` verify totals and period ranges
- `src/components/ParsedDataDisplay.test.tsx` update data setup for overview
- `PROJECT_BOARD.md` mark Heat 4.3 complete and advance next task

## Tests
- 3 new tests added
- All tests passing (248/248)
- Coverage: not measured

## Screenshots/Demo
N/A (UI structure + logic)

## Breaking Changes
None

## Checklist
- [x] Tests written and passing
- [ ] Linting passes (no warnings)
- [ ] Documentation updated (if needed)
- [x] PROJECT_BOARD.md updated
- [x] Follows TDD methodology
- [x] No console errors or warnings

## Related Issues
N/A
