### PR TITLE
feat: add charts and visualizations

### DIFF
--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -176,7 +176,7 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
   - ✅ Implement summary components
   - ✅ Add period selector (this month, last month, custom range)
 
-- [ ] **4.4** Charts & Visualizations (TDD)
+- [x] **4.4** Charts & Visualizations (TDD) ✅
   - ✅ Write tests for spending by category (pie/donut chart)
   - ✅ Write tests for monthly trends (line/bar chart)
   - ✅ Write tests for income vs expenses comparison
@@ -306,7 +306,7 @@ Built with **React + TypeScript + Vite** following strict **TDD** principles.
 - 3.1 - Transaction Store (TDD) ✅
 - 3.2 - Data Aggregation Service (TDD) ✅
 - 3.3 - Filter & Search Engine (TDD) ✅
-**Next Task**: 4.4 - Charts & Visualizations (TDD)
+**Next Task**: 4.5 - Transaction List View (TDD)
 
 ---
 

--- a/src/components/ChartsSection.test.tsx
+++ b/src/components/ChartsSection.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChartsSection } from './ChartsSection'
+import type { Transaction } from '../models'
+
+function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'tx-1',
+    date: new Date('2025-01-01T00:00:00.000Z'),
+    description: 'Transaction',
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+describe('ChartsSection', () => {
+  it('renders chart headings', () => {
+    render(<ChartsSection transactions={[makeTransaction()]} />)
+
+    expect(screen.getByText('Spending by Category')).toBeInTheDocument()
+    expect(screen.getByText('Monthly Trends')).toBeInTheDocument()
+    expect(screen.getByText('Income vs Expenses')).toBeInTheDocument()
+  })
+
+  it('allows switching currency', () => {
+    render(<ChartsSection transactions={[makeTransaction()]} />)
+
+    const uyuButton = screen.getByRole('button', { name: 'UYU' })
+    fireEvent.click(uyuButton)
+
+    expect(uyuButton).toBeInTheDocument()
+  })
+})

--- a/src/components/ChartsSection.tsx
+++ b/src/components/ChartsSection.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+import type { Currency, Transaction } from '../models'
+import { CategorySpendingChart } from './charts/CategorySpendingChart'
+import { MonthlyTrendsChart } from './charts/MonthlyTrendsChart'
+import { IncomeExpenseChart } from './charts/IncomeExpenseChart'
+
+interface ChartsSectionProps {
+  transactions: Transaction[]
+}
+
+const CURRENCIES: Currency[] = ['USD', 'UYU']
+
+export function ChartsSection({ transactions }: ChartsSectionProps) {
+  const [currency, setCurrency] = useState<Currency>('USD')
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-gray-400 dark:text-gray-500">
+            Charts
+          </p>
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            Visual Insights
+          </h2>
+        </div>
+        <div className="flex items-center gap-2">
+          {CURRENCIES.map((item) => (
+            <button
+              key={item}
+              type="button"
+              onClick={() => setCurrency(item)}
+              className={`rounded-full px-4 py-2 text-xs font-semibold ${
+                currency === item
+                  ? 'bg-gray-900 text-white'
+                  : 'border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300'
+              }`}
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+        <div className="rounded-2xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+          <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Spending by Category
+          </p>
+          <CategorySpendingChart
+            transactions={transactions}
+            currency={currency}
+          />
+        </div>
+        <div className="rounded-2xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+          <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Monthly Trends
+          </p>
+          <MonthlyTrendsChart
+            transactions={transactions}
+            currency={currency}
+          />
+        </div>
+        <div className="rounded-2xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+          <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Income vs Expenses
+          </p>
+          <IncomeExpenseChart
+            transactions={transactions}
+            currency={currency}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/ParsedDataDisplay.tsx
+++ b/src/components/ParsedDataDisplay.tsx
@@ -13,6 +13,7 @@ import {
   type FilterOptions,
 } from '../services/filters/filters'
 import { DashboardOverview } from './DashboardOverview'
+import { ChartsSection } from './ChartsSection'
 
 interface ParsedDataDisplayProps {
   data: ParsedData
@@ -204,6 +205,8 @@ export function ParsedDataDisplay({
         transactions={sortedTransactions}
         onPeriodChange={handlePeriodChange}
       />
+
+      <ChartsSection transactions={sortedTransactions} />
 
       {/* Filters */}
       <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow-sm">

--- a/src/components/charts/CategorySpendingChart.tsx
+++ b/src/components/charts/CategorySpendingChart.tsx
@@ -1,0 +1,56 @@
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts'
+import type { Currency, Transaction } from '../../models'
+import { Category, CATEGORY_LABELS } from '../../models'
+import { buildCategorySpending } from '../../services/charts/chart-data'
+
+const COLORS = ['#111827', '#2563eb', '#16a34a', '#f97316', '#ef4444']
+
+interface CategorySpendingChartProps {
+  transactions: Transaction[]
+  currency: Currency
+}
+
+export function CategorySpendingChart({
+  transactions,
+  currency,
+}: CategorySpendingChartProps) {
+  const data = buildCategorySpending(transactions, currency).map((item) => ({
+    ...item,
+    label: CATEGORY_LABELS[item.category as Category] ?? item.category,
+  }))
+
+  return (
+    <div className="h-64 w-full" data-testid="chart-category">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="total"
+            nameKey="label"
+            innerRadius={50}
+            outerRadius={80}
+            paddingAngle={2}
+          >
+            {data.map((entry, index) => (
+              <Cell
+                key={`${entry.category}-${index}`}
+                fill={COLORS[index % COLORS.length]}
+              />
+            ))}
+          </Pie>
+          <Tooltip
+            formatter={(value: number) =>
+              `${value.toFixed(2)} ${currency}`
+            }
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/charts/IncomeExpenseChart.tsx
+++ b/src/components/charts/IncomeExpenseChart.tsx
@@ -1,0 +1,51 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { Currency, Transaction } from '../../models'
+import { buildIncomeExpenseSummary } from '../../services/charts/chart-data'
+
+interface IncomeExpenseChartProps {
+  transactions: Transaction[]
+  currency: Currency
+}
+
+export function IncomeExpenseChart({
+  transactions,
+  currency,
+}: IncomeExpenseChartProps) {
+  const summary = buildIncomeExpenseSummary(transactions, currency)
+  const data = [
+    {
+      name: 'Income',
+      value: summary.income,
+    },
+    {
+      name: 'Expenses',
+      value: summary.expense,
+    },
+  ]
+
+  return (
+    <div className="h-64 w-full" data-testid="chart-income-expense">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} layout="vertical" margin={{ left: 24 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis type="number" />
+          <YAxis dataKey="name" type="category" width={80} />
+          <Tooltip
+            formatter={(value: number) =>
+              `${value.toFixed(2)} ${currency}`
+            }
+          />
+          <Bar dataKey="value" fill="#2563eb" radius={[0, 6, 6, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/charts/MonthlyTrendsChart.tsx
+++ b/src/components/charts/MonthlyTrendsChart.tsx
@@ -1,0 +1,42 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { Currency, Transaction } from '../../models'
+import { buildMonthlyTrends } from '../../services/charts/chart-data'
+
+interface MonthlyTrendsChartProps {
+  transactions: Transaction[]
+  currency: Currency
+}
+
+export function MonthlyTrendsChart({
+  transactions,
+  currency,
+}: MonthlyTrendsChartProps) {
+  const data = buildMonthlyTrends(transactions, currency)
+
+  return (
+    <div className="h-64 w-full" data-testid="chart-trends">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip
+            formatter={(value: number) =>
+              `${value.toFixed(2)} ${currency}`
+            }
+          />
+          <Bar dataKey="income" fill="#16a34a" radius={[6, 6, 0, 0]} />
+          <Bar dataKey="expense" fill="#ef4444" radius={[6, 6, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/services/charts/chart-data.test.ts
+++ b/src/services/charts/chart-data.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildCategorySpending,
+  buildIncomeExpenseSummary,
+  buildMonthlyTrends,
+} from './chart-data'
+import type { Transaction } from '../../models'
+import { Category } from '../../models'
+
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
+  return {
+    id,
+    date: new Date('2025-01-01T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+describe('chart-data', () => {
+  it('builds category spending for a currency using debits only', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        amount: 20,
+        currency: 'USD',
+        type: 'debit',
+        category: Category.Groceries,
+      }),
+      makeTransaction('tx-2', {
+        amount: 5,
+        currency: 'USD',
+        type: 'credit',
+        category: Category.Groceries,
+      }),
+      makeTransaction('tx-3', {
+        amount: 10,
+        currency: 'USD',
+        type: 'debit',
+        category: Category.Restaurants,
+      }),
+      makeTransaction('tx-4', {
+        amount: 30,
+        currency: 'UYU',
+        type: 'debit',
+        category: Category.Restaurants,
+      }),
+    ]
+
+    const result = buildCategorySpending(transactions, 'USD')
+
+    expect(result).toEqual([
+      { category: Category.Groceries, total: 20 },
+      { category: Category.Restaurants, total: 10 },
+    ])
+  })
+
+  it('builds monthly trends per currency', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        amount: 100,
+        type: 'credit',
+        currency: 'USD',
+        date: new Date('2025-01-15T00:00:00.000Z'),
+      }),
+      makeTransaction('tx-2', {
+        amount: 40,
+        type: 'debit',
+        currency: 'USD',
+        date: new Date('2025-01-20T00:00:00.000Z'),
+      }),
+      makeTransaction('tx-3', {
+        amount: 10,
+        type: 'debit',
+        currency: 'USD',
+        date: new Date('2025-02-01T00:00:00.000Z'),
+      }),
+    ]
+
+    const result = buildMonthlyTrends(transactions, 'USD')
+
+    expect(result).toEqual([
+      { month: '2025-01', income: 100, expense: 40, net: 60 },
+      { month: '2025-02', income: 0, expense: 10, net: -10 },
+    ])
+  })
+
+  it('builds income vs expense summary per currency', () => {
+    const transactions = [
+      makeTransaction('tx-1', {
+        amount: 50,
+        type: 'credit',
+        currency: 'USD',
+      }),
+      makeTransaction('tx-2', {
+        amount: 25,
+        type: 'debit',
+        currency: 'USD',
+      }),
+    ]
+
+    const result = buildIncomeExpenseSummary(transactions, 'USD')
+
+    expect(result).toEqual({
+      income: 50,
+      expense: 25,
+      net: 25,
+    })
+  })
+})

--- a/src/services/charts/chart-data.ts
+++ b/src/services/charts/chart-data.ts
@@ -1,0 +1,105 @@
+import type { Currency, Transaction } from '../../models'
+import { Category } from '../../models'
+
+export interface CategorySpendingDatum {
+  category: string
+  total: number
+}
+
+export interface MonthlyTrendDatum {
+  month: string
+  income: number
+  expense: number
+  net: number
+}
+
+export interface IncomeExpenseSummary {
+  income: number
+  expense: number
+  net: number
+}
+
+function toMonthKey(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0')
+  return `${year}-${month}`
+}
+
+export function buildCategorySpending(
+  transactions: Transaction[],
+  currency: Currency
+): CategorySpendingDatum[] {
+  const grouped = new Map<string, number>()
+
+  transactions.forEach((tx) => {
+    if (tx.currency !== currency || tx.type !== 'debit') {
+      return
+    }
+
+    const category = tx.category ?? Category.Uncategorized
+    grouped.set(category, (grouped.get(category) ?? 0) + tx.amount)
+  })
+
+  return Array.from(grouped.entries())
+    .map(([category, total]) => ({ category, total }))
+    .sort((a, b) => b.total - a.total)
+}
+
+export function buildMonthlyTrends(
+  transactions: Transaction[],
+  currency: Currency
+): MonthlyTrendDatum[] {
+  const grouped = new Map<string, MonthlyTrendDatum>()
+
+  transactions.forEach((tx) => {
+    if (tx.currency !== currency) {
+      return
+    }
+
+    const month = toMonthKey(tx.date)
+    if (!grouped.has(month)) {
+      grouped.set(month, { month, income: 0, expense: 0, net: 0 })
+    }
+
+    const entry = grouped.get(month)
+    if (!entry) {
+      return
+    }
+
+    if (tx.type === 'credit') {
+      entry.income += tx.amount
+      entry.net += tx.amount
+    } else {
+      entry.expense += tx.amount
+      entry.net -= tx.amount
+    }
+  })
+
+  return Array.from(grouped.values()).sort((a, b) =>
+    a.month.localeCompare(b.month)
+  )
+}
+
+export function buildIncomeExpenseSummary(
+  transactions: Transaction[],
+  currency: Currency
+): IncomeExpenseSummary {
+  return transactions.reduce<IncomeExpenseSummary>(
+    (summary, tx) => {
+      if (tx.currency !== currency) {
+        return summary
+      }
+
+      if (tx.type === 'credit') {
+        summary.income += tx.amount
+        summary.net += tx.amount
+      } else {
+        summary.expense += tx.amount
+        summary.net -= tx.amount
+      }
+
+      return summary
+    },
+    { income: 0, expense: 0, net: 0 }
+  )
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -6,3 +6,30 @@ import '@testing-library/jest-dom/vitest'
 afterEach(() => {
   cleanup()
 })
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserverMock
+}
+
+if (typeof HTMLElement !== 'undefined') {
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      width: 800,
+      height: 400,
+      top: 0,
+      left: 0,
+      bottom: 400,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }),
+  })
+}


### PR DESCRIPTION
## Summary
Adds a charts section to visualize spending by category, monthly trends, and
income vs expenses with Recharts, backed by tested data transformers. Completes
Heat 4.4.

## Heat/Sprint
Heat 4: Dashboard & Visualizations

## Changes
- `src/services/charts/chart-data.ts` add category, trend, and summary builders
- `src/components/charts/*` add Recharts-based chart components with tooltips
- `src/components/ChartsSection.tsx` add currency toggle + chart layout
- `src/components/ParsedDataDisplay.tsx` wire charts into the UI
- `src/test/setup.ts` add ResizeObserver + sizing stubs for charts
- `PROJECT_BOARD.md` mark Heat 4.4 complete and advance next task

## Tests
- 5 new tests added
- All tests passing (253/253)
- Coverage: not measured

## Screenshots/Demo
N/A (chart scaffolding)

## Breaking Changes
None

## Checklist
- [x] Tests written and passing
- [ ] Linting passes (no warnings)
- [ ] Documentation updated (if needed)
- [x] PROJECT_BOARD.md updated
- [x] Follows TDD methodology
- [x] No console errors or warnings

## Related Issues
N/A
