### PR TITLE
feat: responsive mobile layout — hamburger nav + full-width content

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -200,4 +200,33 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Categorías' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Configuración' })).toBeInTheDocument()
   })
+
+  it('mobile hamburger opens nav sheet and closes on nav item click', async () => {
+    render(<App />)
+
+    const hamburger = screen.getByRole('button', { name: /abrir menú/i })
+    expect(hamburger).toBeInTheDocument()
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false')
+
+    await act(async () => {
+      fireEvent.click(hamburger)
+    })
+
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('dialog', { name: /menú de navegación/i })).toBeInTheDocument()
+
+    // clicking a nav item closes the sheet (aria-expanded goes back to false)
+    const dialogNavButtons = screen
+      .getByRole('dialog', { name: /menú de navegación/i })
+      .querySelectorAll('button')
+    const transaccionesBtn = Array.from(dialogNavButtons).find((b) =>
+      b.textContent?.includes('Transacciones')
+    )
+    await act(async () => {
+      fireEvent.click(transaccionesBtn!)
+    })
+
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('heading', { name: 'Transacciones' })).toBeInTheDocument()
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import { Toaster } from './components/ui/sonner'
 import { TatuLogo } from './components/TatuLogo'
-import { AppSidebar } from './components/AppSidebar'
+import { AppSidebar, SidebarInner } from './components/AppSidebar'
 import type { View } from './components/AppSidebar'
 import { Dashboard } from './components/Dashboard'
 import { Transactions } from './components/Transactions'
@@ -17,7 +17,13 @@ import {
   DialogTitle,
   DialogDescription,
 } from './components/ui/dialog'
-import { Sun, Moon } from 'lucide-react'
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+} from './components/ui/sheet'
+import { Sun, Moon, Menu } from 'lucide-react'
 import { useStore } from 'zustand'
 import {
   getPersistedTransactionsSnapshot,
@@ -132,6 +138,7 @@ function App() {
   })
   const [currentView, setCurrentView] = useState<View>('overview')
   const [importOpen, setImportOpen] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const toggleTheme = () => setIsDark((d) => !d)
   const [pendingTxFilter, setPendingTxFilter] = useState<import('./models').TransactionsFilter | null>(null)
   const [session, setSession] = useState<SupabaseSession | null>(() =>
@@ -1028,7 +1035,7 @@ function App() {
     <div
       style={{ display: 'flex', minHeight: '100vh', background: 'var(--bg)' }}
     >
-      {/* Sidebar */}
+      {/* Sidebar (desktop only — hidden on mobile via CSS) */}
       <AppSidebar
         view={currentView}
         onNavigate={(v) => {
@@ -1044,6 +1051,43 @@ function App() {
         supabaseEnabled={supabaseEnabled}
       />
 
+      {/* Mobile nav sheet */}
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+        <SheetContent
+          side="left"
+          style={{
+            padding: 0,
+            width: 'min(288px, 85vw)',
+            background: 'var(--surface)',
+            borderRight: '1px solid var(--border)',
+          }}
+        >
+          <SheetTitle className="sr-only">Menú de navegación</SheetTitle>
+          <SheetDescription className="sr-only">
+            Navegación principal de la aplicación
+          </SheetDescription>
+          <SidebarInner
+            view={currentView}
+            onNavigate={(v) => {
+              if (v === 'transactions') setPendingTxFilter(null)
+              setCurrentView(v)
+              setMobileMenuOpen(false)
+            }}
+            onImport={() => {
+              setImportOpen(true)
+              setMobileMenuOpen(false)
+            }}
+            onSignOut={() => {
+              void handleSignOut()
+              setMobileMenuOpen(false)
+            }}
+            session={session}
+            txCount={transactions.length}
+            supabaseEnabled={supabaseEnabled}
+          />
+        </SheetContent>
+      </Sheet>
+
       {/* Main content */}
       <main
         style={{
@@ -1052,11 +1096,51 @@ function App() {
           marginLeft: 'var(--sidebar-w, 252px)',
         }}
       >
+        {/* Mobile sticky header */}
+        <header
+          className="md:hidden sticky top-0 z-40 flex items-center gap-3"
+          style={{
+            height: 56,
+            padding: '0 16px',
+            background: 'var(--surface)',
+            borderBottom: '1px solid var(--border)',
+          }}
+        >
+          <button
+            onClick={() => setMobileMenuOpen(true)}
+            aria-label="Abrir menú"
+            aria-expanded={mobileMenuOpen}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-muted)',
+              display: 'grid',
+              placeItems: 'center',
+              padding: 8,
+              borderRadius: 8,
+              flexShrink: 0,
+            }}
+          >
+            <Menu size={20} />
+          </button>
+          <span
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: 20,
+              fontWeight: 600,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Tatú
+          </span>
+        </header>
+
         <div
+          className="px-4 pt-5 pb-20 md:px-11 md:pt-10"
           style={{
             maxWidth: 1180,
             margin: '0 auto',
-            padding: '40px 44px 80px',
           }}
         >
           {authError && (

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -31,7 +31,11 @@ interface AppSidebarProps {
   supabaseEnabled: boolean
 }
 
-function BrandMark() {
+interface SidebarInnerProps extends AppSidebarProps {
+  onClose?: () => void
+}
+
+export function BrandMark() {
   return (
     <span
       style={{
@@ -72,7 +76,7 @@ function BrandMark() {
   )
 }
 
-export function AppSidebar({
+export function SidebarInner({
   view,
   onNavigate,
   onImport,
@@ -80,7 +84,8 @@ export function AppSidebar({
   session,
   txCount,
   supabaseEnabled,
-}: AppSidebarProps) {
+  onClose,
+}: SidebarInnerProps) {
   const groups: NavGroup[] = [
     {
       label: 'General',
@@ -109,17 +114,13 @@ export function AppSidebar({
   const avatarInitial = userName.charAt(0).toUpperCase()
 
   return (
-    <aside
+    <div
       style={{
-        position: 'fixed',
-        inset: '0 auto 0 0',
-        width: 'var(--sidebar-w, 252px)',
-        background: 'var(--surface)',
-        borderRight: '1px solid var(--border)',
         display: 'flex',
         flexDirection: 'column',
+        height: '100%',
         padding: '22px 16px 18px',
-        zIndex: 40,
+        overflowY: 'auto',
       }}
     >
       {/* Brand row */}
@@ -160,7 +161,10 @@ export function AppSidebar({
 
       {/* Import button */}
       <button
-        onClick={onImport}
+        onClick={() => {
+          onImport()
+          onClose?.()
+        }}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -226,7 +230,10 @@ export function AppSidebar({
             return (
               <button
                 key={item.id}
-                onClick={() => onNavigate(item.id)}
+                onClick={() => {
+                  onNavigate(item.id)
+                  onClose?.()
+                }}
                 aria-current={isActive ? 'page' : undefined}
                 style={{
                   display: 'flex',
@@ -394,6 +401,24 @@ export function AppSidebar({
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+export function AppSidebar(props: AppSidebarProps) {
+  return (
+    <aside
+      className="hidden md:block"
+      style={{
+        position: 'fixed',
+        inset: '0 auto 0 0',
+        width: 'var(--sidebar-w, 252px)',
+        background: 'var(--surface)',
+        borderRight: '1px solid var(--border)',
+        zIndex: 40,
+      }}
+    >
+      <SidebarInner {...props} />
     </aside>
   )
 }

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -326,13 +326,7 @@ export function Categories({ transactions }: CategoriesProps) {
           Tus categorías
         </h3>
 
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(3, 1fr)',
-            gap: 10,
-          }}
-        >
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5">
           {categoryDefinitions.map((cat) => {
             const count = getCategoryTransactionCount(transactions, cat.id)
             return (
@@ -460,14 +454,14 @@ export function Categories({ transactions }: CategoriesProps) {
         {/* Add pattern form */}
         <div
           style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr auto auto auto',
+            display: 'flex',
+            flexWrap: 'wrap',
             gap: 10,
             marginBottom: 16,
             alignItems: 'flex-end',
           }}
         >
-          <div>
+          <div style={{ flex: '1 1 auto', minWidth: 160 }}>
             <label
               htmlFor="pattern-text"
               style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -527,7 +527,7 @@ export function Dashboard({
                 </button>
               )}
             </div>
-            <div className="grid grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
               <div>
                 <div
                   className="text-muted-foreground"

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -636,8 +636,8 @@ export function Transactions({
 
       <Card className="p-4 space-y-3">
         {/* Row 1: Search + Category + Account */}
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <div className="relative flex-1">
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <div className="relative w-full sm:flex-1">
             <Search
               className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
               size={16}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -192,6 +192,12 @@
   --font-size: 15px;
 }
 
+@media (max-width: 767px) {
+  :root {
+    --sidebar-w: 0px;
+  }
+}
+
 .dark {
   /* ── Dark mode prototype tokens (warm espresso charcoal) ─────── */
   --bg:            oklch(0.162 0.008 65);


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `--sidebar-w` zeroed via `@media (max-width: 767px)` so `marginLeft` on main content becomes 0 on mobile; sidebar hidden with `hidden md:block`
- **Mobile nav**: sticky header with hamburger button opens a `Sheet` drawer containing the same `SidebarInner` used by the desktop aside — no duplication
- **Dashboard** "Este mes" panel: `grid-cols-3` → `grid-cols-1 sm:grid-cols-3`
- **Transactions** filter row 1: wraps on narrow screens (search full-width, selects on row 2)
- **Categories** grid: 3-col → 2-col on mobile; pattern form changed from rigid grid to flex-wrap
- **Test**: hamburger opens nav sheet, nav item click closes it and navigates (539 tests passing)

## Test plan

- [ ] Mobile 390px: no horizontal scroll on any of the 5 views
- [ ] Hamburger opens nav sheet with full nav tree + Import button
- [ ] Tapping a nav item closes the sheet and navigates
- [ ] Desktop 1280px: sidebar unchanged, no regressions
- [ ] `npm run ci:check` passes (539 tests, lint, build)