### PR TITLE
fix: normalize category icons across all surfaces + fix transfer override

### DIFF
--- a/src/App.supabase.test.tsx
+++ b/src/App.supabase.test.tsx
@@ -379,6 +379,7 @@ describe('App with supabase enabled', () => {
         {
           displayDescription: 'New merchant',
           category: 'services',
+          categoryConfidence: 1,
           tags: ['monthly', 'fixed'],
         }
       )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -582,6 +582,7 @@ function App() {
             matchingTransactions.map((tx) =>
               updateRemoteTransaction(session, tx.id, {
                 category: nextCategory,
+                ...(nextCategory !== undefined && { categoryConfidence: 1 }),
                 displayDescription: undefined,
               })
             )
@@ -661,6 +662,7 @@ function App() {
                 ? trimmedDisplayDescription
                 : undefined,
             category: nextCategory,
+            ...(nextCategory !== undefined && { categoryConfidence: 1 }),
             tags: nextTags,
           })
         }
@@ -697,6 +699,7 @@ function App() {
         await updateRemoteTransaction(session, transactionId, {
           displayDescription: singleDisplayDescription,
           category: nextCategory,
+          ...(nextCategory !== undefined && { categoryConfidence: 1 }),
           tags: nextTags,
         })
       }
@@ -751,7 +754,7 @@ function App() {
       if (supabaseEnabled && session) {
         await Promise.all(
           transactionIds.map((id) =>
-            updateRemoteTransaction(session, id, { category })
+            updateRemoteTransaction(session, id, { category, categoryConfidence: 1 })
           )
         )
       }
@@ -761,7 +764,7 @@ function App() {
           if (!targetIds.has(transaction.id)) {
             return transaction
           }
-          return { ...transaction, category }
+          return { ...transaction, category, categoryConfidence: 1 }
         })
       )
       setAuthError('')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -602,7 +602,9 @@ function App() {
               return tx
             }
 
-            const categoryUpdates = nextCategory ? { category: nextCategory } : {}
+            const categoryUpdates = nextCategory
+              ? { category: nextCategory, categoryConfidence: 1 as const }
+              : {}
             const tagsUpdates =
               tx.id === transactionId && nextTags !== undefined
                 ? { tags: nextTags }
@@ -670,6 +672,7 @@ function App() {
               ? trimmedDisplayDescription
               : undefined,
           category: nextCategory,
+          ...(nextCategory !== undefined && { categoryConfidence: 1 }),
           tags: nextTags,
         })
         setAuthError('')
@@ -701,6 +704,7 @@ function App() {
       state.updateTransaction(transactionId, {
         displayDescription: singleDisplayDescription,
         category: nextCategory,
+        ...(nextCategory !== undefined && { categoryConfidence: 1 }),
         tags: nextTags,
       })
       setAuthError('')

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -531,7 +531,7 @@ export function Categories({ transactions }: CategoriesProps) {
               }}
             >
               {getCategoryDefinitions()
-                .filter((c) => c.id !== Category.Uncategorized && !c.isIgnored)
+                .filter((c) => c.id !== Category.Uncategorized)
                 .map((cat) => (
                   <option key={cat.id} value={cat.id}>
                     {cat.icon} {cat.label}

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -20,7 +20,6 @@ import {
   removeCustomPattern,
   type MatchType,
 } from '../services/categorizer/custom-patterns'
-import { CATEGORY_LABELS, CATEGORY_ICONS } from '../models/category'
 
 interface CategoriesProps {
   transactions: Transaction[]
@@ -531,11 +530,11 @@ export function Categories({ transactions }: CategoriesProps) {
                 height: 40,
               }}
             >
-              {Object.values(Category)
-                .filter((c) => c !== Category.Uncategorized)
+              {getCategoryDefinitions()
+                .filter((c) => c.id !== Category.Uncategorized && !c.isIgnored)
                 .map((cat) => (
-                  <option key={cat} value={cat}>
-                    {CATEGORY_ICONS[cat]} {CATEGORY_LABELS[cat]}
+                  <option key={cat.id} value={cat.id}>
+                    {cat.icon} {cat.label}
                   </option>
                 ))}
             </select>

--- a/src/components/CategoryBadge.test.tsx
+++ b/src/components/CategoryBadge.test.tsx
@@ -25,7 +25,7 @@ describe('CategoryBadge', () => {
   it('falls back to uncategorized label for unknown categories', () => {
     render(<CategoryBadge categoryId="unknown-category" />);
 
-    expect(screen.getByText('Unknown category')).toBeInTheDocument();
+    expect(screen.getByText('Sin categoría')).toBeInTheDocument();
   });
 
   it('renders all built-in categories with a label', () => {

--- a/src/components/CategoryBadge.tsx
+++ b/src/components/CategoryBadge.tsx
@@ -1,24 +1,3 @@
-// Category Badge with icon for Tatu
-
-import {
-  Utensils,
-  Car,
-  Zap,
-  Tv,
-  ShoppingBag,
-  Heart,
-  GraduationCap,
-  Laptop,
-  Home,
-  UserRound,
-  Shield,
-  ArrowLeftRight,
-  Receipt,
-  TrendingUp,
-  Ellipsis,
-  EyeOff,
-} from 'lucide-react';
-import { getCategoryDisplay } from '../utils/category-display';
 import { getCategoryDefinition } from '../services/categories/category-registry';
 
 interface CategoryBadgeProps {
@@ -27,57 +6,26 @@ interface CategoryBadgeProps {
   size?: 'sm' | 'md';
 }
 
-const iconMap = {
-  groceries: Utensils,
-  restaurants: Utensils,
-  transport: Car,
-  transfer: ArrowLeftRight,
-  utilities: Zap,
-  entertainment: Tv,
-  shopping: ShoppingBag,
-  healthcare: Heart,
-  education: GraduationCap,
-  software: Laptop,
-  automotive: Car,
-  housing: Home,
-  personal: UserRound,
-  insurance: Shield,
-  fees: Receipt,
-  ignored: EyeOff,
-  uncategorized: Ellipsis,
-  income: TrendingUp,
-};
-
 export function CategoryBadge({ categoryId, showIcon = true, size = 'md' }: CategoryBadgeProps) {
-  const category = getCategoryDisplay(categoryId);
-  const categoryDefinition = getCategoryDefinition(categoryId);
+  const definition = getCategoryDefinition(categoryId);
 
-  const Icon = iconMap[category.icon];
-  const iconSize = size === 'sm' ? 12 : 14;
   const padding = size === 'sm' ? 'px-2 py-0.5' : 'px-2.5 py-1';
   const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
-  const useDefinition = categoryDefinition.isCustom || categoryDefinition.isOverridden;
-  const label = useDefinition ? categoryDefinition.label : category.label;
-  const color = useDefinition ? categoryDefinition.color : category.color;
-  const customIcon = categoryDefinition.isCustom ? categoryDefinition.icon : null;
 
   return (
     <span
       className={`inline-flex items-center gap-1.5 ${padding} ${textSize} rounded-full font-medium transition-colors`}
       style={{
-        backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)`,
-        color,
+        backgroundColor: `color-mix(in srgb, ${definition.color} 15%, transparent)`,
+        color: definition.color,
       }}
     >
-      {showIcon &&
-        (customIcon ? (
-          <span aria-hidden="true" className="leading-none">
-            {customIcon}
-          </span>
-        ) : (
-          Icon && <Icon size={iconSize} />
-        ))}
-      <span>{label}</span>
+      {showIcon && definition.icon && (
+        <span aria-hidden="true" className="leading-none">
+          {definition.icon}
+        </span>
+      )}
+      <span>{definition.label}</span>
     </span>
   );
 }

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -18,6 +18,15 @@ export interface CategoryDefinition {
 
 const DEFAULT_CUSTOM_ICON = '🏷️'
 
+const ID_ALIASES: Partial<Record<string, Category>> = {
+  food: Category.Groceries,
+  restaurant: Category.Restaurants,
+  restaurants: Category.Restaurants,
+  health: Category.Healthcare,
+  salary: Category.Income,
+  other: Category.Uncategorized,
+}
+
 export function getCategoryDefinitions(): CategoryDefinition[] {
   const customList = listCustomCategories()
   const builtinIds = new Set(Object.values(Category) as string[])
@@ -65,8 +74,11 @@ export function getCategoryDefinition(
     return fallback
   }
 
-  if (Object.values(Category).includes(id as Category)) {
-    const category = id as Category
+  const normalizedId = id.toLowerCase()
+  const resolvedId = ID_ALIASES[normalizedId] ?? normalizedId
+
+  if (Object.values(Category).includes(resolvedId as Category)) {
+    const category = resolvedId as Category
     const override = listCustomCategories().find((c) => c.id === id)
     return {
       id: category,
@@ -78,7 +90,7 @@ export function getCategoryDefinition(
     }
   }
 
-  const custom = listCustomCategories().find((category) => category.id === id)
+  const custom = listCustomCategories().find((category) => category.id === resolvedId)
   if (!custom) {
     return fallback
   }

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -79,7 +79,7 @@ export function getCategoryDefinition(
 
   if (Object.values(Category).includes(resolvedId as Category)) {
     const category = resolvedId as Category
-    const override = listCustomCategories().find((c) => c.id === id)
+    const override = listCustomCategories().find((c) => c.id === resolvedId)
     return {
       id: category,
       label: override?.label ?? CATEGORY_LABELS[category],

--- a/src/utils/category-display.ts
+++ b/src/utils/category-display.ts
@@ -1,5 +1,4 @@
 import { Category, CATEGORY_COLORS, CATEGORY_LABELS } from '../models';
-import { categories as legacyCategories } from './figma-data';
 
 export type CategoryIconName =
   | 'groceries'
@@ -146,16 +145,6 @@ export function getCategoryDisplay(categoryId?: string | null): CategoryDisplay 
       label: CATEGORY_LABELS[modernId],
       color: meta.color,
       icon: meta.icon,
-    };
-  }
-
-  const legacy = legacyCategories.find((category) => category.id === normalizedId);
-  if (legacy) {
-    return {
-      id: legacy.id,
-      label: legacy.name,
-      color: legacy.color,
-      icon: ID_ALIASES[legacy.id] ? MODERN_META[ID_ALIASES[legacy.id]].icon : 'uncategorized',
     };
   }
 


### PR DESCRIPTION
## Summary

- **Icon inconsistency**: `CategoryBadge` was using a hardcoded Lucide `iconMap` while the "Tus categorías" grid, description tile, and rules dropdown all used emoji from `CATEGORY_ICONS` — same category looked different within the same table row. Badge now uses `getCategoryDefinition().icon` (emoji) uniformly.
- **Rules dropdown missing custom categories**: Auto-categorization rules `<select>` iterated `Object.values(Category)`, excluding any user-created custom categories. Now uses `getCategoryDefinitions()`.
- **Legacy figma-data fallback removed**: `getCategoryDisplay()` had a dead fallback to `figma-data.ts` categories with CSS variable colors that didn't match the live system. Removed; legacy IDs like `food` are already covered by `ID_ALIASES`.
- **ID_ALIASES added to `getCategoryDefinition()`**: So legacy category IDs (`food`, `health`, `other`) resolve correctly through the registry without going through the old display path.
- **Transfer category override ignored**: Editing a transfer transaction's category had no effect — `updateTransaction` always re-runs `inferInternalTransfers`, which would immediately re-assign it back to Transfer. Fixed by setting `categoryConfidence: 1` on explicit user edits to lock the choice.

## Test plan

- [ ] Transaction table: category badge column and description emoji tile show the same icon for the same category
- [ ] "Tus categorías" grid icons match what's shown in transaction badges
- [ ] Auto-categorization rules dropdown includes custom user categories
- [ ] Editing a transfer transaction's category to something else (e.g. Compras) sticks after saving
- [ ] `npm run tdd:verify` passes (539 tests, 0 lint warnings)