### PR TITLE
feat: UI/UX audit improvements — 6 tracks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@
 // A modern, trustworthy fintech app for managing Santander Uruguay statements
 
 import { useState, useEffect } from 'react'
+import { toast } from 'sonner'
+import { Toaster } from './components/ui/sonner'
 import { TatuLogo } from './components/TatuLogo'
 import { Dashboard } from './components/Dashboard'
 import { Transactions } from './components/Transactions'
@@ -359,6 +361,7 @@ function App() {
           ? await signInWithPassword(email, password)
           : await signUpWithPassword(email, password)
       setSession(nextSession)
+      toast.success('Sesión iniciada')
     } catch (error) {
       setAuthError(
         error instanceof Error ? error.message : 'Error de autenticación'
@@ -374,6 +377,7 @@ function App() {
       await signOut(session)
       setSession(null)
       setAuthMode('signin')
+      toast('Sesión cerrada')
       transactionStore.getState().clearTransactions()
       setCurrentView('dashboard')
       setMobileMenuOpen(false)
@@ -1085,6 +1089,8 @@ function App() {
                 size="sm"
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                 className="md:hidden"
+                aria-label="Abrir menú de navegación"
+                aria-expanded={mobileMenuOpen}
               >
                 {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
               </Button>
@@ -1202,6 +1208,7 @@ function App() {
           </div>
         </div>
       </footer>
+      <Toaster />
     </div>
   )
 }

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -151,7 +151,7 @@ export function Charts({ transactions }: ChartsProps) {
       <Card className="p-6">
         <h3 className="mb-6">Gastos por Categoría</h3>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <div className="flex items-center justify-center">
+          <div className="flex items-start justify-center">
             <ResponsiveContainer width="100%" height={300}>
               <PieChart>
                 <Pie
@@ -159,13 +159,6 @@ export function Charts({ transactions }: ChartsProps) {
                   cx="50%"
                   cy="50%"
                   labelLine={false}
-                  label={(entry) =>
-                    `${entry.name} ${
-                      hasExpenseData
-                        ? ((entry.value / totalExpenses) * 100).toFixed(0)
-                        : '0'
-                    }%`
-                  }
                   outerRadius={100}
                   fill="#8884d8"
                   dataKey="value"
@@ -175,6 +168,7 @@ export function Charts({ transactions }: ChartsProps) {
                   ))}
                 </Pie>
                 <Tooltip content={customTooltip} />
+                <Legend />
               </PieChart>
             </ResponsiveContainer>
           </div>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@
 
 import { Card } from './ui/card';
 import { Button } from './ui/button';
-import { TrendingUp, TrendingDown, Wallet, CreditCard, DollarSign, Landmark, Upload } from 'lucide-react';
+import { TrendingUp, TrendingDown, Wallet, CreditCard, DollarSign, Landmark, Upload, X } from 'lucide-react';
 import type { Transaction, Currency } from '../models';
 import { useMemo, useState } from 'react';
 import { filterByPeriod, generatePeriodOptions } from '../utils/date-utils';
@@ -213,15 +213,33 @@ export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) 
 
   const hasTransactions = transactions.length > 0;
 
+  const [bannerDismissed, setBannerDismissed] = useState(
+    () => localStorage.getItem('tatu:welcomeBannerDismissed') === 'true'
+  )
+
+  function dismissBanner() {
+    localStorage.setItem('tatu:welcomeBannerDismissed', 'true')
+    setBannerDismissed(true)
+  }
+
   return (
     <div className="space-y-6">
-      <div className="bg-gradient-to-r from-primary/10 via-accent/10 to-primary/10 rounded-2xl p-6 md:p-8 border border-primary/20">
-        <h1 className="mb-2">Bienvenido a Tatú</h1>
-        <p className="text-muted-foreground max-w-2xl">
-          Tu gestor de gastos inteligente. Monitoreá tus finanzas, descubrí patrones de gasto y
-          tomá decisiones informadas con datos de tus cuentas Santander Uruguay.
-        </p>
-      </div>
+      {!bannerDismissed && (
+        <div className="relative bg-gradient-to-r from-primary/10 via-accent/10 to-primary/10 rounded-2xl p-6 md:p-8 border border-primary/20">
+          <button
+            onClick={dismissBanner}
+            aria-label="Cerrar bienvenida"
+            className="absolute top-4 right-4 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X size={18} />
+          </button>
+          <h1 className="mb-2">Bienvenido a Tatú</h1>
+          <p className="text-muted-foreground max-w-2xl">
+            Tu gestor de gastos inteligente. Monitoreá tus finanzas, descubrí patrones de gasto y
+            tomá decisiones informadas con datos de tus cuentas Santander Uruguay.
+          </p>
+        </div>
+      )}
 
       {!hasTransactions && (
         <Card className="p-8 text-center space-y-4">
@@ -331,7 +349,7 @@ export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) 
             <div className="p-2 rounded-lg bg-primary-50 dark:bg-primary-900/20">
               <Wallet className="text-primary" size={24} />
             </div>
-            <span className="text-xs text-primary bg-primary-50 dark:bg-primary-900/20 px-2 py-1 rounded-full">
+            <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full">
               Balance
             </span>
           </div>

--- a/src/components/ImportCSV.tsx
+++ b/src/components/ImportCSV.tsx
@@ -4,6 +4,7 @@ import { Card } from './ui/card';
 import { Button } from './ui/button';
 import { Upload, FileText, Check, CircleAlert, Loader } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 import { parseCSV } from '../services/parsers/csv-parser';
 import { transactionStore } from '../stores/transaction-store';
 import type { ParsedData, Transaction } from '../models';
@@ -113,6 +114,9 @@ export function ImportCSV({
       });
 
       setImportState('success');
+      toast.success(
+        `${added.length} nueva${added.length === 1 ? '' : 's'} · ${duplicates.length} duplicada${duplicates.length === 1 ? '' : 's'} omitida${duplicates.length === 1 ? '' : 's'}`
+      );
 
       if (onImportComplete) {
         onImportComplete();

--- a/src/components/Tools.tsx
+++ b/src/components/Tools.tsx
@@ -385,7 +385,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 <Input
                   id="tools-amount-min"
                   type="number"
-                  placeholder="0.00"
+                  placeholder="Mínimo"
                   value={amountRange.min}
                   onChange={(e) => setAmountRange(prev => ({ ...prev, min: e.target.value }))}
                 />
@@ -397,7 +397,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 <Input
                   id="tools-amount-max"
                   type="number"
-                  placeholder="999999.99"
+                  placeholder="Máximo"
                   value={amountRange.max}
                   onChange={(e) => setAmountRange(prev => ({ ...prev, max: e.target.value }))}
                 />

--- a/src/components/Transactions.test.tsx
+++ b/src/components/Transactions.test.tsx
@@ -168,8 +168,7 @@ describe('Transactions', () => {
     )
 
     expect(
-      screen.getAllByText('No hay transacciones que coincidan con los filtros')
-        .length
+      screen.getAllByText('Sin resultados').length
     ).toBeGreaterThan(0)
     expect(screen.getByText('Mostrando 0 de 0')).toBeInTheDocument()
   })

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import {
   ArrowUpDown,
   CreditCard,
+  Loader2,
   Pencil,
   Search,
+  SlidersHorizontal,
   Sparkles,
   Trash2,
   Wallet,
+  X,
 } from 'lucide-react'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
@@ -136,8 +140,16 @@ export function Transactions({
   const filteredTransactions = useMemo(() => {
     const query = searchTerm.toLowerCase()
     const categoryQuery = categoryFilter.trim()
-    const dateFrom = dateFromFilter ? new Date(`${dateFromFilter}T00:00:00`) : null
-    const dateTo = dateToFilter ? new Date(`${dateToFilter}T23:59:59.999`) : null
+    const invalidDateRange =
+      dateFromFilter && dateToFilter && dateToFilter < dateFromFilter
+    const dateFrom =
+      !invalidDateRange && dateFromFilter
+        ? new Date(`${dateFromFilter}T00:00:00`)
+        : null
+    const dateTo =
+      !invalidDateRange && dateToFilter
+        ? new Date(`${dateToFilter}T23:59:59.999`)
+        : null
 
     const filtered = transactions.filter((transaction) => {
       const searchable =
@@ -216,6 +228,19 @@ export function Transactions({
     Boolean(dateToFilter) ||
     Boolean(categoryFilter) ||
     accountFilter !== 'all'
+
+  const dateRangeError =
+    dateFromFilter && dateToFilter && dateToFilter < dateFromFilter
+      ? 'La fecha "hasta" debe ser posterior a la fecha "desde"'
+      : null
+
+  function clearAllFilters() {
+    setSearchTerm('')
+    setDateFromFilter('')
+    setDateToFilter('')
+    setCategoryFilter('')
+    setAccountFilter('all')
+  }
 
   const categorySuggestions = useMemo(() => {
     return Array.from(
@@ -379,6 +404,7 @@ export function Transactions({
         tags: editTagList,
         applyScope,
       })
+      toast.success('Cambios guardados')
       resetEditState()
     } finally {
       setPendingTransactionId(null)
@@ -459,10 +485,12 @@ export function Transactions({
       return
     }
 
+    const count = selectedTransactionIds.length
     setIsAutoCategorizing(true)
     try {
       await onAutoCategorizeTransactions(selectedTransactionIds)
       setSelectedTransactionIds([])
+      toast.success(`${count} transacción${count === 1 ? '' : 'es'} categorizad${count === 1 ? 'a' : 'as'}`)
     } finally {
       setIsAutoCategorizing(false)
     }
@@ -479,10 +507,12 @@ export function Transactions({
     )
     if (!confirmed) return
 
+    const count = selectedTransactionIds.length
     setIsBulkOperating(true)
     try {
       await onBulkDelete(selectedTransactionIds)
       setSelectedTransactionIds([])
+      toast.success(`${count} transacción${count === 1 ? '' : 'es'} eliminada${count === 1 ? '' : 's'}`)
     } finally {
       setIsBulkOperating(false)
     }
@@ -508,6 +538,7 @@ export function Transactions({
   async function handleBulkEditSave() {
     if (selectedTransactionIds.length === 0 || isBulkOperating) return
 
+    const count = selectedTransactionIds.length
     setIsBulkOperating(true)
     try {
       if (bulkEditCategory && onBulkCategorize) {
@@ -520,6 +551,7 @@ export function Transactions({
       }
       setSelectedTransactionIds([])
       closeBulkEdit()
+      toast.success(`${count} transacción${count === 1 ? '' : 'es'} actualizada${count === 1 ? '' : 's'}`)
     } finally {
       setIsBulkOperating(false)
     }
@@ -554,17 +586,30 @@ export function Transactions({
 
       <Card className="p-4">
         <div className="space-y-4">
-          <div className="relative">
-            <Search
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-              size={20}
-            />
-            <Input
-              placeholder="Buscar por comercio o descripción..."
-              value={searchTerm}
-              onChange={(event) => setSearchTerm(event.target.value)}
-              className="pl-10"
-            />
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                size={20}
+              />
+              <Input
+                placeholder="Buscar por comercio o descripción..."
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                className="pl-10"
+              />
+            </div>
+            {hasActiveFilters && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={clearAllFilters}
+                className="shrink-0 gap-1.5"
+              >
+                <X size={14} />
+                Limpiar filtros
+              </Button>
+            )}
           </div>
 
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -597,7 +642,11 @@ export function Transactions({
                 type="date"
                 value={dateToFilter}
                 onChange={(event) => setDateToFilter(event.target.value)}
+                className={dateRangeError ? 'border-destructive' : ''}
               />
+              {dateRangeError && (
+                <p className="text-xs text-destructive">{dateRangeError}</p>
+              )}
             </div>
 
             <div className="space-y-1">
@@ -652,7 +701,7 @@ export function Transactions({
 
       {hasSelection && (
         <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-2.5 flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium" role="status">
+          <span className="text-sm font-medium" role="status" aria-live="polite">
             {selectionCount} seleccionada{selectionCount === 1 ? '' : 's'}
           </span>
 
@@ -685,7 +734,11 @@ export function Transactions({
                 void handleAutoCategorizeSelected()
               }}
             >
-              <Sparkles size={14} className="mr-1.5" />
+              {isAutoCategorizing ? (
+                <Loader2 size={14} className="mr-1.5 animate-spin" />
+              ) : (
+                <Sparkles size={14} className="mr-1.5" />
+              )}
               {isAutoCategorizing ? 'Auto-categorizando...' : 'Auto-categorizar'}
             </Button>
           )}
@@ -722,7 +775,10 @@ export function Transactions({
                     disabled={paginatedTransactionIds.length === 0 || isBusy}
                   />
                 </th>
-                <th className="text-left p-4 text-sm font-medium">
+                <th
+                  className="text-left p-4 text-sm font-medium"
+                  aria-sort={sortField === 'date' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                >
                   <button
                     onClick={() => handleSort('date')}
                     className="flex items-center gap-2 hover:text-primary transition-colors"
@@ -731,7 +787,10 @@ export function Transactions({
                     {sortField === 'date' && <ArrowUpDown size={14} />}
                   </button>
                 </th>
-                <th className="text-left p-4 text-sm font-medium">
+                <th
+                  className="text-left p-4 text-sm font-medium"
+                  aria-sort={sortField === 'description' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                >
                   <button
                     onClick={() => handleSort('description')}
                     className="flex items-center gap-2 hover:text-primary transition-colors"
@@ -740,7 +799,10 @@ export function Transactions({
                     {sortField === 'description' && <ArrowUpDown size={14} />}
                   </button>
                 </th>
-                <th className="text-left p-4 text-sm font-medium">
+                <th
+                  className="text-left p-4 text-sm font-medium"
+                  aria-sort={sortField === 'category' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                >
                   <button
                     onClick={() => handleSort('category')}
                     className="flex items-center gap-2 hover:text-primary transition-colors"
@@ -750,7 +812,10 @@ export function Transactions({
                   </button>
                 </th>
                 <th className="text-left p-4 text-sm font-medium">Cuenta</th>
-                <th className="text-right p-4 text-sm font-medium">
+                <th
+                  className="text-right p-4 text-sm font-medium"
+                  aria-sort={sortField === 'amount' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                >
                   <button
                     onClick={() => handleSort('amount')}
                     className="flex items-center gap-2 ml-auto hover:text-primary transition-colors"
@@ -765,10 +830,24 @@ export function Transactions({
             <tbody>
               {paginatedTransactions.length === 0 && (
                 <tr>
-                  <td colSpan={8} className="p-8 text-center text-muted-foreground">
-                    {hasActiveFilters
-                      ? 'No hay transacciones que coincidan con los filtros'
-                      : 'No hay transacciones para mostrar'}
+                  <td colSpan={8} className="p-10 text-center">
+                    {hasActiveFilters ? (
+                      <div className="flex flex-col items-center gap-3">
+                        <SlidersHorizontal className="text-muted-foreground" size={32} />
+                        <p className="font-medium">Sin resultados</p>
+                        <p className="text-sm text-muted-foreground">
+                          Probá ajustar los filtros o{' '}
+                          <button
+                            onClick={clearAllFilters}
+                            className="text-primary underline-offset-2 hover:underline"
+                          >
+                            limpiá los filtros
+                          </button>
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="text-muted-foreground">No hay transacciones para mostrar</p>
+                    )}
                   </td>
                 </tr>
               )}
@@ -900,10 +979,24 @@ export function Transactions({
             </div>
           )}
           {paginatedTransactions.length === 0 && (
-            <div className="p-6 text-center text-sm text-muted-foreground">
-              {hasActiveFilters
-                ? 'No hay transacciones que coincidan con los filtros'
-                : 'No hay transacciones para mostrar'}
+            <div className="p-8 text-center">
+              {hasActiveFilters ? (
+                <div className="flex flex-col items-center gap-3">
+                  <SlidersHorizontal className="text-muted-foreground" size={28} />
+                  <p className="font-medium text-sm">Sin resultados</p>
+                  <p className="text-xs text-muted-foreground">
+                    Probá ajustar los filtros o{' '}
+                    <button
+                      onClick={clearAllFilters}
+                      className="text-primary underline-offset-2 hover:underline"
+                    >
+                      limpiá los filtros
+                    </button>
+                  </p>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No hay transacciones para mostrar</p>
+              )}
             </div>
           )}
           {paginatedTransactions.map((transaction) => (
@@ -922,8 +1015,8 @@ export function Transactions({
                   }
                   disabled={isBusy}
                 />
-                <div className="flex-1">
-                  <div className="font-medium mb-1">{displayDescription}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium mb-1 truncate">{displayDescription}</div>
                   {hasFriendlyOverride && (
                     <div className="text-xs text-muted-foreground mb-1">
                       Original: {transaction.description}
@@ -966,28 +1059,27 @@ export function Transactions({
                   {getAccountLabel(transaction.source)}
                 </span>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1 justify-end">
                 <Button
-                  variant="outline"
-                  size="sm"
+                  variant="ghost"
+                  size="icon"
                   aria-label={`Editar ${displayDescription}`}
                   disabled={pendingTransactionId === transaction.id}
                   onClick={() => startEditTransaction(transaction)}
                 >
-                  <Pencil size={14} />
-                  Editar
+                  <Pencil size={16} />
                 </Button>
                 <Button
-                  variant="outline"
-                  size="sm"
+                  variant="ghost"
+                  size="icon"
                   aria-label={`Eliminar ${displayDescription}`}
+                  className="text-destructive hover:text-destructive"
                   disabled={pendingTransactionId === transaction.id}
                   onClick={() => {
                     void handleDeleteTransaction(transaction)
                   }}
                 >
-                  <Trash2 size={14} />
-                  Eliminar
+                  <Trash2 size={16} />
                 </Button>
               </div>
             </div>
@@ -1239,6 +1331,9 @@ export function Transactions({
               }}
               disabled={Boolean(editingTransaction && pendingTransactionId === editingTransaction.id)}
             >
+              {editingTransaction && pendingTransactionId === editingTransaction.id && (
+                <Loader2 size={14} className="mr-1.5 animate-spin" />
+              )}
               Guardar cambios
             </Button>
           </DialogFooter>
@@ -1422,6 +1517,7 @@ export function Transactions({
               }}
               disabled={isBulkOperating || (!bulkEditCategory && bulkEditTagList.length === 0)}
             >
+              {isBulkOperating && <Loader2 size={14} className="mr-1.5 animate-spin" />}
               Guardar cambios
             </Button>
           </DialogFooter>
@@ -1447,20 +1543,40 @@ export function Transactions({
             Anterior
           </Button>
           <div className="flex items-center gap-1">
-            {Array.from({ length: Math.min(5, totalPages) }, (_, index) => {
-              const page = index + 1
-              return (
-                <Button
-                  key={page}
-                  variant={currentPage === page ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setCurrentPage(page)}
-                  className="w-10"
-                >
-                  {page}
-                </Button>
+            {(() => {
+              const pages: (number | '...')[] = []
+              if (safeTotalPages <= 7) {
+                for (let i = 1; i <= safeTotalPages; i++) pages.push(i)
+              } else {
+                pages.push(1)
+                if (currentPage > 3) pages.push('...')
+                for (
+                  let i = Math.max(2, currentPage - 1);
+                  i <= Math.min(safeTotalPages - 1, currentPage + 1);
+                  i++
+                )
+                  pages.push(i)
+                if (currentPage < safeTotalPages - 2) pages.push('...')
+                pages.push(safeTotalPages)
+              }
+              return pages.map((p, i) =>
+                p === '...' ? (
+                  <span key={`ellipsis-${i}`} className="px-1 text-muted-foreground">
+                    …
+                  </span>
+                ) : (
+                  <Button
+                    key={p}
+                    variant={currentPage === p ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCurrentPage(p)}
+                    className="w-10"
+                  >
+                    {p}
+                  </Button>
+                )
               )
-            })}
+            })()}
           </div>
           <Button
             variant="outline"


### PR DESCRIPTION
## Summary

Full implementation of the UI/UX audit plan across 6 tracks:

- **Track 1 — Toast notifications**: Mounted `<Toaster>`, fire toasts on sign-in, sign-out, import (with new/duplicate count), bulk delete, auto-categorize, bulk edit save, and single transaction save.
- **Track 2 — Pagination**: Replaced the hard-coded 5-page cap (`Math.min(5, totalPages)`) with a windowed page list — always shows page 1 + last, current page ±1, and `…` ellipsis for gaps.
- **Track 3 — Filter UX**: "Limpiar filtros" button appears when any filter is active; `from > to` date range shows a destructive inline error and skips date filtering; empty state replaced with a styled card (icon + "Sin resultados" + CTA link).
- **Track 4 — Loading states**: `Loader2` spinner inside auto-categorize, bulk-edit save, and single-transaction save buttons while the operation is in-flight.
- **Track 5 — Layout & visual fixes**: Pie chart container `items-start` (was `items-center`), removed overlapping inline labels, added `<Legend>`; Dashboard "Balance" badge demoted to `text-muted-foreground`; welcome banner gets a dismiss `×` button persisted in localStorage; mobile transaction cards replaced full-width outline buttons with icon-only ghost buttons and description text truncated to 1 line; Tools amount range placeholders changed from `0.00` / `999999.99` to "Mínimo" / "Máximo".
- **Track 6 — Accessibility**: `aria-live="polite"` on selection count; `aria-sort` on all four sortable column headers; `aria-label` + `aria-expanded` on mobile hamburger.

## Test plan

- [ ] 528 tests pass, lint clean (`npm run tdd:verify`)
- [ ] Toasts fire on import, delete, categorize, save, sign-in/out
- [ ] Pagination navigates past page 5 on large datasets
- [ ] Date `from > to` shows red error; "Limpiar filtros" resets all fields; no-results shows styled card
- [ ] Spinner appears inside buttons during async ops
- [ ] Pie chart appears at top-left; legend shows below
- [ ] Dashboard "Balance" badge is gray, not blue
- [ ] Dismiss welcome banner → reload → stays gone
- [ ] Mobile: cards show icon-only edit/delete buttons; descriptions truncate
- [ ] Tools Filtros: amount range shows "Mínimo" / "Máximo" placeholder text