### PR TITLE
feat: design fidelity, auto theme, and category selector fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tatu - Expense Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from './components/ui/sheet'
-import { Sun, Moon, Menu } from 'lucide-react'
+import { Sun, Moon, Menu, Monitor } from 'lucide-react'
 import { useStore } from 'zustand'
 import {
   getPersistedTransactionsSnapshot,
@@ -132,14 +132,26 @@ function App() {
   const supabaseEnabled = isSupabaseConfigured()
 
   // Initialize theme from localStorage
-  const [isDark, setIsDark] = useState(() => {
+  const [theme, setTheme] = useState<'light' | 'dark' | 'auto'>(() => {
     const saved = localStorage.getItem('theme')
-    return saved === 'dark'
+    if (saved === 'light' || saved === 'dark' || saved === 'auto') return saved
+    return 'auto'
   })
+  const [systemDark, setSystemDark] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  )
+  const isDark = theme === 'dark' || (theme === 'auto' && systemDark)
   const [currentView, setCurrentView] = useState<View>('overview')
   const [importOpen, setImportOpen] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const toggleTheme = () => setIsDark((d) => !d)
+  const cycleTheme = () =>
+    setTheme((t) => (t === 'light' ? 'dark' : t === 'dark' ? 'auto' : 'light'))
+  const [preferredCurrency, setPreferredCurrencyState] = useState<
+    'UYU' | 'USD'
+  >(() => {
+    const saved = localStorage.getItem('tatu:preferences:currency')
+    return saved === 'USD' ? 'USD' : 'UYU'
+  })
   const [pendingTxFilter, setPendingTxFilter] = useState<import('./models').TransactionsFilter | null>(null)
   const [session, setSession] = useState<SupabaseSession | null>(() =>
     supabaseEnabled ? getCurrentSession() : null
@@ -156,16 +168,28 @@ function App() {
   // Get transactions from store
   const transactions = useStore(transactionStore, (state) => state.transactions)
 
-  // Handle theme toggle and persist to localStorage
+  // Listen for system color-scheme changes (used when theme === 'auto')
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  // Apply dark class and persist theme preference
   useEffect(() => {
     if (isDark) {
       document.documentElement.classList.add('dark')
-      localStorage.setItem('theme', 'dark')
     } else {
       document.documentElement.classList.remove('dark')
-      localStorage.setItem('theme', 'light')
     }
-  }, [isDark])
+    localStorage.setItem('theme', theme)
+  }, [isDark, theme])
+
+  function setPreferredCurrency(c: 'UYU' | 'USD') {
+    setPreferredCurrencyState(c)
+    localStorage.setItem('tatu:preferences:currency', c)
+  }
 
   useEffect(() => {
     setActiveSupabaseSession(session)
@@ -1176,6 +1200,7 @@ function App() {
                 onNavigateToImport={() => setImportOpen(true)}
                 onNavigateToTransactions={navigateToTransactions}
                 onNavigateToAnalysis={() => setCurrentView('analysis')}
+                defaultCurrency={preferredCurrency}
               />
             )}
             {currentView === 'transactions' && (
@@ -1201,8 +1226,10 @@ function App() {
             )}
             {currentView === 'settings' && (
               <Settings
-                isDark={isDark}
-                onToggleTheme={toggleTheme}
+                theme={theme}
+                onSetTheme={setTheme}
+                preferredCurrency={preferredCurrency}
+                onSetCurrency={setPreferredCurrency}
                 session={session}
                 supabaseEnabled={supabaseEnabled}
                 onSignOut={() => {
@@ -1247,8 +1274,14 @@ function App() {
 
       {/* Floating theme toggle */}
       <button
-        onClick={toggleTheme}
-        aria-label={isDark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'}
+        onClick={cycleTheme}
+        aria-label={
+          theme === 'auto'
+            ? 'Tema automático (según sistema)'
+            : isDark
+              ? 'Cambiar a modo claro'
+              : 'Cambiar a modo oscuro'
+        }
         style={{
           position: 'fixed',
           bottom: 22,
@@ -1278,7 +1311,13 @@ function App() {
             'var(--text-muted)'
         }}
       >
-        {isDark ? <Sun size={18} /> : <Moon size={18} />}
+        {theme === 'auto' ? (
+          <Monitor size={18} />
+        ) : isDark ? (
+          <Sun size={18} />
+        ) : (
+          <Moon size={18} />
+        )}
       </button>
 
       <Toaster />

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -8,8 +8,8 @@ import {
   PieChart,
   Pie,
   Cell,
-  BarChart,
-  Bar,
+  AreaChart,
+  Area,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -549,11 +549,21 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
           </div>
         </div>
         <ResponsiveContainer width="100%" height={280}>
-          <BarChart
+          <AreaChart
             data={monthlyTrend}
-            margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+            margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
           >
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+            <defs>
+              <linearGradient id="gradIngresos" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--pos)" stopOpacity={0.22} />
+                <stop offset="95%" stopColor="var(--pos)" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="gradGastos" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--neg)" stopOpacity={0.2} />
+                <stop offset="95%" stopColor="var(--neg)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="2 4" stroke="var(--border)" vertical={false} />
             <XAxis
               dataKey="month"
               stroke="var(--text-faint)"
@@ -579,21 +589,27 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
                 formatAmt(Number(value), currency)
               }
             />
-            <Bar
+            <Area
+              type="monotone"
               dataKey="ingresos"
-              fill="var(--pos)"
+              stroke="var(--pos)"
+              strokeWidth={2.5}
+              fill="url(#gradIngresos)"
               name="Ingresos"
-              radius={[6, 6, 0, 0]}
-              opacity={0.85}
+              dot={false}
+              activeDot={{ r: 4, fill: 'var(--pos)' }}
             />
-            <Bar
+            <Area
+              type="monotone"
               dataKey="gastos"
-              fill="var(--neg)"
+              stroke="var(--neg)"
+              strokeWidth={2.5}
+              fill="url(#gradGastos)"
               name="Gastos"
-              radius={[6, 6, 0, 0]}
-              opacity={0.85}
+              dot={false}
+              activeDot={{ r: 4, fill: 'var(--neg)' }}
             />
-          </BarChart>
+          </AreaChart>
         </ResponsiveContainer>
       </Card>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -13,10 +13,35 @@ import type { Transaction, Currency, TransactionsFilter } from '../models'
 import { useMemo, useState } from 'react'
 import { getCategoryDisplay } from '../utils/category-display'
 import { isTransferCategory } from '../services/transfers/internal-transfers'
-import { isCategoryIgnored } from '../services/categories/category-registry'
+import {
+  isCategoryIgnored,
+  getCategoryDefinition,
+} from '../services/categories/category-registry'
 
 function toSafeNumber(value: number): number {
   return Number.isFinite(value) ? value : 0
+}
+
+function MiniBars({ values, color }: { values: number[]; color: string }) {
+  const max = Math.max(...values, 1)
+  const bars = values.slice(-6)
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, height: 24 }}>
+      {bars.map((v, i) => (
+        <div
+          key={i}
+          style={{
+            flex: 1,
+            height: `${Math.round((v / max) * 100)}%`,
+            minHeight: 3,
+            background: color,
+            borderRadius: 2,
+            opacity: i === bars.length - 1 ? 1 : 0.35,
+          }}
+        />
+      ))}
+    </div>
+  )
 }
 
 function formatCurrency(amount: number, currency: Currency): string {
@@ -56,6 +81,7 @@ interface DashboardProps {
   onNavigateToImport?: () => void
   onNavigateToTransactions?: (filter: TransactionsFilter) => void
   onNavigateToAnalysis?: () => void
+  defaultCurrency?: Currency
 }
 
 type CurrencyFilter = Currency | 'all'
@@ -66,8 +92,11 @@ export function Dashboard({
   onNavigateToImport,
   onNavigateToTransactions,
   onNavigateToAnalysis,
+  defaultCurrency,
 }: DashboardProps) {
-  const [selectedCurrency, setSelectedCurrency] = useState<CurrencyFilter>('all')
+  const [selectedCurrency, setSelectedCurrency] = useState<CurrencyFilter>(
+    defaultCurrency ?? 'all'
+  )
 
   const hasTransactions = transactions.length > 0
 
@@ -181,6 +210,28 @@ export function Dashboard({
         .slice(0, 6),
     [transactions],
   )
+
+  const uyuMonthlyTrend = useMemo(() => {
+    const grouped = new Map<string, { income: number; expense: number }>()
+    transactions
+      .filter(
+        (tx) =>
+          tx.currency === 'UYU' &&
+          !isTransferCategory(tx.category) &&
+          !isCategoryIgnored(tx.category),
+      )
+      .forEach((tx) => {
+        const key = `${tx.date.getFullYear()}-${String(tx.date.getMonth() + 1).padStart(2, '0')}`
+        if (!grouped.has(key)) grouped.set(key, { income: 0, expense: 0 })
+        const entry = grouped.get(key)!
+        if (tx.type === 'credit') entry.income += toSafeNumber(tx.amount)
+        else entry.expense += toSafeNumber(tx.amount)
+      })
+    return Array.from(grouped.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, v]) => v)
+      .slice(-6)
+  }, [transactions])
 
   const firstName = userName ? userName.split('@')[0] : null
   const greeting = firstName ? `Hola, ${firstName} 👋` : 'Hola 👋'
@@ -549,6 +600,14 @@ export function Dashboard({
                     {formatCurrency(thisMonthSummaryUSD.income, 'USD')}
                   </div>
                 )}
+                {uyuMonthlyTrend.length > 1 && selectedCurrency !== 'USD' && (
+                  <div style={{ marginTop: 12 }}>
+                    <MiniBars
+                      values={uyuMonthlyTrend.map((m) => m.income)}
+                      color="var(--pos)"
+                    />
+                  </div>
+                )}
               </div>
               <div>
                 <div
@@ -572,6 +631,14 @@ export function Dashboard({
                       {formatCurrency(thisMonthSummaryUSD.expenses, 'USD')}
                     </div>
                   )}
+                {uyuMonthlyTrend.length > 1 && selectedCurrency !== 'USD' && (
+                  <div style={{ marginTop: 12 }}>
+                    <MiniBars
+                      values={uyuMonthlyTrend.map((m) => m.expense)}
+                      color="var(--neg)"
+                    />
+                  </div>
+                )}
               </div>
               <div>
                 <div
@@ -742,7 +809,9 @@ export function Dashboard({
               </div>
               <div style={{ display: 'flex', flexDirection: 'column' }}>
                 {recentTransactions.map((tx, i) => {
-                  const display = getCategoryDisplay(tx.category ?? 'uncategorized')
+                  const catDef = getCategoryDefinition(
+                    tx.category ?? 'uncategorized',
+                  )
                   const isCredit = tx.type === 'credit'
                   return (
                     <div
@@ -763,21 +832,14 @@ export function Dashboard({
                           width: 32,
                           height: 32,
                           borderRadius: 9,
-                          background: display.color + '1f',
+                          background: catDef.color + '1f',
                           display: 'grid',
                           placeItems: 'center',
                           flexShrink: 0,
+                          fontSize: 15,
                         }}
                       >
-                        <span
-                          style={{
-                            width: 10,
-                            height: 10,
-                            borderRadius: '50%',
-                            background: display.color,
-                            display: 'block',
-                          }}
-                        />
+                        {catDef.icon}
                       </span>
                       <div style={{ minWidth: 0, flex: 1 }}>
                         <div

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -32,11 +32,13 @@ describe('Settings', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders the page heading and Apariencia section', () => {
+  it('renders the page heading and Apariencia section with all theme options', () => {
     render(
       <Settings
-        isDark={false}
-        onToggleTheme={() => {}}
+        theme="light"
+        onSetTheme={() => {}}
+        preferredCurrency="UYU"
+        onSetCurrency={() => {}}
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
@@ -49,15 +51,18 @@ describe('Settings', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('Apariencia')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Claro' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Auto' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Oscuro' })).toBeInTheDocument()
   })
 
-  it('calls onToggleTheme when clicking the opposite theme button', () => {
-    const onToggle = vi.fn()
+  it('calls onSetTheme with the selected value when clicking a theme button', () => {
+    const onSetTheme = vi.fn()
     render(
       <Settings
-        isDark={false}
-        onToggleTheme={onToggle}
+        theme="light"
+        onSetTheme={onSetTheme}
+        preferredCurrency="UYU"
+        onSetCurrency={() => {}}
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
@@ -66,14 +71,38 @@ describe('Settings', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Oscuro' }))
-    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onSetTheme).toHaveBeenCalledWith('dark')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auto' }))
+    expect(onSetTheme).toHaveBeenCalledWith('auto')
+  })
+
+  it('calls onSetCurrency when clicking a currency button', () => {
+    const onSetCurrency = vi.fn()
+    render(
+      <Settings
+        theme="light"
+        onSetTheme={() => {}}
+        preferredCurrency="UYU"
+        onSetCurrency={onSetCurrency}
+        session={null}
+        supabaseEnabled={false}
+        onSignOut={() => {}}
+        transactions={[]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dólares' }))
+    expect(onSetCurrency).toHaveBeenCalledWith('USD')
   })
 
   it('shows Conectado badge and sign-out button when session is active', () => {
     render(
       <Settings
-        isDark={false}
-        onToggleTheme={() => {}}
+        theme="light"
+        onSetTheme={() => {}}
+        preferredCurrency="UYU"
+        onSetCurrency={() => {}}
         session={mockSession}
         supabaseEnabled={true}
         onSignOut={() => {}}
@@ -89,8 +118,10 @@ describe('Settings', () => {
     const onSignOut = vi.fn()
     render(
       <Settings
-        isDark={false}
-        onToggleTheme={() => {}}
+        theme="light"
+        onSetTheme={() => {}}
+        preferredCurrency="UYU"
+        onSetCurrency={() => {}}
         session={mockSession}
         supabaseEnabled={true}
         onSignOut={onSignOut}
@@ -105,8 +136,10 @@ describe('Settings', () => {
   it('shows the correct privacy copy', () => {
     render(
       <Settings
-        isDark={false}
-        onToggleTheme={() => {}}
+        theme="light"
+        onSetTheme={() => {}}
+        preferredCurrency="UYU"
+        onSetCurrency={() => {}}
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
@@ -128,8 +161,10 @@ describe('Settings', () => {
 
     render(
       <Settings
-        isDark={false}
-        onToggleTheme={() => {}}
+        theme="light"
+        onSetTheme={() => {}}
+        preferredCurrency="UYU"
+        onSetCurrency={() => {}}
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,8 +6,10 @@ import type { SupabaseSession } from '../services/supabase/client'
 import { exportTransactions } from '../services/export/export'
 
 interface SettingsProps {
-  isDark: boolean
-  onToggleTheme: () => void
+  theme: 'light' | 'dark' | 'auto'
+  onSetTheme: (t: 'light' | 'dark' | 'auto') => void
+  preferredCurrency: 'UYU' | 'USD'
+  onSetCurrency: (c: 'UYU' | 'USD') => void
   session: SupabaseSession | null
   supabaseEnabled: boolean
   onSignOut: () => void
@@ -135,8 +137,10 @@ function SettingRow({
 }
 
 export function Settings({
-  isDark,
-  onToggleTheme,
+  theme,
+  onSetTheme,
+  preferredCurrency,
+  onSetCurrency,
   session,
   supabaseEnabled,
   onSignOut,
@@ -194,12 +198,11 @@ export function Settings({
             <SegmentControl
               options={[
                 { label: 'Claro', value: 'light' },
+                { label: 'Auto', value: 'auto' },
                 { label: 'Oscuro', value: 'dark' },
               ]}
-              value={isDark ? 'dark' : 'light'}
-              onChange={(v) => {
-                if ((v === 'dark') !== isDark) onToggleTheme()
-              }}
+              value={theme}
+              onChange={(v) => onSetTheme(v as 'light' | 'dark' | 'auto')}
             />
           }
         />
@@ -225,8 +228,8 @@ export function Settings({
               { label: 'Pesos', value: 'UYU' },
               { label: 'Dólares', value: 'USD' },
             ]}
-            value="UYU"
-            onChange={() => {}}
+            value={preferredCurrency}
+            onChange={(v) => onSetCurrency(v as 'UYU' | 'USD')}
           />
         </div>
       </SectionCard>

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -287,7 +287,6 @@ export function Transactions({
         [
           ...Object.values(Category),
           ...listCustomCategories().map((c) => c.id),
-          ...transactions.map((tx) => tx.category ?? ''),
           editCategory,
         ]
           .map((value) => value.trim())
@@ -296,15 +295,16 @@ export function Transactions({
     ).sort((a, b) =>
       getCategoryDisplay(a).label.localeCompare(getCategoryDisplay(b).label, 'es')
     )
-  }, [transactions, editCategory])
+  }, [editCategory])
 
   const filteredCategorySuggestions = useMemo(() => {
     const query = newCategoryInput.trim().toLowerCase()
-    if (!query) {
-      return categorySuggestions
-    }
+    const base = categorySuggestions.filter(
+      (c) => c !== Category.Uncategorized
+    )
+    if (!query) return base
 
-    return categorySuggestions.filter((category) => {
+    return base.filter((category) => {
       const label = getCategoryDisplay(category).label.toLowerCase()
       return category.toLowerCase().includes(query) || label.includes(query)
     })

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -46,8 +46,14 @@ export function getCategoryDefinitions(): CategoryDefinition[] {
     }
   })
 
+  const seenCustomIds = new Set<string>()
   const custom = customList
-    .filter((c) => !builtinIds.has(c.id))
+    .filter((c) => {
+      if (builtinIds.has(c.id)) return false
+      if (seenCustomIds.has(c.id)) return false
+      seenCustomIds.add(c.id)
+      return true
+    })
     .map((c) => ({
       id: c.id,
       label: c.label,
@@ -57,7 +63,11 @@ export function getCategoryDefinitions(): CategoryDefinition[] {
       isIgnored: c.isIgnored ?? false,
     }))
 
-  return [...builtin, ...custom]
+  return [...builtin, ...custom].sort((a, b) => {
+    if (a.id === Category.Uncategorized) return 1
+    if (b.id === Category.Uncategorized) return -1
+    return a.label.localeCompare(b.label, 'es')
+  })
 }
 
 export function getCategoryDefinition(

--- a/src/services/categories/category-store.ts
+++ b/src/services/categories/category-store.ts
@@ -33,7 +33,12 @@ export function listCustomCategories(): CustomCategory[] {
 }
 
 export function replaceCustomCategories(categories: CustomCategory[]): void {
-  _customCategories = categories
+  const seen = new Set<string>()
+  _customCategories = categories.filter((c) => {
+    if (seen.has(c.id)) return false
+    seen.add(c.id)
+    return true
+  })
 }
 
 export function addCustomCategory(input: {


### PR DESCRIPTION
## Summary

- **Fonts**: Add `<link rel="preconnect">` + Google Fonts stylesheet to `index.html` so Spectral, Hanken Grotesk, and JetBrains Mono load before paint rather than via deferred CSS `@import`
- **Análisis chart**: Replace `BarChart` with `AreaChart` — soft gradient fills (0.22/0.2 opacity), 2.5px stroke lines, dotted gridlines — matching the design spec
- **Dashboard**: Recent transactions now show category emoji tiles (🛒, 🍽️, etc.) instead of a colored dot; "Este mes" panel gets `MiniBars` sparklines below Ingresos/Gastos when 2+ months of UYU data exist
- **Theme**: Add `auto` mode that tracks the system `prefers-color-scheme`; theme cycles light → dark → auto; persists to localStorage
- **Settings**: Preferred currency (UYU/USD) is now wired through the Settings UI and persisted
- **Category selector**: Remove transaction category values as a suggestion source — stale/obsolete IDs from old transactions were appearing as phantom duplicates in the inline category editor
- **Category dedup**: Defensive dedup-by-id guards in `getCategoryDefinitions()` and `replaceCustomCategories()` to prevent same-id entries from rendering twice

## Test plan

- [ ] Fonts render correctly (Spectral for headings, Hanken Grotesk for body, JetBrains Mono for amounts)
- [ ] Análisis → "Ingresos vs Gastos" shows area chart with gradient fills, not bar chart
- [ ] Dashboard recent transactions show emoji icons (e.g. 🛒 for Alimentación)
- [ ] Dashboard "Este mes" panel shows mini sparkline bars under Ingresos and Gastos (requires 2+ months of data)
- [ ] Settings → Theme segment now has Claro / Auto / Oscuro; Auto follows system preference
- [ ] Settings → Preferred currency persists across reload
- [ ] Transactions → inline category editor dropdown shows no duplicate entries