### PR TITLE
fix: don't treat external person transfers as internal

### DIFF
--- a/src/services/categorizer/transaction-categorizer.test.ts
+++ b/src/services/categorizer/transaction-categorizer.test.ts
@@ -80,6 +80,51 @@ describe('Transaction Categorizer', () => {
     expect(result.category).toBe(Category.Transfer)
   })
 
+  it('should not categorize TRF. PLAZA- NAME transfers as Transfer', () => {
+    const result = categorizeTransaction(
+      'TRANSFERENCIA ENVIADA 797258TT55557944 TRF. PLAZA- FEDERICO GAZZANO',
+      'debit'
+    )
+
+    expect(result.category).not.toBe(Category.Transfer)
+  })
+
+  it('should not categorize DEBITO OPERACION EN BANCA DIGITAL TRF. PLAZA- NAME as Transfer', () => {
+    const result = categorizeTransaction(
+      'DEBITO OPERACION EN BANCA DIGITAL 526741TT55770545 TRF. PLAZA- ISABEL ARISMENDI',
+      'debit'
+    )
+
+    expect(result.category).not.toBe(Category.Transfer)
+  })
+
+  it('should not categorize TRANSF INSTANTANEA ENVIADA NRR: NAME as Transfer', () => {
+    const result = categorizeTransaction(
+      'TRANSF INSTANTANEA ENVIADA 381239LE NRR:182500517 JOSE PREX',
+      'debit'
+    )
+
+    expect(result.category).not.toBe(Category.Transfer)
+  })
+
+  it('should not categorize DEBITO OPERACION EN SUPERNET TRF. PLAZA- NAME as Transfer', () => {
+    const result = categorizeTransaction(
+      'DEBITO OPERACION EN SUPERNET O SMS 466949TT55365654 TRF. PLAZA- MATEO RODRIGUEZ',
+      'debit'
+    )
+
+    expect(result.category).not.toBe(Category.Transfer)
+  })
+
+  it('should still categorize TRF. PLAZA without a named recipient as Transfer', () => {
+    const result = categorizeTransaction(
+      'TRANSFERENCIA ENVIADA 754934TT55557465 TRF. PLAZA',
+      'debit'
+    )
+
+    expect(result.category).toBe(Category.Transfer)
+  })
+
   it('should categorize income when credit matches income keywords', () => {
     const result = categorizeTransaction(
       'CR. PAGO SUELDOS 20251106_0610426 SETA WORKSHOP SRL',

--- a/src/services/categorizer/transaction-categorizer.ts
+++ b/src/services/categorizer/transaction-categorizer.ts
@@ -14,6 +14,9 @@ import {
   type TemporalPattern,
 } from './temporal-patterns'
 
+// Matches "TRF. PLAZA- NAME", "TRF. BROU- NAME", or "NRR:182500517 JOSE PREX"
+const EXTERNAL_BENEFICIARY_RE = /trf\.\s*\w+\s*-\s*[a-z]|nrr:[a-z0-9]+\s+[a-z]/
+
 const FEE_KEYWORDS = [
   'comision',
   'cargo',
@@ -137,8 +140,11 @@ export function categorizeTransaction(
     }
   }
 
-  // 5. Transfer keywords
-  if (matchesAny(normalized, TRANSFER_KEYWORDS)) {
+  // 5. Transfer keywords — skip if description names an external beneficiary
+  if (
+    matchesAny(normalized, TRANSFER_KEYWORDS) &&
+    !EXTERNAL_BENEFICIARY_RE.test(normalized)
+  ) {
     return {
       category: Category.Transfer,
       confidence: 0.9,

--- a/src/services/transfers/internal-transfers.test.ts
+++ b/src/services/transfers/internal-transfers.test.ts
@@ -71,4 +71,57 @@ describe('internal transfer inference', () => {
     expect(isTransferCategory('groceries')).toBe(false)
     expect(isTransferCategory(undefined)).toBe(false)
   })
+
+  it('does not mark TRANSFERENCIA ENVIADA TRF. PLAZA- NAME as Transfer', () => {
+    const result = inferInternalTransfers([
+      makeTransaction('debit-ext', {
+        description:
+          'TRANSFERENCIA ENVIADA 797258TT55557944 TRF. PLAZA- FEDERICO GAZZANO',
+        type: 'debit',
+        amount: 476.81,
+        currency: 'UYU',
+        // No initial category — simulating fresh import
+      }),
+    ])
+
+    const debit = result.find((tx) => tx.id === 'debit-ext')!
+    expect(debit.category).not.toBe(Category.Transfer)
+  })
+
+  it('does not mark TRANSF INSTANTANEA ENVIADA NRR: NAME as Transfer', () => {
+    const result = inferInternalTransfers([
+      makeTransaction('debit-ext', {
+        description:
+          'TRANSF INSTANTANEA ENVIADA 381239LE NRR:182500517 JOSE PREX',
+        type: 'debit',
+        amount: 250,
+        currency: 'UYU',
+        // No initial category — simulating fresh import
+      }),
+    ])
+
+    const debit = result.find((tx) => tx.id === 'debit-ext')!
+    expect(debit.category).not.toBe(Category.Transfer)
+  })
+
+  it('still marks legitimate internal transfers as Transfer', () => {
+    const result = inferInternalTransfers([
+      makeTransaction('debit-int', {
+        description: 'Transferencia enviada supernet ref 999999',
+        type: 'debit',
+        amount: 1500,
+        currency: 'UYU',
+        rawData: { referencia: '999999' },
+      }),
+      makeTransaction('credit-int', {
+        description: 'Transferencia recibida supernet ref 999999',
+        type: 'credit',
+        amount: 1500,
+        currency: 'UYU',
+        rawData: { referencia: '999999' },
+      }),
+    ])
+
+    expect(result.every((tx) => tx.category === Category.Transfer)).toBe(true)
+  })
 })

--- a/src/services/transfers/internal-transfers.ts
+++ b/src/services/transfers/internal-transfers.ts
@@ -14,6 +14,11 @@ const TRANSFER_DESCRIPTION_KEYWORDS = [
   'cambio moneda',
 ]
 
+// Matches "TRF. PLAZA- NAME", "TRF. BROU- NAME", or "NRR:182500517 JOSE PREX"
+// These patterns indicate a named external beneficiary, so the transaction cannot
+// be an internal (own-account) transfer.
+const EXTERNAL_BENEFICIARY_RE = /trf\.\s*\w+\s*-\s*[a-z]|nrr:[a-z0-9]+\s+[a-z]/
+
 function normalizeText(value: string | undefined): string {
   return (value ?? '').toLowerCase().trim().replace(/\s+/g, ' ')
 }
@@ -42,6 +47,10 @@ function isTransferDescription(description: string): boolean {
   return TRANSFER_DESCRIPTION_KEYWORDS.some((keyword) =>
     normalized.includes(keyword)
   )
+}
+
+function hasExternalBeneficiary(description: string): boolean {
+  return EXTERNAL_BENEFICIARY_RE.test(normalizeText(description))
 }
 
 function canAutoAssignTransfer(transaction: Transaction): boolean {
@@ -90,7 +99,8 @@ export function inferInternalTransfers(transactions: Transaction[]): Transaction
   next.forEach((transaction) => {
     if (
       canAutoAssignTransfer(transaction) &&
-      isTransferDescription(transaction.description)
+      isTransferDescription(transaction.description) &&
+      !hasExternalBeneficiary(transaction.description)
     ) {
       byId.set(transaction.id, markTransfer(transaction, 0.9))
     }
@@ -99,6 +109,7 @@ export function inferInternalTransfers(transactions: Transaction[]): Transaction
   const candidates = next.filter(
     (transaction) =>
       isBankTransaction(transaction) &&
+      !hasExternalBeneficiary(transaction.description) &&
       (isTransferCategory(transaction.category) ||
         isTransferDescription(transaction.description))
   )


### PR DESCRIPTION
## Summary

- External transfers to named beneficiaries (e.g. `TRF. PLAZA- FEDERICO GAZZANO`, `NRR:182500517 JOSE PREX`) were being assigned `Category.Transfer` and excluded from Dashboard expense totals — money effectively disappeared from spending view
- The categorizer now falls through for descriptions matching the external beneficiary pattern, leaving them as `Uncategorized` so they surface as expenses
- Both Pass 1 (keyword marking) and Pass 2 (pairing) in `inferInternalTransfers` are guarded so these can't be re-tagged as Transfer or accidentally paired with a matching credit entry

**Covered patterns (all Santander Uruguay external transfer formats):**
- `TRANSFERENCIA ENVIADA ... TRF. PLAZA- NAME`
- `DEBITO OPERACION EN BANCA DIGITAL ... TRF. PLAZA- NAME`
- `DEBITO OPERACION EN SUPERNET ... TRF. PLAZA- NAME`
- `TRANSF INSTANTANEA ENVIADA ... NRR:ref NAME`

## Test plan

- [ ] All 1105 existing tests pass, lint clean (`npm run tdd:verify`)
- [ ] New regression tests in `transaction-categorizer.test.ts` verify the above four formats are NOT categorized as Transfer
- [ ] New tests in `internal-transfers.test.ts` verify `TRF. PLAZA-` and `NRR:` transactions are not re-tagged by `inferInternalTransfers`
- [ ] Legitimate internal transfers (`TRANSFERENCIA ENVIADA ... TRF. PLAZA` without a name) still categorize as Transfer correctly