### PR TITLE
feat: page structure & user flow improvements

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -136,7 +136,7 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Herramientas' }))
 
     expect(screen.getByRole('heading', { name: 'Herramientas' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Filtros Avanzados' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Exportar Datos' })).toBeInTheDocument()
   })
 
   it('applies dark theme from localStorage on initial render', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,7 @@ function App() {
     return saved === 'dark'
   })
   const [currentView, setCurrentView] = useState<View>('dashboard')
+  const [pendingTxFilter, setPendingTxFilter] = useState<import('./models').TransactionsFilter | null>(null)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [session, setSession] = useState<SupabaseSession | null>(() =>
     supabaseEnabled ? getCurrentSession() : null
@@ -390,6 +391,11 @@ function App() {
     } finally {
       setAuthSubmitting(false)
     }
+  }
+
+  function navigateToTransactions(filter: import('./models').TransactionsFilter) {
+    setPendingTxFilter(filter)
+    setCurrentView('transactions')
   }
 
   async function handleTransactionsImported(
@@ -1045,7 +1051,7 @@ function App() {
               {navItems.map((item) => (
                 <button
                   key={item.id}
-                  onClick={() => setCurrentView(item.id)}
+                  onClick={() => { if (item.id === 'transactions') setPendingTxFilter(null); setCurrentView(item.id) }}
                   className={`px-4 py-2 rounded-lg transition-colors ${
                     currentView === item.id
                       ? 'bg-primary text-primary-foreground'
@@ -1072,6 +1078,17 @@ function App() {
                   Salir
                 </Button>
               )}
+              {/* Import Quick-Access */}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCurrentView('import')}
+                className="hidden sm:flex gap-1.5"
+                aria-label="Importar CSV"
+              >
+                <Upload size={16} />
+                <span className="hidden lg:inline">Importar</span>
+              </Button>
               {/* Theme Toggle */}
               <Button
                 variant="ghost"
@@ -1113,6 +1130,7 @@ function App() {
                     <button
                       key={item.id}
                       onClick={() => {
+                        if (item.id === 'transactions') setPendingTxFilter(null)
                         setCurrentView(item.id)
                         setMobileMenuOpen(false)
                       }}
@@ -1156,11 +1174,16 @@ function App() {
           </p>
         )}
         {currentView === 'dashboard' && (
-          <Dashboard transactions={transactions} onNavigateToImport={() => setCurrentView('import')} />
+          <Dashboard
+            transactions={transactions}
+            onNavigateToImport={() => setCurrentView('import')}
+            onNavigateToTransactions={navigateToTransactions}
+          />
         )}
         {currentView === 'transactions' && (
           <Transactions
             transactions={transactions}
+            initialFilter={pendingTxFilter ?? undefined}
             onUpdateTransaction={handleUpdateTransaction}
             onDeleteTransaction={handleDeleteTransaction}
             onAutoCategorizeTransactions={handleAutoCategorizeTransactions}
@@ -1169,7 +1192,9 @@ function App() {
             onBulkTag={handleBulkTagTransactions}
           />
         )}
-        {currentView === 'charts' && <Charts transactions={transactions} />}
+        {currentView === 'charts' && (
+          <Charts transactions={transactions} onNavigateToTransactions={navigateToTransactions} />
+        )}
         {currentView === 'tools' && (
           <Tools
             transactions={transactions}

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -2,7 +2,7 @@
 
 import { Card } from './ui/card';
 import { ChartPie } from 'lucide-react';
-import type { Transaction } from '../models';
+import type { Transaction, TransactionsFilter } from '../models';
 import { Category } from '../models';
 import {
   PieChart,
@@ -66,9 +66,10 @@ function groupByMonth(transactions: Transaction[]) {
 
 interface ChartsProps {
   transactions: Transaction[];
+  onNavigateToTransactions?: (filter: TransactionsFilter) => void;
 }
 
-export function Charts({ transactions }: ChartsProps) {
+export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) {
   const categoryData = Object.entries(groupByCategory(transactions))
     .map(([categoryId, amount]) => {
       const category = getCategoryDisplay(categoryId);
@@ -76,6 +77,7 @@ export function Charts({ transactions }: ChartsProps) {
         name: category.label,
         value: amount,
         color: category.color,
+        categoryId,
       };
     })
     .sort((a, b) => b.value - a.value);
@@ -151,7 +153,7 @@ export function Charts({ transactions }: ChartsProps) {
       <Card className="p-6">
         <h3 className="mb-6">Gastos por Categoría</h3>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <div className="flex items-start justify-center">
+          <div className={`flex items-start justify-center${onNavigateToTransactions ? ' cursor-pointer' : ''}`}>
             <ResponsiveContainer width="100%" height={300}>
               <PieChart>
                 <Pie
@@ -162,6 +164,9 @@ export function Charts({ transactions }: ChartsProps) {
                   outerRadius={100}
                   fill="#8884d8"
                   dataKey="value"
+                  onClick={onNavigateToTransactions ? (data: { categoryId?: string } | null) => {
+                    if (data?.categoryId) onNavigateToTransactions({ category: data.categoryId })
+                  } : undefined}
                 >
                   {categoryData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={entry.color} />
@@ -180,7 +185,11 @@ export function Charts({ transactions }: ChartsProps) {
                 ? (cat.value / totalExpenses) * 100
                 : 0;
               return (
-                <div key={index} className="space-y-1">
+                <div
+                  key={index}
+                  className={`space-y-1${onNavigateToTransactions ? ' cursor-pointer hover:bg-muted/50 rounded p-1 -m-1 transition-colors' : ''}`}
+                  onClick={onNavigateToTransactions ? () => onNavigateToTransactions({ category: cat.categoryId }) : undefined}
+                >
                   <div className="flex items-center justify-between text-sm">
                     <div className="flex items-center gap-2">
                       <div

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@
 import { Card } from './ui/card';
 import { Button } from './ui/button';
 import { TrendingUp, TrendingDown, Wallet, CreditCard, DollarSign, Landmark, Upload, X } from 'lucide-react';
-import type { Transaction, Currency } from '../models';
+import type { Transaction, Currency, TransactionsFilter } from '../models';
 import { useMemo, useState } from 'react';
 import { filterByPeriod, generatePeriodOptions } from '../utils/date-utils';
 import { getCategoryDisplay } from '../utils/category-display';
@@ -102,9 +102,10 @@ function getTopCategory(transactions: Transaction[]): {
 interface DashboardProps {
   transactions: Transaction[];
   onNavigateToImport?: () => void;
+  onNavigateToTransactions?: (filter: TransactionsFilter) => void;
 }
 
-export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) {
+export function Dashboard({ transactions, onNavigateToImport, onNavigateToTransactions }: DashboardProps) {
   const [selectedCurrency, setSelectedCurrency] = useState<Currency | 'all'>('all');
   const [selectedPeriodId, setSelectedPeriodId] = useState<string>('all');
 
@@ -370,7 +371,10 @@ export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) 
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        <Card className="p-6">
+        <Card
+          className={`p-6${onNavigateToTransactions ? ' cursor-pointer hover:ring-2 hover:ring-primary/30 transition-all' : ''}`}
+          onClick={onNavigateToTransactions ? () => onNavigateToTransactions({ accountType: 'credit_card' }) : undefined}
+        >
           <div className="flex items-center gap-3 mb-4">
             <div className="p-2 rounded-lg bg-accent-50 dark:bg-accent-900/20">
               <CreditCard className="text-accent" size={20} />
@@ -407,7 +411,10 @@ export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) 
           </div>
         </Card>
 
-        <Card className="p-6">
+        <Card
+          className={`p-6${onNavigateToTransactions ? ' cursor-pointer hover:ring-2 hover:ring-primary/30 transition-all' : ''}`}
+          onClick={onNavigateToTransactions ? () => onNavigateToTransactions({ accountType: 'bank_account', currency: 'USD' }) : undefined}
+        >
           <div className="flex items-center gap-3 mb-4">
             <div className="p-2 rounded-lg bg-primary-50 dark:bg-primary-900/20">
               <DollarSign className="text-primary" size={20} />
@@ -429,7 +436,10 @@ export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) 
           </div>
         </Card>
 
-        <Card className="p-6">
+        <Card
+          className={`p-6${onNavigateToTransactions ? ' cursor-pointer hover:ring-2 hover:ring-primary/30 transition-all' : ''}`}
+          onClick={onNavigateToTransactions ? () => onNavigateToTransactions({ accountType: 'bank_account', currency: 'UYU' }) : undefined}
+        >
           <div className="flex items-center gap-3 mb-4">
             <div className="p-2 rounded-lg bg-success-50 dark:bg-success-900/20">
               <Landmark className="text-success-600" size={20} />
@@ -479,9 +489,14 @@ export function Dashboard({ transactions, onNavigateToImport }: DashboardProps) 
               {topExpense?.description || 'Sin movimientos en el período'}
             </p>
           </div>
-          <div>
+          <div
+            className={onNavigateToTransactions && topCategory ? 'cursor-pointer group' : ''}
+            onClick={onNavigateToTransactions && topCategory ? () => onNavigateToTransactions({ category: topCategory.category }) : undefined}
+          >
             <p className="text-sm text-muted-foreground mb-1">Categoría top</p>
-            <p className="font-mono">{topCategoryDisplay.label}</p>
+            <p className={`font-mono${onNavigateToTransactions && topCategory ? ' group-hover:text-primary transition-colors' : ''}`}>
+              {topCategoryDisplay.label}
+            </p>
             <p className="text-xs text-muted-foreground">
               {topCategory ? `${topCategory.percentage.toFixed(1)}% del total` : '0.0% del total'}
             </p>

--- a/src/components/Tools.test.tsx
+++ b/src/components/Tools.test.tsx
@@ -70,9 +70,10 @@ describe('Tools', () => {
   it('renders export and settings tabs with expected controls', () => {
     render(<Tools transactions={[makeTransaction({ id: 'tx-a' })]} />)
 
+    // Export is the default tab — no click needed, but click is a no-op
     fireEvent.click(screen.getByRole('button', { name: 'Exportar' }))
     expect(screen.getByRole('heading', { name: 'Exportar Datos' })).toBeInTheDocument()
-    expect(screen.getByLabelText('Fecha inicial')).toBeInTheDocument()
+    expect(screen.getByLabelText('Desde')).toBeInTheDocument()
     expect(screen.getByText(/La exportación incluirá 1 transacciones/)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Configuración' }))

--- a/src/components/Tools.tsx
+++ b/src/components/Tools.tsx
@@ -6,11 +6,13 @@ import { Input } from './ui/input';
 import { Switch } from './ui/switch';
 import { Badge } from './ui/badge';
 import { CategoryBadge } from './CategoryBadge';
-import { ListFilter, Download, Plus, Pencil, Trash, FileText, Settings } from 'lucide-react';
+import { Download, Plus, Pencil, Trash, FileText, Settings } from 'lucide-react';
 import type { Transaction } from '../models';
 import { Category } from '../models';
 import { categories } from '../utils/figma-data';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { toast } from 'sonner';
+import { exportTransactions } from '../services/export/export';
 import { getCategoryDefinitions } from '../services/categories/category-registry';
 import {
   addCustomCategoryWithSync,
@@ -33,7 +35,7 @@ interface ToolsProps {
 }
 
 export function Tools({ transactions, onResetAllData }: ToolsProps) {
-  const [activeTab, setActiveTab] = useState<'filters' | 'export' | 'categories' | 'settings'>('filters');
+  const [activeTab, setActiveTab] = useState<'export' | 'categories' | 'settings'>('export');
   const [, setCategoriesVersion] = useState(0);
   const [customCategoryForm, setCustomCategoryForm] = useState({
     id: '',
@@ -92,6 +94,40 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
     (dateRange.start || dateRange.end ? 1 : 0) + 
     (amountRange.min || amountRange.max ? 1 : 0) +
     (selectedCurrency !== 'all' ? 1 : 0);
+
+  const filteredForExport = useMemo(() => {
+    let result = transactions
+    if (dateRange.start) {
+      const from = new Date(`${dateRange.start}T00:00:00`)
+      result = result.filter((tx) => tx.date >= from)
+    }
+    if (dateRange.end) {
+      const to = new Date(`${dateRange.end}T23:59:59.999`)
+      result = result.filter((tx) => tx.date <= to)
+    }
+    if (selectedCategories.length > 0) {
+      result = result.filter((tx) => selectedCategories.includes(tx.category ?? ''))
+    }
+    if (selectedCurrency !== 'all') {
+      result = result.filter((tx) => tx.currency === selectedCurrency)
+    }
+    if (amountRange.min) {
+      result = result.filter((tx) => tx.amount >= parseFloat(amountRange.min))
+    }
+    if (amountRange.max) {
+      result = result.filter((tx) => tx.amount <= parseFloat(amountRange.max))
+    }
+    return result
+  }, [transactions, dateRange, selectedCategories, selectedCurrency, amountRange])
+
+  function handleExport(format: 'csv' | 'pdf') {
+    exportTransactions(filteredForExport, { format })
+    toast.success(
+      format === 'csv'
+        ? `CSV exportado: ${filteredForExport.length} transacciones`
+        : 'Reporte PDF generado'
+    )
+  }
 
   const categoryDefinitions = getCategoryDefinitions();
 
@@ -196,29 +232,11 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
       {/* Header */}
       <div>
         <h2 className="mb-1">Herramientas</h2>
-        <p className="text-muted-foreground">Filtros, exportación y configuración</p>
+        <p className="text-muted-foreground">Exportación y configuración</p>
       </div>
 
       {/* Tab Navigation */}
       <div className="flex gap-2 border-b border-border overflow-x-auto">
-        <button
-          onClick={() => setActiveTab('filters')}
-          className={`px-4 py-3 border-b-2 transition-colors whitespace-nowrap ${
-            activeTab === 'filters'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          <div className="flex items-center gap-2">
-            <ListFilter size={18} />
-            <span>Filtros</span>
-            {activeFiltersCount > 0 && (
-              <Badge variant="secondary" className="ml-1">
-                {activeFiltersCount}
-              </Badge>
-            )}
-          </div>
-        </button>
         <button
           onClick={() => setActiveTab('export')}
           className={`px-4 py-3 border-b-2 transition-colors whitespace-nowrap ${
@@ -230,6 +248,11 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
           <div className="flex items-center gap-2">
             <Download size={18} />
             <span>Exportar</span>
+            {activeFiltersCount > 0 && (
+              <Badge variant="secondary" className="ml-1">
+                {activeFiltersCount}
+              </Badge>
+            )}
           </div>
         </button>
         <button
@@ -260,11 +283,11 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
         </button>
       </div>
 
-      {/* Filters Tab */}
-      {activeTab === 'filters' && (
+      {/* Export Tab */}
+      {activeTab === 'export' && (
         <div className="space-y-6">
           <div className="flex items-center justify-between">
-            <h3>Filtros Avanzados</h3>
+            <h3>Exportar Datos</h3>
             {activeFiltersCount > 0 && (
               <Button variant="ghost" size="sm" onClick={clearFilters}>
                 Limpiar todos
@@ -272,7 +295,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
             )}
           </div>
 
-          {/* Active Filters Chips */}
+          {/* Active Filter Chips */}
           {activeFiltersCount > 0 && (
             <Card className="p-4">
               <div className="flex items-center gap-2 flex-wrap">
@@ -280,7 +303,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 {selectedCategories.map(catId => (
                   <Badge key={catId} variant="secondary" className="gap-1">
                     {categories.find(c => c.id === catId)?.name}
-                    <button 
+                    <button
                       onClick={() => toggleCategory(catId)}
                       className="ml-1 hover:text-destructive"
                     >
@@ -291,7 +314,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 {(dateRange.start || dateRange.end) && (
                   <Badge variant="secondary">
                     Rango de fechas
-                    <button 
+                    <button
                       onClick={() => setDateRange({ start: '', end: '' })}
                       className="ml-1 hover:text-destructive"
                     >
@@ -302,7 +325,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 {(amountRange.min || amountRange.max) && (
                   <Badge variant="secondary">
                     Rango de monto
-                    <button 
+                    <button
                       onClick={() => setAmountRange({ min: '', max: '' })}
                       className="ml-1 hover:text-destructive"
                     >
@@ -313,7 +336,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 {selectedCurrency !== 'all' && (
                   <Badge variant="secondary">
                     {selectedCurrency}
-                    <button 
+                    <button
                       onClick={() => setSelectedCurrency('all')}
                       className="ml-1 hover:text-destructive"
                     >
@@ -345,7 +368,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
             </div>
           </Card>
 
-          {/* Date Range Filter */}
+          {/* Date Range */}
           <Card className="p-6">
             <h4 className="mb-4">Rango de Fechas</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -374,7 +397,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
             </div>
           </Card>
 
-          {/* Amount Range Filter */}
+          {/* Amount Range */}
           <Card className="p-6">
             <h4 className="mb-4">Rango de Monto</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -405,7 +428,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
             </div>
           </Card>
 
-          {/* Currency Filter */}
+          {/* Currency */}
           <Card className="p-6">
             <h4 className="mb-4">Moneda</h4>
             <div className="flex gap-3">
@@ -429,18 +452,15 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
               </Button>
             </div>
           </Card>
-        </div>
-      )}
 
-      {/* Export Tab */}
-      {activeTab === 'export' && (
-        <div className="space-y-6">
-          <h3>Exportar Datos</h3>
-
+          {/* Format & Export */}
           <Card className="p-6">
             <h4 className="mb-4">Formato de Exportación</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <button className="p-6 border-2 border-border hover:border-primary rounded-lg transition-all text-left group">
+              <button
+                onClick={() => handleExport('csv')}
+                className="p-6 border-2 border-border hover:border-primary rounded-lg transition-all text-left group"
+              >
                 <div className="flex items-center gap-3 mb-2">
                   <div className="p-2 rounded-lg bg-primary-50 dark:bg-primary-900/20 group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
                     <FileText size={24} />
@@ -455,7 +475,10 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                 </p>
               </button>
 
-              <button className="p-6 border-2 border-border hover:border-primary rounded-lg transition-all text-left group">
+              <button
+                onClick={() => handleExport('pdf')}
+                className="p-6 border-2 border-border hover:border-primary rounded-lg transition-all text-left group"
+              >
                 <div className="flex items-center gap-3 mb-2">
                   <div className="p-2 rounded-lg bg-accent-50 dark:bg-accent-900/20 group-hover:bg-accent group-hover:text-accent-foreground transition-colors">
                     <FileText size={24} />
@@ -466,54 +489,18 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
                   </div>
                 </div>
                 <p className="text-sm text-muted-foreground">
-                  Generar un reporte en PDF con resúmenes, gráficos y detalles de transacciones.
+                  Generar un reporte en PDF con resúmenes y detalles de transacciones.
                 </p>
               </button>
             </div>
           </Card>
 
-          <Card className="p-6">
-            <h4 className="mb-4">Opciones de Exportación</h4>
-            <div className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label htmlFor="tools-export-start" className="block text-sm mb-2">
-                    Fecha inicial
-                  </label>
-                  <Input id="tools-export-start" type="date" defaultValue="2024-01-01" />
-                </div>
-                <div>
-                  <label htmlFor="tools-export-end" className="block text-sm mb-2">
-                    Fecha final
-                  </label>
-                  <Input id="tools-export-end" type="date" defaultValue="2024-12-29" />
-                </div>
-              </div>
-
-              <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                <div>
-                  <p className="font-medium">Incluir gráficos</p>
-                  <p className="text-sm text-muted-foreground">Solo para PDF</p>
-                </div>
-                <Switch defaultChecked />
-              </div>
-
-              <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                <div>
-                  <p className="font-medium">Agrupar por categoría</p>
-                  <p className="text-sm text-muted-foreground">Incluir subtotales</p>
-                </div>
-                <Switch defaultChecked />
-              </div>
-            </div>
-          </Card>
-
           <div className="flex gap-3">
-            <Button className="flex-1">
+            <Button className="flex-1" onClick={() => handleExport('csv')}>
               <Download size={18} className="mr-2" />
               Exportar como CSV
             </Button>
-            <Button variant="secondary" className="flex-1">
+            <Button variant="secondary" className="flex-1" onClick={() => handleExport('pdf')}>
               <Download size={18} className="mr-2" />
               Exportar como PDF
             </Button>
@@ -521,7 +508,7 @@ export function Tools({ transactions, onResetAllData }: ToolsProps) {
 
           <Card className="p-4 bg-primary-50 dark:bg-primary-900/10 border-primary/20">
             <p className="text-sm">
-              <strong>Nota:</strong> La exportación incluirá {transactions.length} transacciones 
+              <strong>Nota:</strong> La exportación incluirá {filteredForExport.length} transacciones
               según los filtros activos. El archivo estará listo en unos segundos.
             </p>
           </Card>

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -36,9 +36,11 @@ import {
   listCustomCategories,
   syncCustomCategoryToCloud,
 } from '../services/categories/category-store'
+import type { TransactionsFilter } from '../models'
 
 interface TransactionsProps {
   transactions: Transaction[]
+  initialFilter?: TransactionsFilter
   onUpdateTransaction?: (
     transactionId: string,
     updates: {
@@ -92,6 +94,7 @@ function formatDate(date: Date): string {
 
 export function Transactions({
   transactions,
+  initialFilter,
   onUpdateTransaction,
   onDeleteTransaction,
   onAutoCategorizeTransactions,
@@ -104,6 +107,16 @@ export function Transactions({
   const [dateToFilter, setDateToFilter] = useState('')
   const [categoryFilter, setCategoryFilter] = useState('')
   const [accountFilter, setAccountFilter] = useState<'all' | 'credit_card' | 'bank_account'>('all')
+  const [currencyFilter, setCurrencyFilter] = useState<'all' | 'USD' | 'UYU'>('all')
+
+  useEffect(() => {
+    if (initialFilter) {
+      setCategoryFilter(initialFilter.category ?? '')
+      setAccountFilter(initialFilter.accountType ?? 'all')
+      setCurrencyFilter(initialFilter.currency ?? 'all')
+    }
+  }, [initialFilter])
+
   const [sortField, setSortField] = useState<SortField>('date')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
   const [currentPage, setCurrentPage] = useState(1)
@@ -174,6 +187,10 @@ export function Transactions({
         return false
       }
 
+      if (currencyFilter !== 'all' && transaction.currency !== currencyFilter) {
+        return false
+      }
+
       return true
     })
 
@@ -206,6 +223,7 @@ export function Transactions({
     dateToFilter,
     categoryFilter,
     accountFilter,
+    currencyFilter,
     sortField,
     sortDirection,
   ])
@@ -227,7 +245,8 @@ export function Transactions({
     Boolean(dateFromFilter) ||
     Boolean(dateToFilter) ||
     Boolean(categoryFilter) ||
-    accountFilter !== 'all'
+    accountFilter !== 'all' ||
+    currencyFilter !== 'all'
 
   const dateRangeError =
     dateFromFilter && dateToFilter && dateToFilter < dateFromFilter
@@ -240,6 +259,7 @@ export function Transactions({
     setDateToFilter('')
     setCategoryFilter('')
     setAccountFilter('all')
+    setCurrencyFilter('all')
   }
 
   const categorySuggestions = useMemo(() => {
@@ -612,7 +632,7 @@ export function Transactions({
             )}
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
             <div className="space-y-1">
               <label
                 htmlFor="transactions-date-from-filter"
@@ -693,6 +713,28 @@ export function Transactions({
                 <option value="all">Todas</option>
                 <option value="bank_account">Cuenta bancaria</option>
                 <option value="credit_card">Tarjeta</option>
+              </select>
+            </div>
+
+            <div className="space-y-1">
+              <label
+                htmlFor="transactions-currency-filter"
+                className="text-sm font-medium"
+              >
+                Moneda
+              </label>
+              <select
+                id="transactions-currency-filter"
+                aria-label="Filtro moneda"
+                value={currencyFilter}
+                onChange={(event) =>
+                  setCurrencyFilter(event.target.value as 'all' | 'USD' | 'UYU')
+                }
+                className="border-input bg-input-background focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm outline-none focus-visible:ring-[3px]"
+              >
+                <option value="all">Todas</option>
+                <option value="UYU">UYU ($U)</option>
+                <option value="USD">USD (US$)</option>
               </select>
             </div>
           </div>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -22,6 +22,12 @@ export type {
 } from './parsed-data'
 
 export type { ImportRun, ImportRunStatus } from './import-run'
+
+export interface TransactionsFilter {
+  category?: string
+  accountType?: 'all' | 'credit_card' | 'bank_account'
+  currency?: 'all' | 'USD' | 'UYU'
+}
 export type { CategoryOverride } from './category-override'
 export type { CustomCategoryRecord } from './custom-category'
 


### PR DESCRIPTION
## Summary

- **Cross-view drill-down navigation**: Dashboard account cards (Credit Card, USD Bank, UYU Bank) and "Top category" stat are now clickable and navigate to Transactions with filters pre-applied. Charts pie slices and category breakdown rows do the same. Implements a `TransactionsFilter` interface and `pendingTxFilter` state in App.tsx.
- **Currency filter in Transactions**: Added a 5th filter column (Moneda) to the filter row. A `useEffect` applies any `initialFilter` passed from Dashboard/Charts on navigation, and clearing filters resets currency too.
- **Tools consolidation**: Removed the orphaned "Filtros" tab. All filter controls (date range, amount, category, currency) now live in the "Exportar" tab with a live filtered transaction count. CSV/PDF export buttons are wired to the actual `exportTransactions` service.
- **Import header shortcut**: Added a persistent "Importar" button in the header (icon-only on sm–lg, icon+label on lg+), so returning users don't have to hunt for the Import nav item.

## Test plan

- [ ] All 528 tests pass, lint clean (`npm run tdd:verify`)
- [ ] Click a Dashboard account card → Transactions view loads with correct account/currency filters pre-applied
- [ ] Click a Charts pie slice or category row → Transactions view loads with that category pre-selected
- [ ] Click Transactions nav tab manually → filters are cleared (no stale filter from prior navigation)
- [ ] Tools → Exportar tab shows filter controls and live count; CSV export downloads a file
- [ ] Header Import button appears at tablet+ widths and navigates to Import view