### PR TITLE
feat: add supabase password recovery reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+VITE_SUPABASE_PASSWORD_RESET_REDIRECT_URL=https://tatu-fdba8.web.app
 
 VITE_FIREBASE_API_KEY=your_api_key
 VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ If you want authentication + cloud persistence enabled:
 
 1. Copy `.env.example` to `.env`
 2. Set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
-3. Run the SQL in `supabase/schema.sql` inside your Supabase project
+3. Set `VITE_SUPABASE_PASSWORD_RESET_REDIRECT_URL` to your hosted app URL
+   (example: `https://tatu-fdba8.web.app`)
+4. Run the SQL in `supabase/schema.sql` inside your Supabase project
 
 When these variables are present, the app enables login and stores
 transactions in Supabase.

--- a/src/App.supabase.test.tsx
+++ b/src/App.supabase.test.tsx
@@ -8,6 +8,8 @@ const {
   signInWithPasswordMock,
   signOutMock,
   signUpWithPasswordMock,
+  subscribeToAuthChangesMock,
+  updatePasswordMock,
   isSupabaseConfiguredMock,
   loadUserTransactionsMock,
   persistTransactionsMock,
@@ -23,6 +25,8 @@ const {
   signInWithPasswordMock: vi.fn(),
   signOutMock: vi.fn(),
   signUpWithPasswordMock: vi.fn(),
+  subscribeToAuthChangesMock: vi.fn(),
+  updatePasswordMock: vi.fn(),
   isSupabaseConfiguredMock: vi.fn(),
   loadUserTransactionsMock: vi.fn(),
   persistTransactionsMock: vi.fn(),
@@ -44,6 +48,8 @@ vi.mock('./services/supabase/auth', () => ({
   signInWithPassword: signInWithPasswordMock,
   signOut: signOutMock,
   signUpWithPassword: signUpWithPasswordMock,
+  subscribeToAuthChanges: subscribeToAuthChangesMock,
+  updatePassword: updatePasswordMock,
 }))
 
 vi.mock('./services/supabase/transactions', () => ({
@@ -73,6 +79,7 @@ vi.mock('./services/supabase/import-runs', () => ({
 describe('App with supabase enabled', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    window.history.replaceState({}, '', '/')
     localStorage.clear()
     transactionStore.getState().clearTransactions()
     isSupabaseConfiguredMock.mockReturnValue(true)
@@ -86,6 +93,8 @@ describe('App with supabase enabled', () => {
     listCustomCategoriesMock.mockResolvedValue([])
     upsertCustomCategoryMock.mockResolvedValue(undefined)
     requestPasswordResetMock.mockResolvedValue(undefined)
+    subscribeToAuthChangesMock.mockReturnValue(() => undefined)
+    updatePasswordMock.mockResolvedValue(undefined)
     signOutMock.mockResolvedValue(undefined)
     signUpWithPasswordMock.mockResolvedValue({
       access_token: 'access',
@@ -154,6 +163,72 @@ describe('App with supabase enabled', () => {
     await waitFor(() =>
       expect(requestPasswordResetMock).toHaveBeenCalledWith('test@example.com')
     )
+  })
+
+  it('updates password from recovery mode', async () => {
+    window.history.replaceState({}, '', '/?mode=reset-password')
+
+    const { default: App } = await import('./App')
+    render(<App />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Elegí una nueva contraseña' })
+    ).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Nueva contraseña'), {
+      target: { value: 'new-secret123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar contraseña' }))
+
+    await waitFor(() =>
+      expect(updatePasswordMock).toHaveBeenCalledWith('new-secret123')
+    )
+    await waitFor(() =>
+      expect(signOutMock).toHaveBeenCalledWith(null)
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Ingresar a Tatú' })
+      ).toBeInTheDocument()
+    )
+  })
+
+  it('keeps user in reset screen during recovery even with active session', async () => {
+    window.history.replaceState({}, '', '/?mode=reset-password')
+    getCurrentSessionMock.mockReturnValue({
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: 9999,
+      user: { id: 'user-1', email: 'test@example.com' },
+    })
+
+    const { default: App } = await import('./App')
+    render(<App />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Elegí una nueva contraseña' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Bienvenido a Tatú' })
+    ).not.toBeInTheDocument()
+    expect(loadUserTransactionsMock).not.toHaveBeenCalled()
+  })
+
+  it('switches to reset mode when recovery event is raised', async () => {
+    subscribeToAuthChangesMock.mockImplementation((_onSession, onRecovery) => {
+      onRecovery?.()
+      return () => undefined
+    })
+
+    const { default: App } = await import('./App')
+    render(<App />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Elegí una nueva contraseña' })
+    ).toBeInTheDocument()
+    expect(loadUserTransactionsMock).not.toHaveBeenCalled()
   })
 
   it('migrates local persisted transactions after sign in', async () => {
@@ -251,7 +326,9 @@ describe('App with supabase enabled', () => {
     await waitFor(() => expect(upsertCustomCategoryMock).toHaveBeenCalledTimes(1))
   })
 
-  it('updates and soft-deletes transactions from transactions view', async () => {
+  it(
+    'updates and soft-deletes transactions from transactions view',
+    async () => {
     getCurrentSessionMock.mockReturnValue({
       access_token: 'access',
       refresh_token: 'refresh',
@@ -332,5 +409,7 @@ describe('App with supabase enabled', () => {
         'tx-10'
       )
     )
-  })
+    },
+    15000
+  )
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,8 @@ import {
   signInWithPassword,
   signOut,
   signUpWithPassword,
+  subscribeToAuthChanges,
+  updatePassword,
 } from './services/supabase/auth'
 import {
   isSupabaseConfigured,
@@ -69,6 +71,36 @@ const CATEGORY_OVERRIDES_MIGRATION_KEY =
   'tatu:migration:category-overrides:v1'
 const CUSTOM_CATEGORIES_MIGRATION_KEY = 'tatu:migration:custom-categories:v1'
 
+function isPasswordResetMode(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  return (
+    new URLSearchParams(window.location.search).get('mode') ===
+    'reset-password'
+  )
+}
+
+function clearPasswordResetModeFromUrl(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const url = new URL(window.location.href)
+  if (!url.searchParams.has('mode')) {
+    return
+  }
+
+  url.searchParams.delete('mode')
+  const nextQuery = url.searchParams.toString()
+  window.history.replaceState(
+    {},
+    '',
+    `${url.pathname}${nextQuery ? `?${nextQuery}` : ''}${url.hash}`
+  )
+}
+
 function App() {
   const supabaseEnabled = isSupabaseConfigured()
 
@@ -88,6 +120,9 @@ function App() {
   const [authNotice, setAuthNotice] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [authMode, setAuthMode] = useState<'signin' | 'reset'>(() =>
+    isPasswordResetMode() ? 'reset' : 'signin'
+  )
 
   // Get transactions from store
   const transactions = useStore(transactionStore, (state) => state.transactions)
@@ -108,10 +143,36 @@ function App() {
   }, [session])
 
   useEffect(() => {
+    if (!supabaseEnabled) {
+      return
+    }
+
+    const unsubscribe = subscribeToAuthChanges(
+      (nextSession) => {
+        setSession(nextSession)
+      },
+      () => {
+        setAuthMode('reset')
+        setAuthError('')
+        setAuthNotice('Ingresá una nueva contraseña para tu cuenta')
+      }
+    )
+
+    return () => {
+      unsubscribe()
+    }
+  }, [supabaseEnabled])
+
+  useEffect(() => {
     let cancelled = false
 
     async function syncTransactions() {
       if (!supabaseEnabled) {
+        setAuthLoading(false)
+        return
+      }
+
+      if (authMode === 'reset') {
         setAuthLoading(false)
         return
       }
@@ -241,7 +302,7 @@ function App() {
     return () => {
       cancelled = true
     }
-  }, [session, supabaseEnabled])
+  }, [authMode, session, supabaseEnabled])
 
   async function handleAuth(action: 'signin' | 'signup') {
     setAuthSubmitting(true)
@@ -268,6 +329,7 @@ function App() {
     try {
       await signOut(session)
       setSession(null)
+      setAuthMode('signin')
       transactionStore.getState().clearTransactions()
       setCurrentView('dashboard')
       setMobileMenuOpen(false)
@@ -359,6 +421,35 @@ function App() {
     }
   }
 
+  async function handlePasswordUpdate() {
+    setAuthSubmitting(true)
+    setAuthError('')
+    setAuthNotice('')
+
+    try {
+      await updatePassword(password)
+      try {
+        await signOut(session)
+      } catch {
+        // Ignore sign-out errors after a successful password change.
+      }
+      setSession(null)
+      transactionStore.getState().clearTransactions()
+      setPassword('')
+      setAuthMode('signin')
+      clearPasswordResetModeFromUrl()
+      setAuthNotice('Contraseña actualizada. Iniciá sesión nuevamente')
+    } catch (error) {
+      setAuthError(
+        error instanceof Error
+          ? error.message
+          : 'No se pudo actualizar la contraseña'
+      )
+    } finally {
+      setAuthSubmitting(false)
+    }
+  }
+
   async function handleResetAllData() {
     transactionStore.getState().clearTransactions()
     clearAllCategoryOverrides()
@@ -433,18 +524,25 @@ function App() {
     { id: 'import' as View, label: 'Importar', icon: Upload },
   ]
 
-  if (supabaseEnabled && !session) {
+  if (supabaseEnabled && (!session || authMode === 'reset')) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center px-4">
         <div className="w-full max-w-md bg-card border border-border rounded-xl p-6 space-y-4">
           <div>
             <TatuLogo size="md" />
-            <h2 className="mt-4 mb-1">Ingresar a Tatú</h2>
+            <h2 className="mt-4 mb-1">
+              {authMode === 'reset'
+                ? 'Elegí una nueva contraseña'
+                : 'Ingresar a Tatú'}
+            </h2>
             <p className="text-sm text-muted-foreground">
-              Tu información se guarda de forma segura en tu cuenta.
+              {authMode === 'reset'
+                ? 'Este cambio se aplica a tu cuenta de Supabase.'
+                : 'Tu información se guarda de forma segura en tu cuenta.'}
             </p>
           </div>
           <AuthCard
+            mode={authMode}
             email={email}
             password={password}
             authError={authError}
@@ -460,6 +558,19 @@ function App() {
             }}
             onResetPassword={() => {
               void handlePasswordReset()
+            }}
+            onUpdatePassword={() => {
+              void handlePasswordUpdate()
+            }}
+            onBackToSignIn={() => {
+              setAuthMode('signin')
+              setPassword('')
+              setAuthError('')
+              setAuthNotice('')
+              clearPasswordResetModeFromUrl()
+              void signOut(session)
+              setSession(null)
+              transactionStore.getState().clearTransactions()
             }}
           />
         </div>

--- a/src/components/AuthCard.tsx
+++ b/src/components/AuthCard.tsx
@@ -1,6 +1,7 @@
 import { Button } from './ui/button'
 
 interface AuthCardProps {
+  mode: 'signin' | 'reset'
   email: string
   password: string
   authError: string
@@ -11,9 +12,12 @@ interface AuthCardProps {
   onSignIn: () => void
   onSignUp: () => void
   onResetPassword: () => void
+  onUpdatePassword: () => void
+  onBackToSignIn: () => void
 }
 
 export function AuthCard({
+  mode,
   email,
   password,
   authError,
@@ -24,31 +28,42 @@ export function AuthCard({
   onSignIn,
   onSignUp,
   onResetPassword,
+  onUpdatePassword,
+  onBackToSignIn,
 }: AuthCardProps) {
+  const isResetMode = mode === 'reset'
+
   return (
     <form
       className="space-y-3"
       onSubmit={(event) => {
         event.preventDefault()
+        if (isResetMode) {
+          onUpdatePassword()
+          return
+        }
+
         onSignIn()
       }}
     >
-      <input
-        type="email"
-        value={email}
-        onChange={(event) => onEmailChange(event.target.value)}
-        className="w-full px-3 py-2 rounded-md border border-border bg-background"
-        placeholder="email@ejemplo.com"
-        autoComplete="email"
-        required
-      />
+      {!isResetMode && (
+        <input
+          type="email"
+          value={email}
+          onChange={(event) => onEmailChange(event.target.value)}
+          className="w-full px-3 py-2 rounded-md border border-border bg-background"
+          placeholder="email@ejemplo.com"
+          autoComplete="email"
+          required
+        />
+      )}
       <input
         type="password"
         value={password}
         onChange={(event) => onPasswordChange(event.target.value)}
         className="w-full px-3 py-2 rounded-md border border-border bg-background"
-        placeholder="Contraseña"
-        autoComplete="current-password"
+        placeholder={isResetMode ? 'Nueva contraseña' : 'Contraseña'}
+        autoComplete={isResetMode ? 'new-password' : 'current-password'}
         required
         minLength={6}
       />
@@ -62,23 +77,47 @@ export function AuthCard({
           {authNotice}
         </p>
       )}
-      <div className="flex gap-2">
-        <Button type="submit" disabled={authSubmitting}>
-          {authSubmitting ? 'Procesando...' : 'Iniciar sesión'}
-        </Button>
-        <Button type="button" variant="outline" disabled={authSubmitting} onClick={onSignUp}>
-          Crear cuenta
-        </Button>
-      </div>
-      <Button
-        type="button"
-        variant="ghost"
-        disabled={authSubmitting || !email}
-        onClick={onResetPassword}
-        className="px-0"
-      >
-        Restablecer contraseña
-      </Button>
+      {isResetMode ? (
+        <>
+          <Button type="submit" disabled={authSubmitting}>
+            {authSubmitting ? 'Procesando...' : 'Guardar contraseña'}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={authSubmitting}
+            onClick={onBackToSignIn}
+            className="px-0"
+          >
+            Volver a iniciar sesión
+          </Button>
+        </>
+      ) : (
+        <>
+          <div className="flex gap-2">
+            <Button type="submit" disabled={authSubmitting}>
+              {authSubmitting ? 'Procesando...' : 'Iniciar sesión'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={authSubmitting}
+              onClick={onSignUp}
+            >
+              Crear cuenta
+            </Button>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={authSubmitting || !email}
+            onClick={onResetPassword}
+            className="px-0"
+          >
+            Restablecer contraseña
+          </Button>
+        </>
+      )}
     </form>
   )
 }

--- a/src/hooks/useTheme.test.tsx
+++ b/src/hooks/useTheme.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTheme } from './useTheme'
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+  })
+
+  it('initializes from localStorage and applies dark class', () => {
+    localStorage.setItem('theme', 'dark')
+
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('uses system preference when no stored theme', () => {
+    const matchMediaMock = vi.fn().mockReturnValue({ matches: true })
+    vi.stubGlobal('matchMedia', matchMediaMock)
+
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe('dark')
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('toggles theme and persists update', () => {
+    localStorage.setItem('theme', 'light')
+
+    const { result } = renderHook(() => useTheme())
+
+    act(() => {
+      result.current.toggleTheme()
+    })
+
+    expect(result.current.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+})

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createRootMock, renderMock } = vi.hoisted(() => ({
+  createRootMock: vi.fn(),
+  renderMock: vi.fn(),
+}))
+
+vi.mock('react-dom/client', () => ({
+  default: {
+    createRoot: createRootMock,
+  },
+  createRoot: createRootMock,
+}))
+
+vi.mock('./App.tsx', () => ({
+  default: () => null,
+}))
+
+vi.mock('./services/firebase', () => ({}))
+
+describe('main bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    document.body.innerHTML = '<div id="root"></div>'
+    createRootMock.mockReturnValue({ render: renderMock })
+  })
+
+  it('creates react root and renders app tree', async () => {
+    await import('./main')
+
+    expect(createRootMock).toHaveBeenCalledTimes(1)
+    expect(createRootMock).toHaveBeenCalledWith(
+      document.getElementById('root')
+    )
+    expect(renderMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/services/parsers/index.test.ts
+++ b/src/services/parsers/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import * as parsers from './index'
+import { parseCSV, detectFileType } from './csv-parser'
+import { parseCreditCardCSV } from './credit-card-parser'
+import { parseBankAccountCSV } from './bank-account-parser'
+import {
+  parseSantanderNumber,
+  parseSantanderDate,
+  generateTransactionId,
+} from './utils'
+
+describe('parsers module index exports', () => {
+  it('re-exports parser entry points', () => {
+    expect(parsers.parseCSV).toBe(parseCSV)
+    expect(parsers.detectFileType).toBe(detectFileType)
+    expect(parsers.parseCreditCardCSV).toBe(parseCreditCardCSV)
+    expect(parsers.parseBankAccountCSV).toBe(parseBankAccountCSV)
+  })
+
+  it('re-exports parser utility functions', () => {
+    expect(parsers.parseSantanderNumber).toBe(parseSantanderNumber)
+    expect(parsers.parseSantanderDate).toBe(parseSantanderDate)
+    expect(parsers.generateTransactionId).toBe(generateTransactionId)
+  })
+})

--- a/src/services/supabase/auth.test.ts
+++ b/src/services/supabase/auth.test.ts
@@ -5,6 +5,9 @@ const {
   signUpMock,
   signOutMock,
   resetPasswordForEmailMock,
+  updateUserMock,
+  onAuthStateChangeMock,
+  unsubscribeMock,
   loadStoredSessionMock,
   storeSessionMock,
   clearStoredSessionMock,
@@ -13,6 +16,9 @@ const {
   signUpMock: vi.fn(),
   signOutMock: vi.fn(),
   resetPasswordForEmailMock: vi.fn(),
+  updateUserMock: vi.fn(),
+  onAuthStateChangeMock: vi.fn(),
+  unsubscribeMock: vi.fn(),
   loadStoredSessionMock: vi.fn(),
   storeSessionMock: vi.fn(),
   clearStoredSessionMock: vi.fn(),
@@ -29,6 +35,8 @@ vi.mock('./client', () => ({
       signUp: signUpMock,
       signOut: signOutMock,
       resetPasswordForEmail: resetPasswordForEmailMock,
+      updateUser: updateUserMock,
+      onAuthStateChange: onAuthStateChangeMock,
     },
   }),
 }))
@@ -36,6 +44,9 @@ vi.mock('./client', () => ({
 describe('supabase auth service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    onAuthStateChangeMock.mockReturnValue({
+      data: { subscription: { unsubscribe: unsubscribeMock } },
+    })
   })
 
   it('signs in and stores session', async () => {
@@ -89,7 +100,76 @@ describe('supabase auth service', () => {
     const { requestPasswordReset } = await import('./auth')
     await requestPasswordReset('test@example.com')
 
-    expect(resetPasswordForEmailMock).toHaveBeenCalledWith('test@example.com')
+    expect(resetPasswordForEmailMock).toHaveBeenCalledWith(
+      'test@example.com',
+      expect.objectContaining({
+        redirectTo: expect.stringContaining('?mode=reset-password'),
+      })
+    )
+  })
+
+  it('updates password for authenticated user', async () => {
+    updateUserMock.mockResolvedValue({ error: null })
+
+    const { updatePassword } = await import('./auth')
+    await updatePassword('new-secret')
+
+    expect(updateUserMock).toHaveBeenCalledWith({ password: 'new-secret' })
+  })
+
+  it('subscribes to auth changes and handles password recovery', async () => {
+    const nextSession = {
+      access_token: 'next-token',
+      user: { id: 'user-1' },
+    }
+    let callback: ((event: string, session: unknown) => void) | undefined
+    onAuthStateChangeMock.mockImplementation(
+      (cb: (event: string, session: unknown) => void) => {
+        callback = cb
+        return {
+          data: { subscription: { unsubscribe: unsubscribeMock } },
+        }
+      }
+    )
+
+    const onSessionChange = vi.fn()
+    const onPasswordRecovery = vi.fn()
+    const { subscribeToAuthChanges } = await import('./auth')
+    const unsubscribe = subscribeToAuthChanges(
+      onSessionChange,
+      onPasswordRecovery
+    )
+
+    callback?.('PASSWORD_RECOVERY', nextSession)
+
+    expect(storeSessionMock).toHaveBeenCalledWith(nextSession)
+    expect(onSessionChange).toHaveBeenCalledWith(nextSession)
+    expect(onPasswordRecovery).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles signed out auth change by clearing session', async () => {
+    let callback: ((event: string, session: unknown) => void) | undefined
+    onAuthStateChangeMock.mockImplementation(
+      (cb: (event: string, session: unknown) => void) => {
+        callback = cb
+        return {
+          data: { subscription: { unsubscribe: unsubscribeMock } },
+        }
+      }
+    )
+
+    const onSessionChange = vi.fn()
+    const { subscribeToAuthChanges } = await import('./auth')
+    subscribeToAuthChanges(onSessionChange)
+
+    callback?.('SIGNED_OUT', null)
+
+    expect(clearStoredSessionMock).toHaveBeenCalledTimes(1)
+    expect(onSessionChange).toHaveBeenCalledWith(null)
+    expect(storeSessionMock).not.toHaveBeenCalled()
   })
 
   it('returns current session when configured', async () => {

--- a/src/services/supabase/auth.ts
+++ b/src/services/supabase/auth.ts
@@ -15,6 +15,19 @@ export function getCurrentSession(): SupabaseSession | null {
   return loadStoredSession()
 }
 
+function getPasswordRecoveryRedirectUrl(): string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  const configuredRedirectUrl =
+    import.meta.env.VITE_SUPABASE_PASSWORD_RESET_REDIRECT_URL?.trim()
+  const fallbackRedirectUrl = `${window.location.origin}${window.location.pathname}`
+  const url = new URL(configuredRedirectUrl || fallbackRedirectUrl)
+  url.searchParams.set('mode', 'reset-password')
+  return url.toString()
+}
+
 export async function signInWithPassword(
   email: string,
   password: string
@@ -76,8 +89,53 @@ export async function signOut(
 
 export async function requestPasswordReset(email: string): Promise<void> {
   const client = getSupabaseClient()
-  const { error } = await client.auth.resetPasswordForEmail(email)
+  const redirectTo = getPasswordRecoveryRedirectUrl()
+  const { error } = await client.auth.resetPasswordForEmail(email, redirectTo ? {
+    redirectTo,
+  } : undefined)
   if (error) {
     throw new Error(error.message)
+  }
+}
+
+export async function updatePassword(password: string): Promise<void> {
+  const client = getSupabaseClient()
+  const { error } = await client.auth.updateUser({
+    password,
+  })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+}
+
+export function subscribeToAuthChanges(
+  onSessionChange: (session: SupabaseSession | null) => void,
+  onPasswordRecovery?: () => void
+): () => void {
+  const client = getSupabaseClient()
+  const {
+    data: { subscription },
+  } = client.auth.onAuthStateChange((event, nextSession) => {
+    if (event === 'SIGNED_OUT') {
+      clearStoredSession()
+      onSessionChange(null)
+      return
+    }
+
+    if (!nextSession) {
+      return
+    }
+
+    storeSession(nextSession)
+    onSessionChange(nextSession)
+
+    if (event === 'PASSWORD_RECOVERY') {
+      onPasswordRecovery?.()
+    }
+  })
+
+  return () => {
+    subscription.unsubscribe()
   }
 }

--- a/src/services/supabase/client.test.ts
+++ b/src/services/supabase/client.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: createClientMock,
+}))
+
+describe('supabase client service', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('stores, loads, and clears session from localStorage', async () => {
+    const { storeSession, loadStoredSession, clearStoredSession } = await import('./client')
+
+    const session = {
+      access_token: 'token',
+      refresh_token: 'refresh',
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: 9999,
+      user: { id: 'user-1', email: 'test@example.com' },
+    }
+
+    storeSession(session as never)
+    expect(loadStoredSession()).toEqual(session)
+
+    clearStoredSession()
+    expect(loadStoredSession()).toBeNull()
+  })
+
+  it('returns null and clears storage when session JSON is invalid', async () => {
+    localStorage.setItem('tatu:supabase:session', '{invalid-json')
+    const { loadStoredSession } = await import('./client')
+
+    expect(loadStoredSession()).toBeNull()
+    expect(localStorage.getItem('tatu:supabase:session')).toBeNull()
+  })
+
+  it('creates supabase client once and reuses singleton instance', async () => {
+    createClientMock.mockReturnValue({ auth: {} })
+
+    const { getSupabaseClient } = await import('./client')
+    const first = getSupabaseClient()
+    const second = getSupabaseClient()
+
+    expect(first).toBe(second)
+    expect(createClientMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports configured status based on env vars', async () => {
+    const originalUrl = import.meta.env.VITE_SUPABASE_URL
+    const originalKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+
+    import.meta.env.VITE_SUPABASE_URL = 'https://example.supabase.co'
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY = 'anon-key'
+    vi.resetModules()
+
+    const configuredClient = await import('./client')
+    expect(configuredClient.isSupabaseConfigured()).toBe(true)
+
+    import.meta.env.VITE_SUPABASE_URL = ''
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY = ''
+    vi.resetModules()
+
+    const unconfiguredClient = await import('./client')
+    expect(unconfiguredClient.isSupabaseConfigured()).toBe(false)
+
+    import.meta.env.VITE_SUPABASE_URL = originalUrl
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY = originalKey
+  })
+})


### PR DESCRIPTION
## Summary
Adds a full Supabase password recovery reset flow in the app, including reset mode routing, password update handling, and auth state subscription wiring.

## Changes
- Add VITE_SUPABASE_PASSWORD_RESET_REDIRECT_URL to env docs and setup notes
- Handle mode=reset-password and recovery events in App
- Add reset-mode UX and actions in AuthCard
- Extend auth service with password update and auth change subscription
- Add tests for app reset flow, auth service behavior, bootstrap, parser exports, and theme hook

## Tests
- npm run lint
- npm test (401 passing)

## Breaking Changes
- None
