### PR TITLE
fix: use font-sans for UI section header h2s

### DIFF
--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -304,7 +304,7 @@ export function Charts({
 
       {/* Donut + category breakdown */}
       <Card className="p-6">
-        <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20, fontFamily: 'var(--font-sans)' }}>
           Gasto por categoría
         </h2>
         {!hasExpenseData ? (
@@ -427,7 +427,7 @@ export function Charts({
             alignItems: 'center', marginBottom: 20,
           }}
         >
-          <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Ingresos vs Gastos</h2>
+          <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0, fontFamily: 'var(--font-sans)' }}>Ingresos vs Gastos</h2>
           <div style={{ display: 'flex', gap: 18 }}>
             {[
               { label: 'Ingresos', color: 'var(--pos)' },
@@ -497,7 +497,7 @@ export function Charts({
       {monthlyTrend.length > 0 && (
         <Card className="p-6">
           <div style={{ marginBottom: 20 }}>
-            <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0, marginBottom: 4 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0, marginBottom: 4, fontFamily: 'var(--font-sans)' }}>
               ¿Estás ahorrando?
             </h2>
             <p className="text-muted-foreground" style={{ fontSize: 13 }}>
@@ -572,7 +572,7 @@ export function Charts({
       {/* Gasto por moneda */}
       {currencySplit.total > 0 && (
         <Card className="p-6">
-          <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20 }}>
+          <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20, fontFamily: 'var(--font-sans)' }}>
             Gasto por moneda
           </h2>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -624,7 +624,7 @@ export function Charts({
       {/* Top merchants */}
       {topMerchants.length > 0 && (
         <Card className="p-6">
-          <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 18 }}>
+          <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 18, fontFamily: 'var(--font-sans)' }}>
             Mayores comercios
           </h2>
           <div

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -477,7 +477,7 @@ export function Dashboard({
               }}
             >
               <div>
-                <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>
+                <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0, fontFamily: 'var(--font-sans)' }}>
                   Este mes, todo en{' '}
                   {homeCurrency === 'USD' ? 'dólares' : 'pesos'}
                 </h2>
@@ -566,7 +566,7 @@ export function Dashboard({
                   alignItems: 'center', marginBottom: 18,
                 }}
               >
-                <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>
+                <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0, fontFamily: 'var(--font-sans)' }}>
                   Gasto por categoría
                 </h2>
                 {onNavigateToAnalysis && (
@@ -642,7 +642,7 @@ export function Dashboard({
                   alignItems: 'center', marginBottom: 14,
                 }}
               >
-                <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>
+                <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0, fontFamily: 'var(--font-sans)' }}>
                   Movimientos recientes
                 </h2>
                 {onNavigateToTransactions && (


### PR DESCRIPTION
## Summary

- `theme.css` applies `font-family: var(--font-display)` (Spectral, serif) to all h2 elements via the base rule
- Small UI section headers in Dashboard and Charts (15–16px) are not display headings — they should use Hanken Grotesk (`--font-sans`)
- Spectral's thin serifs render noticeably different on dark vs light backgrounds at small sizes: on light, serifs are subtle (looks clean); on dark, light-on-dark antialiasing makes them more pronounced (looks mismatched)
- Fix: add explicit `fontFamily: 'var(--font-sans)'` inline override to each UI section header h2 in Dashboard.tsx and Charts.tsx

## Affected headings

Dashboard: "Este mes, todo en…", "Gasto por categoría", "Movimientos recientes"  
Charts: "Gasto por categoría", "Ingresos vs Gastos", "¿Estás ahorrando?", "Gasto por moneda", "Mayores comercios"

Display headings (auth screen "Ingresar a Tatú", empty state "Empezá importando tu extracto") keep Spectral — correct.

## Test plan

- [x] 1114/1114 tests pass
- [x] ESLint zero warnings
- [ ] Visual check: light and dark mode section headers now match