### PR TITLE
feat: multicurrency convert+combine model (PR 4.5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,12 @@ function App() {
     'UYU' | 'USD'
   >(() => {
     const saved = localStorage.getItem('tatu:preferences:currency')
-    return saved === 'USD' ? 'USD' : 'UYU'
+    return saved === 'UYU' ? 'UYU' : 'USD'
+  })
+  const [fxRate, setFxRateState] = useState<number>(() => {
+    const saved = localStorage.getItem('tatu:preferences:fxRate')
+    const parsed = saved ? parseFloat(saved) : NaN
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 40.5
   })
   const [pendingTxFilter, setPendingTxFilter] = useState<import('./models').TransactionsFilter | null>(null)
   const [session, setSession] = useState<SupabaseSession | null>(() =>
@@ -189,6 +194,11 @@ function App() {
   function setPreferredCurrency(c: 'UYU' | 'USD') {
     setPreferredCurrencyState(c)
     localStorage.setItem('tatu:preferences:currency', c)
+  }
+
+  function setFxRate(r: number) {
+    setFxRateState(r)
+    localStorage.setItem('tatu:preferences:fxRate', String(r))
   }
 
   useEffect(() => {
@@ -1200,7 +1210,10 @@ function App() {
                 onNavigateToImport={() => setImportOpen(true)}
                 onNavigateToTransactions={navigateToTransactions}
                 onNavigateToAnalysis={() => setCurrentView('analysis')}
-                defaultCurrency={preferredCurrency}
+                homeCurrency={preferredCurrency}
+                fxRate={fxRate}
+                onSetHomeCurrency={setPreferredCurrency}
+                onSetFxRate={setFxRate}
               />
             )}
             {currentView === 'transactions' && (
@@ -1219,6 +1232,10 @@ function App() {
               <Charts
                 transactions={transactions}
                 onNavigateToTransactions={navigateToTransactions}
+                homeCurrency={preferredCurrency}
+                fxRate={fxRate}
+                onSetHomeCurrency={setPreferredCurrency}
+                onSetFxRate={setFxRate}
               />
             )}
             {currentView === 'categories' && (
@@ -1230,6 +1247,8 @@ function App() {
                 onSetTheme={setTheme}
                 preferredCurrency={preferredCurrency}
                 onSetCurrency={setPreferredCurrency}
+                fxRate={fxRate}
+                onSetFxRate={setFxRate}
                 session={session}
                 supabaseEnabled={supabaseEnabled}
                 onSignOut={() => {

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -3,13 +3,16 @@
 import { Card } from './ui/card'
 import { ChartPie } from 'lucide-react'
 import type { Transaction, Currency, TransactionsFilter } from '../models'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
   PieChart,
   Pie,
   Cell,
   AreaChart,
   Area,
+  BarChart,
+  Bar,
+  ReferenceLine,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -17,13 +20,17 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import type { TooltipProps } from 'recharts'
-import type {
-  NameType,
-  ValueType,
-} from 'recharts/types/component/DefaultTooltipContent'
+import type { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent'
 import { getCategoryDisplay } from '../utils/category-display'
 import { getCategoryDefinitions } from '../services/categories/category-registry'
 import { isTransferCategory } from '../services/transfers/internal-transfers'
+import {
+  buildCategorySpendingConverted,
+  buildMonthlyTrendsConverted,
+  buildCurrencySplit,
+} from '../services/charts/chart-data'
+import { convert } from '../services/currency/convert'
+import { FxChip } from './FxChip'
 
 function formatAmt(amount: number, currency: Currency): string {
   const formatted = Math.abs(amount).toLocaleString('es-UY', {
@@ -44,72 +51,65 @@ function formatAmtShort(amount: number, currency: Currency): string {
 interface ChartsProps {
   transactions: Transaction[]
   onNavigateToTransactions?: (filter: TransactionsFilter) => void
+  homeCurrency?: Currency
+  fxRate?: number
+  onSetHomeCurrency?: (c: Currency) => void
+  onSetFxRate?: (r: number) => void
 }
 
-export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) {
-  const [currency, setCurrency] = useState<Currency>('UYU')
-
-  // Emoji icon lookup from category definitions
+export function Charts({
+  transactions,
+  onNavigateToTransactions,
+  homeCurrency = 'USD',
+  fxRate = 40.5,
+  onSetHomeCurrency,
+  onSetFxRate,
+}: ChartsProps) {
   const emojiLookup = useMemo(() => {
     const map = new Map<string, string>()
     getCategoryDefinitions().forEach((d) => map.set(d.id, d.icon))
     return map
   }, [])
 
-  const currencyTxs = useMemo(
-    () => transactions.filter((tx) => tx.currency === currency),
-    [transactions, currency],
-  )
-
-  // Category breakdown (expenses only, no transfers)
+  // Category breakdown — converted + combined
   const categoryData = useMemo(() => {
-    const grouped = new Map<string, number>()
-    currencyTxs
-      .filter((tx) => tx.type === 'debit' && !isTransferCategory(tx.category))
-      .forEach((tx) => {
-        const cat = tx.category ?? 'uncategorized'
-        grouped.set(cat, (grouped.get(cat) ?? 0) + tx.amount)
-      })
-
-    const total = Array.from(grouped.values()).reduce((s, v) => s + v, 0)
-    return Array.from(grouped.entries())
-      .map(([catId, value]) => {
-        const display = getCategoryDisplay(catId)
-        return {
-          categoryId: catId,
-          label: display.label,
-          color: display.color,
-          emoji: emojiLookup.get(catId) ?? '',
-          value,
-          pct: total > 0 ? (value / total) * 100 : 0,
-        }
-      })
-      .sort((a, b) => b.value - a.value)
-  }, [currencyTxs, emojiLookup])
+    const data = buildCategorySpendingConverted(transactions, homeCurrency, fxRate)
+    const total = data.reduce((s, r) => s + r.total, 0) || 1
+    return data.map((row) => {
+      const display = getCategoryDisplay(row.category)
+      return {
+        categoryId: row.category,
+        label: display.label,
+        color: display.color,
+        emoji: emojiLookup.get(row.category) ?? '',
+        value: row.total,
+        pct: (row.total / total) * 100,
+      }
+    })
+  }, [transactions, homeCurrency, fxRate, emojiLookup])
 
   const totalExpenses = categoryData.reduce((s, c) => s + c.value, 0)
   const hasExpenseData = totalExpenses > 0
 
-  // Monthly trend
+  // Monthly trend — converted + combined
   const monthlyTrend = useMemo(() => {
-    const grouped = new Map<string, { income: number; expense: number; key: string }>()
-    currencyTxs.forEach((tx) => {
-      if (isTransferCategory(tx.category)) return
-      const key = `${tx.date.getFullYear()}-${String(tx.date.getMonth() + 1).padStart(2, '0')}`
-      const label = new Intl.DateTimeFormat('es-UY', {
-        year: 'numeric',
-        month: 'short',
-      }).format(tx.date)
-      if (!grouped.has(key)) grouped.set(key, { income: 0, expense: 0, key: label })
-      const entry = grouped.get(key)!
-      if (tx.type === 'credit') entry.income += tx.amount
-      else entry.expense += tx.amount
-    })
-    return Array.from(grouped.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([, v]) => ({ month: v.key, ingresos: v.income, gastos: v.expense }))
+    return buildMonthlyTrendsConverted(transactions, homeCurrency, fxRate)
       .slice(-12)
-  }, [currencyTxs])
+      .map((m) => ({
+        month: new Intl.DateTimeFormat('es-UY', { year: 'numeric', month: 'short' }).format(
+          new Date(m.month + '-01T00:00:00.000Z')
+        ),
+        ingresos: m.income,
+        gastos: m.expense,
+        neto: m.net,
+      }))
+  }, [transactions, homeCurrency, fxRate])
+
+  // Currency split card
+  const currencySplit = useMemo(
+    () => buildCurrencySplit(transactions, homeCurrency, fxRate),
+    [transactions, homeCurrency, fxRate],
+  )
 
   const totalIncome = monthlyTrend.reduce((s, m) => s + m.ingresos, 0)
   const totalExpenseTrend = monthlyTrend.reduce((s, m) => s + m.gastos, 0)
@@ -122,37 +122,30 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
       ? Math.round(totalExpenseTrend / monthlyTrend.length)
       : 0
 
-  // Top merchants by spend
+  // Top merchants — spending across all history in home currency
   const topMerchants = useMemo(() => {
     const map = new Map<string, { name: string; total: number; count: number; catId: string }>()
-    currencyTxs
+    transactions
       .filter((tx) => tx.type === 'debit' && !isTransferCategory(tx.category))
       .forEach((tx) => {
         const key = tx.description
-        const entry = map.get(key) ?? {
-          name: key,
-          total: 0,
-          count: 0,
-          catId: tx.category ?? 'uncategorized',
+        const prev = map.get(key) ?? {
+          name: key, total: 0, count: 0, catId: tx.category ?? 'uncategorized',
         }
-        entry.total += tx.amount
-        entry.count++
-        map.set(key, entry)
+        const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
+        prev.total += converted
+        prev.count++
+        map.set(key, prev)
       })
-    return Array.from(map.values())
-      .sort((a, b) => b.total - a.total)
-      .slice(0, 6)
-  }, [currencyTxs])
+    return Array.from(map.values()).sort((a, b) => b.total - a.total).slice(0, 6)
+  }, [transactions, homeCurrency, fxRate])
 
   const hasData = transactions.length > 0
-
   const topCategory = categoryData[0]
 
   const donutData = useMemo(() => {
     const top7 = categoryData.slice(0, 7)
-    const otherVal = categoryData
-      .slice(7)
-      .reduce((s, r) => s + r.value, 0)
+    const otherVal = categoryData.slice(7).reduce((s, r) => s + r.value, 0)
     if (otherVal > 0) {
       return [
         ...top7,
@@ -178,21 +171,13 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
       return (
         <div
           style={{
-            background: 'var(--bg)',
-            border: '1px solid var(--border)',
-            borderRadius: 10,
-            padding: '10px 14px',
-            boxShadow: '0 4px 16px rgba(0,0,0,.08)',
+            background: 'var(--bg)', border: '1px solid var(--border)',
+            borderRadius: 10, padding: '10px 14px', boxShadow: '0 4px 16px rgba(0,0,0,.08)',
           }}
         >
-          <p style={{ fontWeight: 600, fontSize: 13, marginBottom: 2 }}>
-            {payload[0].name}
-          </p>
-          <p
-            className="font-mono"
-            style={{ fontSize: 13, color: 'var(--text-faint)' }}
-          >
-            {formatAmt(value, currency)}
+          <p style={{ fontWeight: 600, fontSize: 13, marginBottom: 2 }}>{payload[0].name}</p>
+          <p className="font-mono" style={{ fontSize: 13, color: 'var(--text-faint)' }}>
+            {formatAmt(value, homeCurrency)}
           </p>
         </div>
       )
@@ -204,9 +189,7 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
     return (
       <div className="space-y-6">
         <div>
-          <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 4 }}>
-            Análisis
-          </h1>
+          <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 4 }}>Análisis</h1>
           <p className="text-muted-foreground" style={{ fontSize: 14 }}>
             Tendencias y patrones de gasto en tus cuentas
           </p>
@@ -232,110 +215,73 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
       {/* Page header */}
       <div
         style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          flexWrap: 'wrap',
-          gap: 12,
+          display: 'flex', justifyContent: 'space-between',
+          alignItems: 'flex-start', flexWrap: 'wrap', gap: 12,
         }}
       >
         <div>
-          <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 4 }}>
-            Análisis
-          </h1>
+          <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 4 }}>Análisis</h1>
           <p className="text-muted-foreground" style={{ fontSize: 14 }}>
             Tendencias y patrones de gasto en tus cuentas
           </p>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            background: 'var(--surface-2)',
-            borderRadius: 10,
-            padding: 3,
-            gap: 2,
-          }}
-        >
-          {(
-            [
-              { value: 'UYU', label: 'Pesos $U' },
-              { value: 'USD', label: 'Dólares US$' },
-            ] as const
-          ).map(({ value, label }) => (
-            <button
-              key={value}
-              onClick={() => setCurrency(value)}
-              style={{
-                padding: '5px 14px',
-                borderRadius: 7,
-                fontSize: 13,
-                fontWeight: 500,
-                background:
-                  currency === value ? 'var(--bg)' : 'transparent',
-                color:
-                  currency === value ? 'var(--text)' : 'var(--text-faint)',
-                border: 'none',
-                cursor: 'pointer',
-                transition: 'all 0.15s',
-                boxShadow:
-                  currency === value ? '0 1px 3px rgba(0,0,0,.08)' : 'none',
-              }}
-            >
-              {label}
-            </button>
-          ))}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+          <FxChip fxRate={fxRate} onSetFxRate={onSetFxRate} />
+          <div
+            style={{
+              display: 'flex', background: 'var(--surface-2)',
+              borderRadius: 10, padding: 3, gap: 2,
+            }}
+          >
+            {(['USD', 'UYU'] as const).map((val) => (
+              <button
+                key={val}
+                onClick={() => onSetHomeCurrency?.(val)}
+                style={{
+                  padding: '5px 14px', borderRadius: 7, fontSize: 13, fontWeight: 500,
+                  background: homeCurrency === val ? 'var(--bg)' : 'transparent',
+                  color: homeCurrency === val ? 'var(--text)' : 'var(--text-faint)',
+                  border: 'none', cursor: 'pointer', transition: 'all 0.15s',
+                  boxShadow: homeCurrency === val ? '0 1px 3px rgba(0,0,0,.08)' : 'none',
+                }}
+              >
+                {val === 'USD' ? 'US$' : '$U'}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 
       {/* KPI tiles */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card className="p-5">
-          <div
-            className="text-muted-foreground"
-            style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}
-          >
+          <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}>
             Mayor categoría
           </div>
           <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>
             {topCategory?.label ?? '—'}
           </div>
           <div className="text-muted-foreground" style={{ fontSize: 12 }}>
-            {topCategory
-              ? `${Math.round(topCategory.pct)}% del gasto`
-              : 'Sin datos'}
+            {topCategory ? `${Math.round(topCategory.pct)}% del gasto` : 'Sin datos'}
           </div>
         </Card>
         <Card className="p-5">
-          <div
-            className="text-muted-foreground"
-            style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}
-          >
+          <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}>
             Gasto promedio mensual
           </div>
-          <div
-            className="font-mono"
-            style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}
-          >
-            {formatAmtShort(avgMonthly, currency)}
+          <div className="font-mono" style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>
+            {formatAmtShort(avgMonthly, homeCurrency)}
           </div>
           <div className="text-muted-foreground" style={{ fontSize: 12 }}>
             Últimos {monthlyTrend.length} meses
           </div>
         </Card>
         <Card className="p-5">
-          <div
-            className="text-muted-foreground"
-            style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}
-          >
+          <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}>
             Tasa de ahorro
           </div>
           <div
-            style={{
-              fontSize: 20,
-              fontWeight: 700,
-              marginBottom: 4,
-              color: savingsRate >= 0 ? 'var(--pos)' : 'var(--neg)',
-            }}
+            style={{ fontSize: 20, fontWeight: 700, marginBottom: 4, color: savingsRate >= 0 ? 'var(--pos)' : 'var(--neg)' }}
           >
             {savingsRate}%
           </div>
@@ -344,10 +290,7 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
           </div>
         </Card>
         <Card className="p-5">
-          <div
-            className="text-muted-foreground"
-            style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}
-          >
+          <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 8 }}>
             Categorías activas
           </div>
           <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>
@@ -372,12 +315,11 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
           <div
             style={{
               display: 'grid',
-              gridTemplateColumns: '220px 1fr',
+              gridTemplateColumns: 'min(220px, 100%) 1fr',
               gap: 36,
               alignItems: 'center',
             }}
           >
-            {/* Donut */}
             <div style={{ position: 'relative', width: 220, height: 220 }}>
               <ResponsiveContainer width={220} height={220}>
                 <PieChart>
@@ -400,53 +342,36 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
               </ResponsiveContainer>
               <div
                 style={{
-                  position: 'absolute',
-                  top: '50%',
-                  left: '50%',
-                  transform: 'translate(-50%, -50%)',
-                  textAlign: 'center',
-                  pointerEvents: 'none',
+                  position: 'absolute', top: '50%', left: '50%',
+                  transform: 'translate(-50%, -50%)', textAlign: 'center', pointerEvents: 'none',
                 }}
               >
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em' }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em' }}>
                   TOTAL
                 </div>
                 <div className="font-mono" style={{ fontSize: 15, fontWeight: 700 }}>
-                  {formatAmtShort(totalExpenses, currency)}
+                  {formatAmtShort(totalExpenses, homeCurrency)}
                 </div>
               </div>
             </div>
 
-            {/* Breakdown list */}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 13 }}>
               {categoryData.slice(0, 7).map((row) => (
                 <div
                   key={row.categoryId}
-                  onClick={() =>
-                    onNavigateToTransactions?.({ category: row.categoryId })
-                  }
-                  style={{
-                    cursor: onNavigateToTransactions ? 'pointer' : 'default',
-                  }}
+                  onClick={() => onNavigateToTransactions?.({ category: row.categoryId })}
+                  style={{ cursor: onNavigateToTransactions ? 'pointer' : 'default' }}
                 >
                   <div
                     style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'baseline',
-                      marginBottom: 5,
+                      display: 'flex', justifyContent: 'space-between',
+                      alignItems: 'baseline', marginBottom: 5,
                     }}
                   >
                     <span
                       style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        gap: 8,
-                        fontSize: 13.5,
-                        fontWeight: 500,
+                        display: 'inline-flex', alignItems: 'center',
+                        gap: 8, fontSize: 13.5, fontWeight: 500,
                       }}
                     >
                       {row.emoji ? (
@@ -454,25 +379,18 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
                       ) : (
                         <span
                           style={{
-                            width: 9,
-                            height: 9,
-                            borderRadius: 3,
-                            background: row.color,
-                            display: 'inline-block',
+                            width: 9, height: 9, borderRadius: 3,
+                            background: row.color, display: 'inline-block',
                           }}
                         />
                       )}
                       {row.label}
                     </span>
                     <span
-                      style={{
-                        display: 'inline-flex',
-                        gap: 10,
-                        alignItems: 'baseline',
-                      }}
+                      style={{ display: 'inline-flex', gap: 10, alignItems: 'baseline' }}
                     >
                       <span className="font-mono" style={{ fontSize: 13 }}>
-                        {formatAmt(row.value, currency)}
+                        {formatAmt(row.value, homeCurrency)}
                       </span>
                       <span
                         className="font-mono text-muted-foreground"
@@ -484,18 +402,13 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
                   </div>
                   <div
                     style={{
-                      height: 4,
-                      borderRadius: 2,
-                      background: 'var(--surface-2)',
-                      overflow: 'hidden',
+                      height: 4, borderRadius: 2, background: 'var(--surface-2)', overflow: 'hidden',
                     }}
                   >
                     <div
                       style={{
-                        height: '100%',
-                        width: `${row.pct}%`,
-                        background: row.color,
-                        borderRadius: 2,
+                        height: '100%', width: `${row.pct}%`,
+                        background: row.color, borderRadius: 2,
                       }}
                     />
                   </div>
@@ -510,15 +423,11 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
       <Card className="p-6">
         <div
           style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 20,
+            display: 'flex', justifyContent: 'space-between',
+            alignItems: 'center', marginBottom: 20,
           }}
         >
-          <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>
-            Ingresos vs Gastos
-          </h2>
+          <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Ingresos vs Gastos</h2>
           <div style={{ display: 'flex', gap: 18 }}>
             {[
               { label: 'Ingresos', color: 'var(--pos)' },
@@ -527,20 +436,14 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
               <span
                 key={label}
                 style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 7,
-                  fontSize: 12.5,
-                  color: 'var(--text-faint)',
+                  display: 'inline-flex', alignItems: 'center',
+                  gap: 7, fontSize: 12.5, color: 'var(--text-faint)',
                 }}
               >
                 <span
                   style={{
-                    width: 12,
-                    height: 3,
-                    borderRadius: 2,
-                    background: color,
-                    display: 'inline-block',
+                    width: 12, height: 3, borderRadius: 2,
+                    background: color, display: 'inline-block',
                   }}
                 />
                 {label}
@@ -549,10 +452,7 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
           </div>
         </div>
         <ResponsiveContainer width="100%" height={280}>
-          <AreaChart
-            data={monthlyTrend}
-            margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
-          >
+          <AreaChart data={monthlyTrend} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
             <defs>
               <linearGradient id="gradIngresos" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor="var(--pos)" stopOpacity={0.22} />
@@ -565,53 +465,161 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
             </defs>
             <CartesianGrid strokeDasharray="2 4" stroke="var(--border)" vertical={false} />
             <XAxis
-              dataKey="month"
-              stroke="var(--text-faint)"
-              tick={{ fontSize: 12 }}
-              axisLine={false}
-              tickLine={false}
+              dataKey="month" stroke="var(--text-faint)"
+              tick={{ fontSize: 12 }} axisLine={false} tickLine={false}
             />
             <YAxis
-              stroke="var(--text-faint)"
-              tick={{ fontSize: 12 }}
-              axisLine={false}
-              tickLine={false}
-              tickFormatter={(v) => formatAmtShort(v, currency)}
-              width={70}
+              stroke="var(--text-faint)" tick={{ fontSize: 12 }}
+              axisLine={false} tickLine={false}
+              tickFormatter={(v) => formatAmtShort(v, homeCurrency)} width={70}
             />
             <Tooltip
               contentStyle={{
-                background: 'var(--bg)',
-                border: '1px solid var(--border)',
-                borderRadius: 10,
+                background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 10,
               }}
-              formatter={(value: ValueType) =>
-                formatAmt(Number(value), currency)
-              }
+              formatter={(value: ValueType) => formatAmt(Number(value), homeCurrency)}
             />
             <Area
-              type="monotone"
-              dataKey="ingresos"
-              stroke="var(--pos)"
-              strokeWidth={2.5}
-              fill="url(#gradIngresos)"
-              name="Ingresos"
-              dot={false}
-              activeDot={{ r: 4, fill: 'var(--pos)' }}
+              type="monotone" dataKey="ingresos" stroke="var(--pos)"
+              strokeWidth={2.5} fill="url(#gradIngresos)" name="Ingresos"
+              dot={false} activeDot={{ r: 4, fill: 'var(--pos)' }}
             />
             <Area
-              type="monotone"
-              dataKey="gastos"
-              stroke="var(--neg)"
-              strokeWidth={2.5}
-              fill="url(#gradGastos)"
-              name="Gastos"
-              dot={false}
-              activeDot={{ r: 4, fill: 'var(--neg)' }}
+              type="monotone" dataKey="gastos" stroke="var(--neg)"
+              strokeWidth={2.5} fill="url(#gradGastos)" name="Gastos"
+              dot={false} activeDot={{ r: 4, fill: 'var(--neg)' }}
             />
           </AreaChart>
         </ResponsiveContainer>
       </Card>
+
+      {/* ¿Estás ahorrando? — diverging monthly net bars */}
+      {monthlyTrend.length > 0 && (
+        <Card className="p-6">
+          <div style={{ marginBottom: 20 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0, marginBottom: 4 }}>
+              ¿Estás ahorrando?
+            </h2>
+            <p className="text-muted-foreground" style={{ fontSize: 13 }}>
+              Neto mensual (ingresos − gastos) en {homeCurrency === 'USD' ? 'dólares' : 'pesos'}
+            </p>
+          </div>
+          <ResponsiveContainer width="100%" height={200}>
+            <BarChart data={monthlyTrend} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="2 4" stroke="var(--border)" vertical={false} />
+              <XAxis
+                dataKey="month" stroke="var(--text-faint)"
+                tick={{ fontSize: 12 }} axisLine={false} tickLine={false}
+              />
+              <YAxis
+                stroke="var(--text-faint)" tick={{ fontSize: 12 }}
+                axisLine={false} tickLine={false}
+                tickFormatter={(v) => formatAmtShort(v, homeCurrency)} width={70}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 10,
+                }}
+                formatter={(value: ValueType) => [formatAmt(Number(value), homeCurrency), 'Neto']}
+              />
+              <ReferenceLine y={0} stroke="var(--border)" strokeWidth={1.5} />
+              <Bar dataKey="neto" radius={[3, 3, 0, 0]}>
+                {monthlyTrend.map((entry, i) => (
+                  <Cell
+                    key={i}
+                    fill={entry.neto >= 0 ? 'var(--pos)' : 'var(--neg)'}
+                    fillOpacity={0.8}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+          <div style={{ display: 'flex', gap: 24, marginTop: 16, flexWrap: 'wrap' }}>
+            <div>
+              <div className="text-muted-foreground" style={{ fontSize: 12 }}>
+                Promedio mensual neto
+              </div>
+              <div
+                className="font-mono"
+                style={{
+                  fontSize: 16, fontWeight: 700, marginTop: 2,
+                  color: (totalIncome - totalExpenseTrend) >= 0 ? 'var(--pos)' : 'var(--neg)',
+                }}
+              >
+                {formatAmtShort(
+                  monthlyTrend.length > 0
+                    ? (totalIncome - totalExpenseTrend) / monthlyTrend.length
+                    : 0,
+                  homeCurrency
+                )}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground" style={{ fontSize: 12 }}>Tasa de ahorro</div>
+              <div
+                style={{
+                  fontSize: 16, fontWeight: 700, marginTop: 2,
+                  color: savingsRate >= 0 ? 'var(--pos)' : 'var(--neg)',
+                }}
+              >
+                {savingsRate}%
+              </div>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Gasto por moneda */}
+      {currencySplit.total > 0 && (
+        <Card className="p-6">
+          <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20 }}>
+            Gasto por moneda
+          </h2>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {(
+              [
+                { key: 'USD' as const, label: 'US$ Dólares', pct: currencySplit.pctUSD, amount: currencySplit.USD },
+                { key: 'UYU' as const, label: '$U Pesos', pct: currencySplit.pctUYU, amount: currencySplit.UYU },
+              ] as const
+            ).map((row) => (
+              <div key={row.key}>
+                <div
+                  style={{
+                    display: 'flex', justifyContent: 'space-between',
+                    alignItems: 'baseline', marginBottom: 6,
+                  }}
+                >
+                  <span style={{ fontSize: 13.5, fontWeight: 500 }}>{row.label}</span>
+                  <span style={{ display: 'flex', gap: 10, alignItems: 'baseline' }}>
+                    <span className="font-mono" style={{ fontSize: 13 }}>
+                      {formatAmt(row.amount, homeCurrency)}
+                    </span>
+                    <span
+                      className="font-mono text-muted-foreground"
+                      style={{ fontSize: 11.5, width: 38, textAlign: 'right' }}
+                    >
+                      {row.pct.toFixed(1)}%
+                    </span>
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 6, borderRadius: 3, background: 'var(--surface-2)', overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      height: '100%', width: `${row.pct}%`,
+                      background: row.key === 'USD' ? 'var(--brand)' : 'var(--accent)',
+                      borderRadius: 3,
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
 
       {/* Top merchants */}
       {topMerchants.length > 0 && (
@@ -620,11 +628,7 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
             Mayores comercios
           </h2>
           <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: '0 36px',
-            }}
+            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 36px' }}
           >
             {topMerchants.map((m, i) => {
               const display = getCategoryDisplay(m.catId)
@@ -633,39 +637,26 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
                 <div
                   key={i}
                   style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 12,
-                    padding: '11px 0',
-                    borderBottom: '1px solid var(--border)',
+                    display: 'flex', alignItems: 'center', gap: 12,
+                    padding: '11px 0', borderBottom: '1px solid var(--border)',
                   }}
                 >
-                  <span
-                    className="font-mono text-muted-foreground"
-                    style={{ fontSize: 12, width: 16 }}
-                  >
+                  <span className="font-mono text-muted-foreground" style={{ fontSize: 12, width: 16 }}>
                     {i + 1}
                   </span>
                   <span
                     style={{
-                      width: 30,
-                      height: 30,
-                      borderRadius: 8,
+                      width: 30, height: 30, borderRadius: 8,
                       background: display.color + '1f',
-                      display: 'grid',
-                      placeItems: 'center',
-                      fontSize: 14,
-                      flexShrink: 0,
+                      display: 'grid', placeItems: 'center',
+                      fontSize: 14, flexShrink: 0,
                     }}
                   >
                     {emoji ?? (
                       <span
                         style={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: '50%',
-                          background: display.color,
-                          display: 'block',
+                          width: 8, height: 8, borderRadius: '50%',
+                          background: display.color, display: 'block',
                         }}
                       />
                     )}
@@ -673,24 +664,18 @@ export function Charts({ transactions, onNavigateToTransactions }: ChartsProps) 
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div
                       style={{
-                        fontSize: 13.5,
-                        fontWeight: 500,
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
+                        fontSize: 13.5, fontWeight: 500,
+                        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
                       }}
                     >
                       {m.name}
                     </div>
-                    <div
-                      className="text-muted-foreground"
-                      style={{ fontSize: 11.5 }}
-                    >
+                    <div className="text-muted-foreground" style={{ fontSize: 11.5 }}>
                       {m.count} {m.count > 1 ? 'movimientos' : 'movimiento'}
                     </div>
                   </div>
                   <span className="font-mono" style={{ fontSize: 13 }}>
-                    {formatAmt(m.total, currency)}
+                    {formatAmt(m.total, homeCurrency)}
                   </span>
                 </div>
               )

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -32,22 +32,26 @@ describe('Dashboard', () => {
     vi.useRealTimers()
   })
 
-  it('shows multi-currency summary amounts in the overview', () => {
+  it('shows converted+combined totals in home currency', () => {
     const transactions = [
       makeTransaction({ id: 'uyu-debit', currency: 'UYU', type: 'debit', amount: 1000 }),
       makeTransaction({ id: 'usd-debit', currency: 'USD', type: 'debit', amount: 50 }),
       makeTransaction({ id: 'usd-credit', currency: 'USD', type: 'credit', amount: 200 }),
     ]
 
-    render(<Dashboard transactions={transactions} />)
+    // homeCurrency defaults to 'USD', fxRate defaults to 40.5
+    // income = 200 USD, expenses = 50 USD + 1000/40.5 ≈ 24.69 USD
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
 
-    // USD income appears as secondary in "Este mes" panel (since > 0)
+    // income = 200 USD appears in "Este mes" panel
     expect(screen.getByText('US$ 200,00')).toBeInTheDocument()
-    // USD expense appears as secondary in "Este mes" panel (since > 0)
-    expect(screen.getAllByText('US$ 50,00').length).toBeGreaterThan(0)
+    // UYU transaction native amount appears in recent list
+    expect(screen.getAllByText('$U 1.000,00').length).toBeGreaterThan(0)
+    // Converted secondary line appears for the UYU tx (≈ USD)
+    expect(screen.getByText(/≈ US\$/)).toBeInTheDocument()
   })
 
-  it('does not count transfer debits as expenses', () => {
+  it('does not count transfer debits as expenses in converted totals', () => {
     const transactions = [
       makeTransaction({
         id: 'normal-expense',
@@ -65,9 +69,12 @@ describe('Dashboard', () => {
       }),
     ]
 
-    render(<Dashboard transactions={transactions} />)
+    // homeCurrency=USD, so expense total = 50 (transfer excluded)
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
 
+    // 50 appears (native + converted total)
     expect(screen.getAllByText('US$ 50,00').length).toBeGreaterThan(0)
+    // 150 should NOT appear (transfer excluded from totals)
     expect(screen.queryByText('US$ 150,00')).not.toBeInTheDocument()
   })
 })

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-// Dashboard - Overview with account cards and monthly summary
+// Dashboard - Overview with account cards, converted+combined monthly summary
 
 import { Card } from './ui/card'
 import { Button } from './ui/button'
@@ -10,13 +10,17 @@ import {
   ArrowRight,
 } from 'lucide-react'
 import type { Transaction, Currency, TransactionsFilter } from '../models'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { getCategoryDisplay } from '../utils/category-display'
 import { isTransferCategory } from '../services/transfers/internal-transfers'
+import { isCategoryIgnored, getCategoryDefinition } from '../services/categories/category-registry'
 import {
-  isCategoryIgnored,
-  getCategoryDefinition,
-} from '../services/categories/category-registry'
+  buildCurrentMonthSummary,
+  buildCategorySpendingConverted,
+  buildMonthlyTrendsConverted,
+} from '../services/charts/chart-data'
+import { convert } from '../services/currency/convert'
+import { FxChip } from './FxChip'
 
 function toSafeNumber(value: number): number {
   return Number.isFinite(value) ? value : 0
@@ -54,19 +58,14 @@ function formatCurrency(amount: number, currency: Currency): string {
   return `${symbol} ${formatted}`
 }
 
-function calculateSummary(transactions: Transaction[], currency?: Currency) {
-  const filtered = currency
-    ? transactions.filter((tx) => tx.currency === currency)
-    : transactions
-
+function calculateAccountSummary(transactions: Transaction[], currency: Currency) {
+  const filtered = transactions.filter((tx) => tx.currency === currency)
   const income = filtered
     .filter((tx) => tx.type === 'credit' && !isTransferCategory(tx.category) && !isCategoryIgnored(tx.category))
     .reduce((sum, tx) => sum + toSafeNumber(tx.amount), 0)
-
   const expenses = filtered
     .filter((tx) => tx.type === 'debit' && !isTransferCategory(tx.category) && !isCategoryIgnored(tx.category))
     .reduce((sum, tx) => sum + toSafeNumber(tx.amount), 0)
-
   return {
     income: toSafeNumber(income),
     expenses: toSafeNumber(expenses),
@@ -81,10 +80,11 @@ interface DashboardProps {
   onNavigateToImport?: () => void
   onNavigateToTransactions?: (filter: TransactionsFilter) => void
   onNavigateToAnalysis?: () => void
-  defaultCurrency?: Currency
+  homeCurrency?: Currency
+  fxRate?: number
+  onSetHomeCurrency?: (c: Currency) => void
+  onSetFxRate?: (r: number) => void
 }
-
-type CurrencyFilter = Currency | 'all'
 
 export function Dashboard({
   transactions,
@@ -92,15 +92,14 @@ export function Dashboard({
   onNavigateToImport,
   onNavigateToTransactions,
   onNavigateToAnalysis,
-  defaultCurrency,
+  homeCurrency = 'USD',
+  fxRate = 40.5,
+  onSetHomeCurrency,
+  onSetFxRate,
 }: DashboardProps) {
-  const [selectedCurrency, setSelectedCurrency] = useState<CurrencyFilter>(
-    defaultCurrency ?? 'all'
-  )
-
   const hasTransactions = transactions.length > 0
 
-  // Reference month from latest transaction date — not current clock
+  // Latest date used as reference month (avoids dependency on system clock)
   const latestDate = useMemo(() => {
     if (transactions.length === 0) return new Date()
     return transactions.reduce(
@@ -109,99 +108,70 @@ export function Dashboard({
     )
   }, [transactions])
 
-  const monthLabel = useMemo(
-    () => latestDate.toLocaleDateString('es-UY', { month: 'long', year: 'numeric' }),
-    [latestDate],
-  )
-
-  const thisMonthTransactions = useMemo(() => {
-    const y = latestDate.getFullYear()
-    const m = latestDate.getMonth()
-    return transactions.filter((tx) => {
-      const d = tx.date
-      return d.getFullYear() === y && d.getMonth() === m
-    })
-  }, [transactions, latestDate])
-
-  // Per-source account summaries
+  // Per-source account summaries (native currency, not converted)
   const creditCardTransactions = useMemo(
     () => transactions.filter((tx) => tx.source === 'credit_card'),
     [transactions],
   )
   const creditCardSummaryUYU = useMemo(
-    () => calculateSummary(creditCardTransactions, 'UYU'),
+    () => calculateAccountSummary(creditCardTransactions, 'UYU'),
     [creditCardTransactions],
   )
   const creditCardSummaryUSD = useMemo(
-    () => calculateSummary(creditCardTransactions, 'USD'),
+    () => calculateAccountSummary(creditCardTransactions, 'USD'),
     [creditCardTransactions],
   )
-
   const usdBankTransactions = useMemo(
-    () =>
-      transactions.filter(
-        (tx) => tx.source === 'bank_account' && tx.currency === 'USD',
-      ),
+    () => transactions.filter((tx) => tx.source === 'bank_account' && tx.currency === 'USD'),
     [transactions],
   )
   const usdBankSummary = useMemo(
-    () => calculateSummary(usdBankTransactions, 'USD'),
+    () => calculateAccountSummary(usdBankTransactions, 'USD'),
     [usdBankTransactions],
   )
-
   const uyuBankTransactions = useMemo(
-    () =>
-      transactions.filter(
-        (tx) => tx.source === 'bank_account' && tx.currency === 'UYU',
-      ),
+    () => transactions.filter((tx) => tx.source === 'bank_account' && tx.currency === 'UYU'),
     [transactions],
   )
   const uyuBankSummary = useMemo(
-    () => calculateSummary(uyuBankTransactions, 'UYU'),
+    () => calculateAccountSummary(uyuBankTransactions, 'UYU'),
     [uyuBankTransactions],
   )
 
-  // "Este mes" panel summaries
-  const thisMonthSummaryUYU = useMemo(
-    () => calculateSummary(thisMonthTransactions, 'UYU'),
-    [thisMonthTransactions],
-  )
-  const thisMonthSummaryUSD = useMemo(
-    () => calculateSummary(thisMonthTransactions, 'USD'),
-    [thisMonthTransactions],
+  // "Este mes" — converted + combined totals in home currency
+  const monthSummary = useMemo(
+    () => buildCurrentMonthSummary(transactions, homeCurrency, fxRate),
+    [transactions, homeCurrency, fxRate],
   )
 
-  const panelCurrency: Currency = selectedCurrency === 'USD' ? 'USD' : 'UYU'
-  const panelSummary =
-    selectedCurrency === 'USD' ? thisMonthSummaryUSD : thisMonthSummaryUYU
-
-  // Top-5 category breakdown for selected currency (defaults to UYU in 'all' mode)
-  const categoryBreakdown = useMemo(() => {
-    const slice =
-      selectedCurrency === 'USD'
-        ? thisMonthTransactions.filter((tx) => tx.currency === 'USD')
-        : thisMonthTransactions.filter((tx) => tx.currency === 'UYU')
-
-    const debits = slice.filter(
-      (tx) => tx.type === 'debit' && !isTransferCategory(tx.category) && !isCategoryIgnored(tx.category),
+  // Category breakdown for current month, in home currency
+  const thisMonthTransactions = useMemo(() => {
+    const y = latestDate.getUTCFullYear()
+    const m = latestDate.getUTCMonth()
+    return transactions.filter(
+      (tx) => tx.date.getUTCFullYear() === y && tx.date.getUTCMonth() === m,
     )
-    const total = debits.reduce((sum, tx) => sum + toSafeNumber(tx.amount), 0)
-    const byCategory = new Map<string, number>()
-    debits.forEach((tx) => {
-      const cat = tx.category ?? 'uncategorized'
-      byCategory.set(cat, (byCategory.get(cat) ?? 0) + toSafeNumber(tx.amount))
-    })
+  }, [transactions, latestDate])
 
-    return Array.from(byCategory.entries())
-      .map(([cat, amount]) => ({
-        category: cat,
-        amount,
-        pct: total > 0 ? (amount / total) * 100 : 0,
-        display: getCategoryDisplay(cat),
-      }))
-      .sort((a, b) => b.amount - a.amount)
-      .slice(0, 5)
-  }, [thisMonthTransactions, selectedCurrency])
+  const categoryBreakdown = useMemo(() => {
+    const data = buildCategorySpendingConverted(
+      thisMonthTransactions,
+      homeCurrency,
+      fxRate,
+    )
+    const total = data.reduce((s, r) => s + r.total, 0) || 1
+    return data.slice(0, 5).map((row) => ({
+      ...row,
+      pct: (row.total / total) * 100,
+      display: getCategoryDisplay(row.category),
+    }))
+  }, [thisMonthTransactions, homeCurrency, fxRate])
+
+  // Monthly sparkline trend (converted+combined for home currency)
+  const monthlyTrend = useMemo(
+    () => buildMonthlyTrendsConverted(transactions, homeCurrency, fxRate).slice(-6),
+    [transactions, homeCurrency, fxRate],
+  )
 
   const recentTransactions = useMemo(
     () =>
@@ -211,32 +181,8 @@ export function Dashboard({
     [transactions],
   )
 
-  const uyuMonthlyTrend = useMemo(() => {
-    const grouped = new Map<string, { income: number; expense: number }>()
-    transactions
-      .filter(
-        (tx) =>
-          tx.currency === 'UYU' &&
-          !isTransferCategory(tx.category) &&
-          !isCategoryIgnored(tx.category),
-      )
-      .forEach((tx) => {
-        const key = `${tx.date.getFullYear()}-${String(tx.date.getMonth() + 1).padStart(2, '0')}`
-        if (!grouped.has(key)) grouped.set(key, { income: 0, expense: 0 })
-        const entry = grouped.get(key)!
-        if (tx.type === 'credit') entry.income += toSafeNumber(tx.amount)
-        else entry.expense += toSafeNumber(tx.amount)
-      })
-    return Array.from(grouped.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([, v]) => v)
-      .slice(-6)
-  }, [transactions])
-
   const firstName = userName ? userName.split('@')[0] : null
   const greeting = firstName ? `Hola, ${firstName} 👋` : 'Hola 👋'
-  const summaryLabel =
-    selectedCurrency === 'USD' ? 'Este mes en dólares' : 'Este mes en pesos'
 
   return (
     <div className="space-y-6">
@@ -254,50 +200,43 @@ export function Dashboard({
           <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 4 }}>
             {greeting}
           </h1>
-          <p
-            className="text-muted-foreground"
-            style={{ fontSize: 14 }}
-          >
-            Esto es lo que pasó en tus cuentas Santander · {monthLabel}
+          <p className="text-muted-foreground" style={{ fontSize: 14 }}>
+            Esto es lo que pasó en tus cuentas Santander · {monthSummary.monthLabel || latestDate.toLocaleDateString('es-UY', { month: 'long', year: 'numeric', timeZone: 'UTC' })}
           </p>
         </div>
         {hasTransactions && (
-          <div
-            style={{
-              display: 'flex',
-              background: 'var(--surface-2)',
-              borderRadius: 10,
-              padding: 3,
-              gap: 2,
-            }}
-          >
-            {(['all', 'UYU', 'USD'] as const).map((val) => (
-              <button
-                key={val}
-                onClick={() => setSelectedCurrency(val)}
-                style={{
-                  padding: '5px 14px',
-                  borderRadius: 7,
-                  fontSize: 13,
-                  fontWeight: 500,
-                  background:
-                    selectedCurrency === val ? 'var(--bg)' : 'transparent',
-                  color:
-                    selectedCurrency === val
-                      ? 'var(--text)'
-                      : 'var(--text-faint)',
-                  border: 'none',
-                  cursor: 'pointer',
-                  transition: 'all 0.15s',
-                  boxShadow:
-                    selectedCurrency === val
-                      ? '0 1px 3px rgba(0,0,0,.08)'
-                      : 'none',
-                }}
-              >
-                {val === 'all' ? 'Todo' : val === 'UYU' ? '$U' : 'US$'}
-              </button>
-            ))}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <FxChip fxRate={fxRate} onSetFxRate={onSetFxRate} />
+            <div
+              style={{
+                display: 'flex',
+                background: 'var(--surface-2)',
+                borderRadius: 10,
+                padding: 3,
+                gap: 2,
+              }}
+            >
+              {(['USD', 'UYU'] as const).map((val) => (
+                <button
+                  key={val}
+                  onClick={() => onSetHomeCurrency?.(val)}
+                  style={{
+                    padding: '5px 14px',
+                    borderRadius: 7,
+                    fontSize: 13,
+                    fontWeight: 500,
+                    background: homeCurrency === val ? 'var(--bg)' : 'transparent',
+                    color: homeCurrency === val ? 'var(--text)' : 'var(--text-faint)',
+                    border: 'none',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                    boxShadow: homeCurrency === val ? '0 1px 3px rgba(0,0,0,.08)' : 'none',
+                  }}
+                >
+                  {val === 'USD' ? 'US$' : '$U'}
+                </button>
+              ))}
+            </div>
           </div>
         )}
       </div>
@@ -326,7 +265,7 @@ export function Dashboard({
 
       {hasTransactions && (
         <>
-          {/* 3 Account cards */}
+          {/* 3 Account cards (native amounts) */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <Card
               className={onNavigateToTransactions ? 'p-5 cursor-pointer' : 'p-5'}
@@ -340,49 +279,30 @@ export function Dashboard({
               <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                 <span
                   style={{
-                    width: 36,
-                    height: 36,
-                    borderRadius: 10,
-                    background: 'var(--surface-2)',
-                    color: 'var(--brand)',
-                    display: 'grid',
-                    placeItems: 'center',
-                    flexShrink: 0,
+                    width: 36, height: 36, borderRadius: 10,
+                    background: 'var(--surface-2)', color: 'var(--brand)',
+                    display: 'grid', placeItems: 'center', flexShrink: 0,
                   }}
                 >
                   <CreditCard size={18} />
                 </span>
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ fontWeight: 600, fontSize: 14 }}>
-                    Tarjeta de Crédito
-                  </div>
-                  <div
-                    className="text-muted-foreground"
-                    style={{ fontSize: 12 }}
-                  >
+                  <div style={{ fontWeight: 600, fontSize: 14 }}>Tarjeta de Crédito</div>
+                  <div className="text-muted-foreground" style={{ fontSize: 12 }}>
                     Santander Mastercard
                   </div>
                 </div>
               </div>
               <div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, fontWeight: 500 }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500 }}>
                   Consumo del período
                 </div>
                 <div style={{ marginTop: 4 }}>
-                  <div
-                    className="font-mono"
-                    style={{ fontSize: 22, color: 'var(--neg)' }}
-                  >
+                  <div className="font-mono" style={{ fontSize: 22, color: 'var(--neg)' }}>
                     {formatCurrency(creditCardSummaryUYU.expenses, 'UYU')}
                   </div>
                   {creditCardSummaryUSD.expenses > 0 && (
-                    <div
-                      className="font-mono text-muted-foreground"
-                      style={{ fontSize: 14, marginTop: 2 }}
-                    >
+                    <div className="font-mono text-muted-foreground" style={{ fontSize: 14, marginTop: 2 }}>
                       {formatCurrency(creditCardSummaryUSD.expenses, 'USD')}
                     </div>
                   )}
@@ -390,12 +310,7 @@ export function Dashboard({
               </div>
               <div
                 className="text-muted-foreground"
-                style={{
-                  fontSize: 12,
-                  marginTop: 'auto',
-                  paddingTop: 8,
-                  borderTop: '1px solid var(--border)',
-                }}
+                style={{ fontSize: 12, marginTop: 'auto', paddingTop: 8, borderTop: '1px solid var(--border)' }}
               >
                 {creditCardTransactions.length} movimientos este período
               </div>
@@ -405,11 +320,7 @@ export function Dashboard({
               className={onNavigateToTransactions ? 'p-5 cursor-pointer' : 'p-5'}
               onClick={
                 onNavigateToTransactions
-                  ? () =>
-                      onNavigateToTransactions({
-                        accountType: 'bank_account',
-                        currency: 'USD',
-                      })
+                  ? () => onNavigateToTransactions({ accountType: 'bank_account', currency: 'USD' })
                   : undefined
               }
               style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
@@ -417,57 +328,34 @@ export function Dashboard({
               <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                 <span
                   style={{
-                    width: 36,
-                    height: 36,
-                    borderRadius: 10,
-                    background: 'var(--surface-2)',
-                    color: 'var(--brand)',
-                    display: 'grid',
-                    placeItems: 'center',
-                    flexShrink: 0,
+                    width: 36, height: 36, borderRadius: 10,
+                    background: 'var(--surface-2)', color: 'var(--brand)',
+                    display: 'grid', placeItems: 'center', flexShrink: 0,
                   }}
                 >
                   <DollarSign size={18} />
                 </span>
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ fontWeight: 600, fontSize: 14 }}>
-                    Cuenta en Dólares
-                  </div>
-                  <div
-                    className="text-muted-foreground"
-                    style={{ fontSize: 12 }}
-                  >
+                  <div style={{ fontWeight: 600, fontSize: 14 }}>Cuenta en Dólares</div>
+                  <div className="text-muted-foreground" style={{ fontSize: 12 }}>
                     Caja de ahorro USD
                   </div>
                 </div>
               </div>
               <div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, fontWeight: 500 }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500 }}>
                   Saldo disponible
                 </div>
                 <div
                   className="font-mono"
-                  style={{
-                    fontSize: 24,
-                    marginTop: 4,
-                    color:
-                      usdBankSummary.balance >= 0 ? 'var(--text)' : 'var(--neg)',
-                  }}
+                  style={{ fontSize: 24, marginTop: 4, color: usdBankSummary.balance >= 0 ? 'var(--text)' : 'var(--neg)' }}
                 >
                   {formatCurrency(usdBankSummary.balance, 'USD')}
                 </div>
               </div>
               <div
                 className="text-muted-foreground"
-                style={{
-                  fontSize: 12,
-                  marginTop: 'auto',
-                  paddingTop: 8,
-                  borderTop: '1px solid var(--border)',
-                }}
+                style={{ fontSize: 12, marginTop: 'auto', paddingTop: 8, borderTop: '1px solid var(--border)' }}
               >
                 {usdBankTransactions.length} movimientos este período
               </div>
@@ -477,11 +365,7 @@ export function Dashboard({
               className={onNavigateToTransactions ? 'p-5 cursor-pointer' : 'p-5'}
               onClick={
                 onNavigateToTransactions
-                  ? () =>
-                      onNavigateToTransactions({
-                        accountType: 'bank_account',
-                        currency: 'UYU',
-                      })
+                  ? () => onNavigateToTransactions({ accountType: 'bank_account', currency: 'UYU' })
                   : undefined
               }
               style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
@@ -489,64 +373,41 @@ export function Dashboard({
               <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                 <span
                   style={{
-                    width: 36,
-                    height: 36,
-                    borderRadius: 10,
-                    background: 'var(--surface-2)',
-                    color: 'var(--brand)',
-                    display: 'grid',
-                    placeItems: 'center',
-                    flexShrink: 0,
+                    width: 36, height: 36, borderRadius: 10,
+                    background: 'var(--surface-2)', color: 'var(--brand)',
+                    display: 'grid', placeItems: 'center', flexShrink: 0,
                   }}
                 >
                   <Landmark size={18} />
                 </span>
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ fontWeight: 600, fontSize: 14 }}>
-                    Cuenta en Pesos
-                  </div>
-                  <div
-                    className="text-muted-foreground"
-                    style={{ fontSize: 12 }}
-                  >
+                  <div style={{ fontWeight: 600, fontSize: 14 }}>Cuenta en Pesos</div>
+                  <div className="text-muted-foreground" style={{ fontSize: 12 }}>
                     Caja de ahorro UYU
                   </div>
                 </div>
               </div>
               <div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, fontWeight: 500 }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500 }}>
                   Saldo disponible
                 </div>
                 <div
                   className="font-mono"
-                  style={{
-                    fontSize: 24,
-                    marginTop: 4,
-                    color:
-                      uyuBankSummary.balance >= 0 ? 'var(--text)' : 'var(--neg)',
-                  }}
+                  style={{ fontSize: 24, marginTop: 4, color: uyuBankSummary.balance >= 0 ? 'var(--text)' : 'var(--neg)' }}
                 >
                   {formatCurrency(uyuBankSummary.balance, 'UYU')}
                 </div>
               </div>
               <div
                 className="text-muted-foreground"
-                style={{
-                  fontSize: 12,
-                  marginTop: 'auto',
-                  paddingTop: 8,
-                  borderTop: '1px solid var(--border)',
-                }}
+                style={{ fontSize: 12, marginTop: 'auto', paddingTop: 8, borderTop: '1px solid var(--border)' }}
               >
                 {uyuBankTransactions.length} movimientos este período
               </div>
             </Card>
           </div>
 
-          {/* Este mes panel */}
+          {/* Este mes panel — converted + combined in home currency */}
           <Card className="p-6">
             <div
               style={{
@@ -557,21 +418,15 @@ export function Dashboard({
               }}
             >
               <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>
-                {summaryLabel}
+                Este mes
               </h2>
               {onNavigateToAnalysis && (
                 <button
                   onClick={onNavigateToAnalysis}
                   style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 4,
-                    fontSize: 13,
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    color: 'var(--brand)',
-                    fontWeight: 500,
+                    display: 'flex', alignItems: 'center', gap: 4,
+                    fontSize: 13, background: 'none', border: 'none',
+                    cursor: 'pointer', color: 'var(--brand)', fontWeight: 500,
                   }}
                 >
                   Ver análisis completo <ArrowRight size={14} />
@@ -580,89 +435,54 @@ export function Dashboard({
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
               <div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}>
                   Ingresos
                 </div>
-                <div
-                  className="font-mono"
-                  style={{ fontSize: 22, color: 'var(--pos)' }}
-                >
-                  {formatCurrency(panelSummary.income, panelCurrency)}
+                <div className="font-mono" style={{ fontSize: 22, color: 'var(--pos)' }}>
+                  {formatCurrency(monthSummary.income, homeCurrency)}
                 </div>
-                {selectedCurrency === 'all' && thisMonthSummaryUSD.income > 0 && (
-                  <div
-                    className="font-mono text-muted-foreground"
-                    style={{ fontSize: 13, marginTop: 2 }}
-                  >
-                    {formatCurrency(thisMonthSummaryUSD.income, 'USD')}
-                  </div>
-                )}
-                {uyuMonthlyTrend.length > 1 && selectedCurrency !== 'USD' && (
+                {monthlyTrend.length > 1 && (
                   <div style={{ marginTop: 12 }}>
-                    <MiniBars
-                      values={uyuMonthlyTrend.map((m) => m.income)}
-                      color="var(--pos)"
-                    />
+                    <MiniBars values={monthlyTrend.map((m) => m.income)} color="var(--pos)" />
                   </div>
                 )}
               </div>
               <div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}>
                   Gastos
                 </div>
-                <div
-                  className="font-mono"
-                  style={{ fontSize: 22, color: 'var(--neg)' }}
-                >
-                  {formatCurrency(panelSummary.expenses, panelCurrency)}
+                <div className="font-mono" style={{ fontSize: 22, color: 'var(--neg)' }}>
+                  {formatCurrency(monthSummary.expense, homeCurrency)}
                 </div>
-                {selectedCurrency === 'all' &&
-                  thisMonthSummaryUSD.expenses > 0 && (
-                    <div
-                      className="font-mono text-muted-foreground"
-                      style={{ fontSize: 13, marginTop: 2 }}
-                    >
-                      {formatCurrency(thisMonthSummaryUSD.expenses, 'USD')}
-                    </div>
-                  )}
-                {uyuMonthlyTrend.length > 1 && selectedCurrency !== 'USD' && (
+                {homeCurrency === 'USD' && monthSummary.split.UYU > 0 && (
+                  <div className="text-muted-foreground" style={{ fontSize: 12, marginTop: 4 }}>
+                    {formatCurrency(monthSummary.split.USD, 'USD')} + {formatCurrency(monthSummary.split.UYU, 'UYU')} nativo
+                  </div>
+                )}
+                {homeCurrency === 'UYU' && monthSummary.split.USD > 0 && (
+                  <div className="text-muted-foreground" style={{ fontSize: 12, marginTop: 4 }}>
+                    {formatCurrency(monthSummary.split.UYU, 'UYU')} + {formatCurrency(monthSummary.split.USD, 'USD')} nativo
+                  </div>
+                )}
+                {monthlyTrend.length > 1 && (
                   <div style={{ marginTop: 12 }}>
-                    <MiniBars
-                      values={uyuMonthlyTrend.map((m) => m.expense)}
-                      color="var(--neg)"
-                    />
+                    <MiniBars values={monthlyTrend.map((m) => m.expense)} color="var(--neg)" />
                   </div>
                 )}
               </div>
               <div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}
-                >
+                <div className="text-muted-foreground" style={{ fontSize: 12, fontWeight: 500, marginBottom: 4 }}>
                   Balance neto
                 </div>
                 <div
                   className="font-mono"
-                  style={{
-                    fontSize: 22,
-                    color:
-                      panelSummary.balance >= 0 ? 'var(--pos)' : 'var(--neg)',
-                  }}
+                  style={{ fontSize: 22, color: monthSummary.net >= 0 ? 'var(--pos)' : 'var(--neg)' }}
                 >
-                  {panelSummary.balance >= 0 ? '+' : '−'}
-                  {formatCurrency(Math.abs(panelSummary.balance), panelCurrency)}
+                  {monthSummary.net >= 0 ? '+' : '−'}
+                  {formatCurrency(Math.abs(monthSummary.net), homeCurrency)}
                 </div>
-                <div
-                  className="text-muted-foreground"
-                  style={{ fontSize: 12, marginTop: 8 }}
-                >
-                  {thisMonthTransactions.length} transacciones registradas
+                <div className="text-muted-foreground" style={{ fontSize: 12, marginTop: 8 }}>
+                  {monthSummary.count} transacciones registradas
                 </div>
               </div>
             </div>
@@ -673,10 +493,8 @@ export function Dashboard({
             <Card className="p-6">
               <div
                 style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  marginBottom: 18,
+                  display: 'flex', justifyContent: 'space-between',
+                  alignItems: 'center', marginBottom: 18,
                 }}
               >
                 <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>
@@ -686,12 +504,8 @@ export function Dashboard({
                   <button
                     onClick={onNavigateToAnalysis}
                     style={{
-                      fontSize: 13,
-                      background: 'none',
-                      border: 'none',
-                      cursor: 'pointer',
-                      color: 'var(--brand)',
-                      fontWeight: 500,
+                      fontSize: 13, background: 'none', border: 'none',
+                      cursor: 'pointer', color: 'var(--brand)', fontWeight: 500,
                     }}
                   >
                     Detalle
@@ -699,10 +513,7 @@ export function Dashboard({
                 )}
               </div>
               {categoryBreakdown.length === 0 ? (
-                <p
-                  className="text-muted-foreground"
-                  style={{ fontSize: 13 }}
-                >
+                <p className="text-muted-foreground" style={{ fontSize: 13 }}>
                   Sin gastos registrados este mes.
                 </p>
               ) : (
@@ -710,63 +521,42 @@ export function Dashboard({
                   {categoryBreakdown.map((row) => (
                     <div
                       key={row.category}
-                      onClick={() =>
-                        onNavigateToTransactions?.({ category: row.category })
-                      }
-                      style={{
-                        cursor: onNavigateToTransactions ? 'pointer' : 'default',
-                      }}
+                      onClick={() => onNavigateToTransactions?.({ category: row.category })}
+                      style={{ cursor: onNavigateToTransactions ? 'pointer' : 'default' }}
                     >
                       <div
                         style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'baseline',
-                          marginBottom: 5,
+                          display: 'flex', justifyContent: 'space-between',
+                          alignItems: 'baseline', marginBottom: 5,
                         }}
                       >
                         <span
                           style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: 7,
-                            fontSize: 13.5,
-                            fontWeight: 500,
+                            display: 'inline-flex', alignItems: 'center',
+                            gap: 7, fontSize: 13.5, fontWeight: 500,
                           }}
                         >
                           <span
                             style={{
-                              width: 9,
-                              height: 9,
-                              borderRadius: 3,
-                              background: row.display.color,
-                              display: 'inline-block',
-                              flexShrink: 0,
+                              width: 9, height: 9, borderRadius: 3,
+                              background: row.display.color, display: 'inline-block', flexShrink: 0,
                             }}
                           />
                           {row.display.label}
                         </span>
-                        <span
-                          className="font-mono"
-                          style={{ fontSize: 13 }}
-                        >
-                          {formatCurrency(row.amount, panelCurrency)}
+                        <span className="font-mono" style={{ fontSize: 13 }}>
+                          {formatCurrency(row.total, homeCurrency)}
                         </span>
                       </div>
                       <div
                         style={{
-                          height: 4,
-                          borderRadius: 2,
-                          background: 'var(--surface-2)',
-                          overflow: 'hidden',
+                          height: 4, borderRadius: 2, background: 'var(--surface-2)', overflow: 'hidden',
                         }}
                       >
                         <div
                           style={{
-                            height: '100%',
-                            width: `${row.pct}%`,
-                            background: row.display.color,
-                            borderRadius: 2,
+                            height: '100%', width: `${row.pct}%`,
+                            background: row.display.color, borderRadius: 2,
                           }}
                         />
                       </div>
@@ -779,10 +569,8 @@ export function Dashboard({
             <Card className="p-6">
               <div
                 style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  marginBottom: 14,
+                  display: 'flex', justifyContent: 'space-between',
+                  alignItems: 'center', marginBottom: 14,
                 }}
               >
                 <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>
@@ -792,15 +580,9 @@ export function Dashboard({
                   <button
                     onClick={() => onNavigateToTransactions({})}
                     style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 4,
-                      fontSize: 13,
-                      background: 'none',
-                      border: 'none',
-                      cursor: 'pointer',
-                      color: 'var(--brand)',
-                      fontWeight: 500,
+                      display: 'flex', alignItems: 'center', gap: 4,
+                      fontSize: 13, background: 'none', border: 'none',
+                      cursor: 'pointer', color: 'var(--brand)', fontWeight: 500,
                     }}
                   >
                     Ver todos <ArrowRight size={14} />
@@ -809,34 +591,27 @@ export function Dashboard({
               </div>
               <div style={{ display: 'flex', flexDirection: 'column' }}>
                 {recentTransactions.map((tx, i) => {
-                  const catDef = getCategoryDefinition(
-                    tx.category ?? 'uncategorized',
-                  )
+                  const catDef = getCategoryDefinition(tx.category ?? 'uncategorized')
                   const isCredit = tx.type === 'credit'
+                  const showConverted = tx.currency !== homeCurrency
+                  const convertedAmt = showConverted
+                    ? convert(tx.amount, tx.currency, homeCurrency, fxRate)
+                    : null
                   return (
                     <div
                       key={tx.id}
                       style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 12,
+                        display: 'flex', alignItems: 'center', gap: 12,
                         padding: '10px 0',
-                        borderBottom:
-                          i < recentTransactions.length - 1
-                            ? '1px solid var(--border)'
-                            : 'none',
+                        borderBottom: i < recentTransactions.length - 1 ? '1px solid var(--border)' : 'none',
                       }}
                     >
                       <span
                         style={{
-                          width: 32,
-                          height: 32,
-                          borderRadius: 9,
+                          width: 32, height: 32, borderRadius: 9,
                           background: catDef.color + '1f',
-                          display: 'grid',
-                          placeItems: 'center',
-                          flexShrink: 0,
-                          fontSize: 15,
+                          display: 'grid', placeItems: 'center',
+                          flexShrink: 0, fontSize: 15,
                         }}
                       >
                         {catDef.icon}
@@ -844,36 +619,33 @@ export function Dashboard({
                       <div style={{ minWidth: 0, flex: 1 }}>
                         <div
                           style={{
-                            fontSize: 13.5,
-                            fontWeight: 500,
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
+                            fontSize: 13.5, fontWeight: 500,
+                            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
                           }}
                         >
-                          {tx.description}
+                          {tx.displayDescription ?? tx.description}
                         </div>
-                        <div
-                          className="text-muted-foreground"
-                          style={{ fontSize: 11.5 }}
-                        >
-                          {tx.date.toLocaleDateString('es-UY', {
-                            day: 'numeric',
-                            month: 'short',
-                          })}
+                        <div className="text-muted-foreground" style={{ fontSize: 11.5 }}>
+                          {tx.date.toLocaleDateString('es-UY', { day: 'numeric', month: 'short' })}
                         </div>
                       </div>
-                      <span
-                        className="font-mono"
-                        style={{
-                          fontSize: 13.5,
-                          color: isCredit ? 'var(--pos)' : 'var(--text)',
-                          flexShrink: 0,
-                        }}
-                      >
-                        {isCredit ? '+' : '−'}
-                        {formatCurrency(tx.amount, tx.currency)}
-                      </span>
+                      <div style={{ flexShrink: 0, textAlign: 'right' }}>
+                        <span
+                          className="font-mono"
+                          style={{ fontSize: 13.5, color: isCredit ? 'var(--pos)' : 'var(--text)', display: 'block' }}
+                        >
+                          {isCredit ? '+' : '−'}
+                          {formatCurrency(tx.amount, tx.currency)}
+                        </span>
+                        {showConverted && convertedAmt !== null && (
+                          <span
+                            className="font-mono text-muted-foreground"
+                            style={{ fontSize: 11, display: 'block' }}
+                          >
+                            ≈ {formatCurrency(convertedAmt, homeCurrency)}
+                          </span>
+                        )}
+                      </div>
                     </div>
                   )
                 })}

--- a/src/components/FxChip.tsx
+++ b/src/components/FxChip.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import { Pencil } from 'lucide-react'
+
+interface FxChipProps {
+  fxRate: number
+  onSetFxRate?: (r: number) => void
+}
+
+export function FxChip({ fxRate, onSetFxRate }: FxChipProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+
+  const label = `1 US$ = $U ${fxRate.toFixed(2)}`
+
+  if (!onSetFxRate) {
+    return (
+      <span
+        style={{ fontSize: 12, color: 'var(--text-faint)', userSelect: 'none' }}
+      >
+        {label}
+      </span>
+    )
+  }
+
+  if (editing) {
+    return (
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          fontSize: 12,
+          color: 'var(--text-muted)',
+        }}
+      >
+        1 US$ = $U{' '}
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              const n = parseFloat(draft)
+              if (Number.isFinite(n) && n > 0) onSetFxRate(n)
+              setEditing(false)
+            }
+            if (e.key === 'Escape') {
+              setEditing(false)
+            }
+          }}
+          onBlur={() => {
+            const n = parseFloat(draft)
+            if (Number.isFinite(n) && n > 0) onSetFxRate(n)
+            setEditing(false)
+          }}
+          autoFocus
+          style={{
+            width: 56,
+            fontSize: 12,
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            padding: '1px 5px',
+            background: 'var(--surface)',
+            color: 'var(--text)',
+            outline: 'none',
+          }}
+        />
+      </span>
+    )
+  }
+
+  return (
+    <button
+      onClick={() => {
+        setDraft(String(fxRate))
+        setEditing(true)
+      }}
+      title="Editar tipo de cambio"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        fontSize: 12,
+        background: 'none',
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        padding: '3px 8px',
+        cursor: 'pointer',
+        color: 'var(--text-muted)',
+        lineHeight: 1,
+      }}
+    >
+      {label}
+      <Pencil size={10} />
+    </button>
+  )
+}

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -92,7 +92,7 @@ describe('Settings', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Dólares' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Dólares US$' }))
     expect(onSetCurrency).toHaveBeenCalledWith('USD')
   })
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -10,6 +10,8 @@ interface SettingsProps {
   onSetTheme: (t: 'light' | 'dark' | 'auto') => void
   preferredCurrency: 'UYU' | 'USD'
   onSetCurrency: (c: 'UYU' | 'USD') => void
+  fxRate?: number
+  onSetFxRate?: (r: number) => void
   session: SupabaseSession | null
   supabaseEnabled: boolean
   onSignOut: () => void
@@ -141,6 +143,8 @@ export function Settings({
   onSetTheme,
   preferredCurrency,
   onSetCurrency,
+  fxRate = 40.5,
+  onSetFxRate,
   session,
   supabaseEnabled,
   onSignOut,
@@ -206,32 +210,58 @@ export function Settings({
             />
           }
         />
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 24,
-            padding: '16px 24px',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text)' }}>
-              Moneda principal
+      </SectionCard>
+
+      {/* Monedas */}
+      <SectionCard title="Monedas">
+        <SettingRow
+          label="Moneda principal"
+          description="Moneda en la que se convierten y combinan todos los totales"
+          control={
+            <SegmentControl
+              options={[
+                { label: 'Pesos $U', value: 'UYU' },
+                { label: 'Dólares US$', value: 'USD' },
+              ]}
+              value={preferredCurrency}
+              onChange={(v) => onSetCurrency(v as 'UYU' | 'USD')}
+            />
+          }
+        />
+        <SettingRow
+          label="Tipo de cambio"
+          description="Usado para convertir entre USD y UYU en resúmenes y análisis"
+          control={
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 13, color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>
+                1 US$ =
+              </span>
+              <input
+                type="number"
+                min="0.01"
+                step="0.5"
+                value={fxRate}
+                onChange={(e) => {
+                  const n = parseFloat(e.target.value)
+                  if (Number.isFinite(n) && n > 0) onSetFxRate?.(n)
+                }}
+                style={{
+                  width: 72,
+                  fontSize: 13,
+                  fontFamily: 'var(--font-mono)',
+                  border: '1px solid var(--border)',
+                  borderRadius: 6,
+                  padding: '5px 8px',
+                  background: 'var(--surface)',
+                  color: 'var(--text)',
+                  outline: 'none',
+                  textAlign: 'right',
+                }}
+              />
+              <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>$U</span>
             </div>
-            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>
-              Moneda por defecto en resúmenes
-            </div>
-          </div>
-          <SegmentControl
-            options={[
-              { label: 'Pesos', value: 'UYU' },
-              { label: 'Dólares', value: 'USD' },
-            ]}
-            value={preferredCurrency}
-            onChange={(v) => onSetCurrency(v as 'UYU' | 'USD')}
-          />
-        </div>
+          }
+        />
       </SectionCard>
 
       {/* Cuenta */}

--- a/src/services/charts/chart-data.test.ts
+++ b/src/services/charts/chart-data.test.ts
@@ -3,6 +3,10 @@ import {
   buildCategorySpending,
   buildIncomeExpenseSummary,
   buildMonthlyTrends,
+  buildCategorySpendingConverted,
+  buildMonthlyTrendsConverted,
+  buildCurrentMonthSummary,
+  buildCurrencySplit,
 } from './chart-data'
 import type { Transaction } from '../../models'
 import { Category } from '../../models'
@@ -114,7 +118,7 @@ describe('chart-data', () => {
     })
   })
 
-  it('excludes transfer category from spending and summary metrics', () => {
+  it('excludes transfer category from spending and summary metrics (original)', () => {
     const transactions = [
       makeTransaction('tx-1', {
         amount: 200,
@@ -144,6 +148,123 @@ describe('chart-data', () => {
       income: 0,
       expense: 80,
       net: -80,
+    })
+  })
+})
+
+describe('chart-data multicurrency converting selectors', () => {
+  const RATE = 40
+
+  function makeTx(
+    id: string,
+    overrides: Partial<Transaction> = {}
+  ): Transaction {
+    return {
+      id,
+      date: new Date('2025-01-15T00:00:00.000Z'),
+      description: `tx-${id}`,
+      amount: 10,
+      currency: 'USD',
+      type: 'debit',
+      source: 'bank_account',
+      rawData: {},
+      ...overrides,
+    }
+  }
+
+  describe('buildCategorySpendingConverted', () => {
+    it('converts USD expenses to UYU when home is UYU', () => {
+      const txs = [
+        makeTx('1', { amount: 10, currency: 'USD', type: 'debit', category: Category.Groceries }),
+        makeTx('2', { amount: 400, currency: 'UYU', type: 'debit', category: Category.Groceries }),
+      ]
+      const result = buildCategorySpendingConverted(txs, 'UYU', RATE)
+      expect(result).toHaveLength(1)
+      expect(result[0].category).toBe(Category.Groceries)
+      expect(result[0].total).toBeCloseTo(800) // 10*40 + 400
+    })
+
+    it('excludes credits and transfers', () => {
+      const txs = [
+        makeTx('1', { type: 'credit', category: Category.Groceries }),
+        makeTx('2', { type: 'debit', category: Category.Transfer }),
+        makeTx('3', { type: 'debit', category: Category.Groceries, amount: 20 }),
+      ]
+      const result = buildCategorySpendingConverted(txs, 'USD', RATE)
+      expect(result).toHaveLength(1)
+      expect(result[0].total).toBe(20)
+    })
+  })
+
+  describe('buildMonthlyTrendsConverted', () => {
+    it('combines USD and UYU amounts for same month into home currency', () => {
+      const txs = [
+        makeTx('1', { amount: 10, currency: 'USD', type: 'credit', date: new Date('2025-01-10T00:00:00.000Z') }),
+        makeTx('2', { amount: 200, currency: 'UYU', type: 'debit', date: new Date('2025-01-20T00:00:00.000Z') }),
+      ]
+      const result = buildMonthlyTrendsConverted(txs, 'UYU', RATE)
+      expect(result).toHaveLength(1)
+      expect(result[0].month).toBe('2025-01')
+      expect(result[0].income).toBeCloseTo(400) // 10 USD * 40
+      expect(result[0].expense).toBeCloseTo(200) // 200 UYU
+      expect(result[0].net).toBeCloseTo(200)
+    })
+  })
+
+  describe('buildCurrentMonthSummary', () => {
+    it('returns zeros for empty transactions', () => {
+      const result = buildCurrentMonthSummary([], 'USD', RATE)
+      expect(result.income).toBe(0)
+      expect(result.expense).toBe(0)
+    })
+
+    it('computes latest-month totals in home currency', () => {
+      const txs = [
+        makeTx('old', { date: new Date('2024-11-01T00:00:00.000Z'), type: 'debit', amount: 999 }),
+        makeTx('inc', { date: new Date('2025-01-15T00:00:00.000Z'), type: 'credit', amount: 100, currency: 'USD' }),
+        makeTx('exp-usd', { date: new Date('2025-01-20T00:00:00.000Z'), type: 'debit', amount: 20, currency: 'USD' }),
+        makeTx('exp-uyu', { date: new Date('2025-01-25T00:00:00.000Z'), type: 'debit', amount: 400, currency: 'UYU' }),
+      ]
+      const result = buildCurrentMonthSummary(txs, 'USD', RATE)
+      expect(result.income).toBeCloseTo(100) // 100 USD income
+      expect(result.expense).toBeCloseTo(30) // 20 USD + 400/40 USD = 30
+      expect(result.net).toBeCloseTo(70)
+      expect(result.split.USD).toBeCloseTo(20)
+      expect(result.split.UYU).toBeCloseTo(400)
+    })
+
+    it('excludes transfers', () => {
+      const txs = [
+        makeTx('t', { date: new Date('2025-01-10T00:00:00.000Z'), type: 'debit', amount: 100, category: Category.Transfer }),
+        makeTx('e', { date: new Date('2025-01-10T00:00:00.000Z'), type: 'debit', amount: 50 }),
+      ]
+      const result = buildCurrentMonthSummary(txs, 'USD', RATE)
+      expect(result.expense).toBe(50)
+    })
+  })
+
+  describe('buildCurrencySplit', () => {
+    it('returns correct percentages for mixed spend', () => {
+      const txs = [
+        makeTx('usd', { amount: 1, currency: 'USD', type: 'debit' }),
+        makeTx('uyu', { amount: RATE, currency: 'UYU', type: 'debit' }),
+      ]
+      // Both equal 1 USD each → 50/50
+      const result = buildCurrencySplit(txs, 'USD', RATE)
+      expect(result.pctUSD).toBeCloseTo(50)
+      expect(result.pctUYU).toBeCloseTo(50)
+    })
+
+    it('excludes credits and transfers from the split', () => {
+      const txs = [
+        makeTx('credit', { type: 'credit', amount: 100 }),
+        makeTx('transfer', { type: 'debit', category: Category.Transfer, amount: 100 }),
+        makeTx('real', { type: 'debit', amount: 50, currency: 'USD' }),
+      ]
+      const result = buildCurrencySplit(txs, 'USD', RATE)
+      expect(result.USD).toBe(50)
+      expect(result.UYU).toBe(0)
+      expect(result.pctUSD).toBeCloseTo(100)
     })
   })
 })

--- a/src/services/charts/chart-data.ts
+++ b/src/services/charts/chart-data.ts
@@ -2,6 +2,7 @@ import type { Currency, Transaction } from '../../models'
 import { Category } from '../../models'
 import { isTransferCategory } from '../transfers/internal-transfers'
 import { isCategoryIgnored } from '../categories/category-registry'
+import { convert } from '../currency/convert'
 
 export interface CategorySpendingDatum {
   category: string
@@ -117,4 +118,163 @@ export function buildIncomeExpenseSummary(
     },
     { income: 0, expense: 0, net: 0 }
   )
+}
+
+// --- Multicurrency converting selectors ---
+// All functions below accept (transactions, homeCurrency, fxRate) and
+// convert every amount to homeCurrency before aggregating.
+
+export interface MonthSummary {
+  income: number
+  expense: number
+  net: number
+  count: number
+  split: { USD: number; UYU: number }
+  monthLabel: string
+}
+
+export interface CurrencySplitData {
+  USD: number
+  UYU: number
+  total: number
+  pctUSD: number
+  pctUYU: number
+}
+
+function shouldExclude(tx: Transaction): boolean {
+  return isTransferCategory(tx.category) || isCategoryIgnored(tx.category)
+}
+
+export function buildCategorySpendingConverted(
+  transactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number
+): CategorySpendingDatum[] {
+  const grouped = new Map<string, number>()
+
+  transactions.forEach((tx) => {
+    if (tx.type !== 'debit' || shouldExclude(tx)) return
+    const category = tx.category ?? Category.Uncategorized
+    const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
+    grouped.set(category, (grouped.get(category) ?? 0) + converted)
+  })
+
+  return Array.from(grouped.entries())
+    .map(([category, total]) => ({ category, total }))
+    .sort((a, b) => b.total - a.total)
+}
+
+export function buildMonthlyTrendsConverted(
+  transactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number
+): MonthlyTrendDatum[] {
+  const grouped = new Map<string, MonthlyTrendDatum>()
+
+  transactions.forEach((tx) => {
+    if (shouldExclude(tx)) return
+    const month = toMonthKey(tx.date)
+    if (!grouped.has(month)) {
+      grouped.set(month, { month, income: 0, expense: 0, net: 0 })
+    }
+    const entry = grouped.get(month)!
+    const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
+    if (tx.type === 'credit') {
+      entry.income += converted
+      entry.net += converted
+    } else {
+      entry.expense += converted
+      entry.net -= converted
+    }
+  })
+
+  return Array.from(grouped.values()).sort((a, b) =>
+    a.month.localeCompare(b.month)
+  )
+}
+
+export function buildCurrentMonthSummary(
+  transactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number
+): MonthSummary {
+  if (transactions.length === 0) {
+    return {
+      income: 0,
+      expense: 0,
+      net: 0,
+      count: 0,
+      split: { USD: 0, UYU: 0 },
+      monthLabel: '',
+    }
+  }
+
+  const latest = transactions.reduce(
+    (max, tx) => (tx.date > max ? tx.date : max),
+    transactions[0].date
+  )
+  const m = latest.getUTCMonth()
+  const y = latest.getUTCFullYear()
+
+  const monthTxs = transactions.filter((tx) => {
+    return (
+      tx.date.getUTCFullYear() === y &&
+      tx.date.getUTCMonth() === m &&
+      !shouldExclude(tx)
+    )
+  })
+
+  let income = 0
+  let expense = 0
+  const split: { USD: number; UYU: number } = { USD: 0, UYU: 0 }
+
+  monthTxs.forEach((tx) => {
+    const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
+    if (tx.type === 'credit') {
+      income += converted
+    } else {
+      expense += converted
+      split[tx.currency] += tx.amount
+    }
+  })
+
+  const monthLabel = latest.toLocaleDateString('es-UY', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+
+  return {
+    income,
+    expense,
+    net: income - expense,
+    count: monthTxs.length,
+    split,
+    monthLabel,
+  }
+}
+
+export function buildCurrencySplit(
+  transactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number
+): CurrencySplitData {
+  let usd = 0
+  let uyu = 0
+
+  transactions.forEach((tx) => {
+    if (tx.type !== 'debit' || shouldExclude(tx)) return
+    const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
+    if (tx.currency === 'USD') usd += converted
+    else uyu += converted
+  })
+
+  const total = usd + uyu || 1
+  return {
+    USD: usd,
+    UYU: uyu,
+    total: usd + uyu,
+    pctUSD: (usd / total) * 100,
+    pctUYU: (uyu / total) * 100,
+  }
 }

--- a/src/services/currency/convert.test.ts
+++ b/src/services/currency/convert.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { convert } from './convert'
+
+describe('convert', () => {
+  it('returns amount unchanged when from and to are the same currency', () => {
+    expect(convert(100, 'USD', 'USD', 40)).toBe(100)
+    expect(convert(500, 'UYU', 'UYU', 40)).toBe(500)
+  })
+
+  it('converts USD to UYU by multiplying by rate', () => {
+    expect(convert(1, 'USD', 'UYU', 40)).toBe(40)
+    expect(convert(10, 'USD', 'UYU', 40.5)).toBeCloseTo(405)
+  })
+
+  it('converts UYU to USD by dividing by rate', () => {
+    expect(convert(40, 'UYU', 'USD', 40)).toBe(1)
+    expect(convert(81, 'UYU', 'USD', 40.5)).toBeCloseTo(2)
+  })
+
+  it('throws for zero rate', () => {
+    expect(() => convert(100, 'USD', 'UYU', 0)).toThrow(
+      'FX rate must be a positive finite number'
+    )
+  })
+
+  it('throws for negative rate', () => {
+    expect(() => convert(100, 'USD', 'UYU', -1)).toThrow(
+      'FX rate must be a positive finite number'
+    )
+  })
+
+  it('throws for NaN rate', () => {
+    expect(() => convert(100, 'USD', 'UYU', NaN)).toThrow(
+      'FX rate must be a positive finite number'
+    )
+  })
+})

--- a/src/services/currency/convert.ts
+++ b/src/services/currency/convert.ts
@@ -1,0 +1,15 @@
+import type { Currency } from '../../models'
+
+// rate: 1 USD = rate UYU (e.g., 40.5 means 1 USD = 40.5 UYU)
+export function convert(
+  amount: number,
+  from: Currency,
+  to: Currency,
+  rate: number
+): number {
+  if (from === to) return amount
+  if (!Number.isFinite(rate) || rate <= 0) {
+    throw new Error('FX rate must be a positive finite number')
+  }
+  return from === 'USD' ? amount * rate : amount / rate
+}


### PR DESCRIPTION
## Summary

- Add `convert()` bidirectional USD↔UYU pure function with full test coverage
- Rewrite Dashboard and Charts to use convert+combine model — all Resumen/Análisis totals fold into the chosen home currency (US$ or \$U) rather than being split by currency
- New `FxChip` inline-editable FX rate chip in dashboard/analysis headers (persists to localStorage)
- Four new chart-data selectors: `buildCategorySpendingConverted`, `buildMonthlyTrendsConverted`, `buildCurrentMonthSummary`, `buildCurrencySplit`
- Settings: new **Monedas** section with home currency selector + FX rate field
- Default home currency is **USD** per spec; `fxRate` defaults to 40.5

## Test plan

- [ ] 554 tests pass (`npm run tdd:verify`)
- [ ] TypeScript compiles + Vite build succeeds (`npm run ci:check`)
- [ ] US$ ↔ \$U toggle re-converts all totals live on Resumen and Análisis
- [ ] FxChip: click to edit, Enter/blur to confirm, Escape to cancel; totals propagate immediately
- [ ] Secondary `≈ converted` line appears only when tx.currency ≠ homeCurrency
- [ ] Transfer transactions excluded from expense totals
- [ ] FX rate persists across page reload (localStorage key `tatu:preferences:fxRate`)
- [ ] Dark mode: warm espresso theme applies to all new/rewritten components