### PR TITLE
fix: persist category "ignore" flag so it affects totals and analysis

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,6 +280,7 @@ function App() {
             label: category.label,
             color: category.color,
             icon: category.icon,
+            isIgnored: category.isIgnored,
           }))
         )
 

--- a/src/services/categories/category-store.test.ts
+++ b/src/services/categories/category-store.test.ts
@@ -84,4 +84,29 @@ describe('Custom category store', () => {
     expect(upsertCustomCategoryMock).toHaveBeenCalledTimes(2)
     expect(archiveCustomCategoryMock).toHaveBeenCalledTimes(1)
   })
+
+  it('syncs the isIgnored flag to the cloud on add and update', async () => {
+    getActiveSupabaseSessionMock.mockReturnValue({
+      user: { id: 'user-1' },
+    })
+    upsertCustomCategoryMock.mockResolvedValue(undefined)
+
+    const created = await addCustomCategoryWithSync({
+      label: 'Reembolsos',
+      color: '#112233',
+      isIgnored: true,
+    })
+
+    expect(upsertCustomCategoryMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: created.id, isIgnored: true })
+    )
+
+    await updateCustomCategoryWithSync(created.id, { isIgnored: false })
+
+    expect(upsertCustomCategoryMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: created.id, isIgnored: false })
+    )
+  })
 })

--- a/src/services/categories/category-store.ts
+++ b/src/services/categories/category-store.ts
@@ -90,6 +90,7 @@ export async function syncCustomCategoryToCloud(id: string): Promise<void> {
         label: category.label,
         color: category.color,
         icon: category.icon,
+        isIgnored: category.isIgnored ?? false,
         isArchived: false,
       })
     }
@@ -129,6 +130,7 @@ export async function updateCustomCategoryWithSync(
         label: category.label,
         color: category.color,
         icon: category.icon,
+        isIgnored: category.isIgnored ?? false,
         isArchived: false,
       })
     }

--- a/src/services/supabase/custom-categories.test.ts
+++ b/src/services/supabase/custom-categories.test.ts
@@ -46,6 +46,7 @@ describe('supabase custom categories service', () => {
           label: 'Mates',
           color: '#00AA11',
           icon: '🧉',
+          is_ignored: true,
           is_archived: false,
           created_at: '2026-02-20T00:00:00.000Z',
           updated_at: '2026-02-20T00:00:00.000Z',
@@ -84,6 +85,37 @@ describe('supabase custom categories service', () => {
     expect(categories).toHaveLength(1)
   })
 
+  it('reads the is_ignored flag from stored rows', async () => {
+    const { listCustomCategories } = await import('./custom-categories')
+    const categories = await listCustomCategories(session)
+
+    expect(categories[0].isIgnored).toBe(true)
+  })
+
+  it('defaults is_ignored to false when the column is null', async () => {
+    isMock.mockResolvedValueOnce({
+      data: [
+        {
+          user_id: 'user-1',
+          id: 'mates',
+          label: 'Mates',
+          color: '#00AA11',
+          icon: '🧉',
+          is_ignored: null,
+          is_archived: false,
+          created_at: '2026-02-20T00:00:00.000Z',
+          updated_at: '2026-02-20T00:00:00.000Z',
+        },
+      ],
+      error: null,
+    })
+
+    const { listCustomCategories } = await import('./custom-categories')
+    const categories = await listCustomCategories(session)
+
+    expect(categories[0].isIgnored).toBe(false)
+  })
+
   it('upserts custom category', async () => {
     const { upsertCustomCategory } = await import('./custom-categories')
     await upsertCustomCategory(session, {
@@ -96,6 +128,23 @@ describe('supabase custom categories service', () => {
 
     expect(upsertMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'mates' }),
+      { onConflict: 'user_id,id' }
+    )
+  })
+
+  it('persists the is_ignored flag on upsert', async () => {
+    const { upsertCustomCategory } = await import('./custom-categories')
+    await upsertCustomCategory(session, {
+      id: 'mates',
+      label: 'Mates',
+      color: '#00AA11',
+      icon: '🧉',
+      isIgnored: true,
+      isArchived: false,
+    })
+
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'mates', is_ignored: true }),
       { onConflict: 'user_id,id' }
     )
   })

--- a/src/services/supabase/custom-categories.test.ts
+++ b/src/services/supabase/custom-categories.test.ts
@@ -123,6 +123,7 @@ describe('supabase custom categories service', () => {
       label: 'Mates',
       color: '#00AA11',
       icon: '🧉',
+      isIgnored: false,
       isArchived: false,
     })
 

--- a/src/services/supabase/custom-categories.ts
+++ b/src/services/supabase/custom-categories.ts
@@ -6,6 +6,7 @@ interface CustomCategoryRow {
   label: string
   color: string
   icon: string | null
+  is_ignored: boolean | null
   is_archived: boolean
   created_at: string
   updated_at: string
@@ -16,6 +17,7 @@ export interface CustomCategoryRecord {
   label: string
   color: string
   icon?: string
+  isIgnored: boolean
   isArchived: boolean
   createdAt: string
   updatedAt: string
@@ -27,6 +29,7 @@ function rowToRecord(row: CustomCategoryRow): CustomCategoryRecord {
     label: row.label,
     color: row.color,
     icon: row.icon ?? undefined,
+    isIgnored: row.is_ignored ?? false,
     isArchived: row.is_archived,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -57,6 +60,7 @@ export async function upsertCustomCategory(
     label: string
     color: string
     icon?: string
+    isIgnored?: boolean
     isArchived?: boolean
   }
 ): Promise<void> {
@@ -68,6 +72,7 @@ export async function upsertCustomCategory(
       label: category.label,
       color: category.color,
       icon: category.icon ?? null,
+      is_ignored: category.isIgnored ?? false,
       is_archived: category.isArchived ?? false,
     },
     { onConflict: 'user_id,id' }

--- a/src/services/supabase/custom-categories.ts
+++ b/src/services/supabase/custom-categories.ts
@@ -60,7 +60,7 @@ export async function upsertCustomCategory(
     label: string
     color: string
     icon?: string
-    isIgnored?: boolean
+    isIgnored: boolean
     isArchived?: boolean
   }
 ): Promise<void> {
@@ -72,7 +72,7 @@ export async function upsertCustomCategory(
       label: category.label,
       color: category.color,
       icon: category.icon ?? null,
-      is_ignored: category.isIgnored ?? false,
+      is_ignored: category.isIgnored,
       is_archived: category.isArchived ?? false,
     },
     { onConflict: 'user_id,id' }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -132,6 +132,7 @@ create table if not exists public.custom_categories (
   label text not null check (length(trim(label)) > 0),
   color text not null check (color ~ '^#([0-9A-Fa-f]{6})$'),
   icon text,
+  is_ignored boolean not null default false,
   is_archived boolean not null default false,
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now()),
@@ -139,6 +140,7 @@ create table if not exists public.custom_categories (
 );
 
 alter table public.custom_categories
+  add column if not exists is_ignored boolean not null default false,
   add column if not exists is_archived boolean not null default false,
   add column if not exists created_at timestamptz not null default timezone('utc', now()),
   add column if not exists updated_at timestamptz not null default timezone('utc', now());


### PR DESCRIPTION
## Problem

The per-category **"ignore"** toggle (`isIgnored`) didn't actually exclude transactions from totals, summaries, and charts. Ignored categories kept showing up everywhere.

## Root cause

The flag *was* wired into all the calculation paths correctly — `isCategoryIgnored()` is checked in `aggregation.ts`, `chart-data.ts`, and the `Dashboard` summaries. The real issue: the flag was **never persisted**.

Toggling it only updated the in-memory category store. But:

1. The Supabase `custom_categories` table had no `is_ignored` column (a prior commit even noted *"drop isIgnored from Supabase upsert — column not in schema yet"*).
2. `upsertCustomCategory` never wrote the flag, and the read layer never returned it.
3. `App.tsx` dropped `isIgnored` when mapping remote categories into the in-memory store on load.

Since the app loads all categories from Supabase on every page load, the flag was wiped on each reload — so ignored categories kept reappearing in totals and analysis.

## The fix (full round-trip)

- **`supabase/schema.sql`** — added `is_ignored boolean not null default false` (in both the `create table` and the `add column if not exists` migration block, so existing DBs get it too).
- **`src/services/supabase/custom-categories.ts`** — read `is_ignored` into `CustomCategoryRecord.isIgnored` and write it on upsert.
- **`src/services/categories/category-store.ts`** — send `isIgnored` in both cloud-sync paths (add + update), which also covers built-in category overrides.
- **`src/App.tsx`** — carry `isIgnored` into the in-memory store when loading remote categories.

## Tests

Added regression coverage for the round-trip (reading the flag, null-defaulting, persisting on upsert, and syncing on add/update). Full suite green: **570 tests passing**, lint clean, build succeeds.

## ⚠️ Deploy note

The `is_ignored` column must exist in the live Supabase database. The schema change handles fresh setups and re-running the schema, but an already-provisioned production DB needs:

```sql
alter table public.custom_categories
  add column if not exists is_ignored boolean not null default false;
```

https://claude.ai/code/session_01V38GrodSnAgKPJaw1YyxTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01V38GrodSnAgKPJaw1YyxTA)_