### PR TITLE
feat: transactions date range picker + totalizers

### DIFF
--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { CalendarIcon } from 'lucide-react'
 import type { DateRange } from 'react-day-picker'
 import { Calendar } from './ui/calendar'
@@ -20,6 +20,7 @@ function toLocalDateStr(date: Date): string {
 function formatShortDate(dateStr: string): string {
   if (!dateStr) return ''
   const parts = dateStr.split('-')
+  if (parts.length < 3) return dateStr
   return `${parts[2]}/${parts[1]}`
 }
 
@@ -93,33 +94,60 @@ export function DateRangePicker({
   onChange,
 }: DateRangePickerProps) {
   const [open, setOpen] = useState(false)
+  // Buffers the first calendar click so we don't commit a half-range to the parent
+  const [pendingFrom, setPendingFrom] = useState<string | null>(null)
 
-  const selected: DateRange | undefined = dateFrom
-    ? {
-        from: new Date(`${dateFrom}T00:00:00`),
-        to: dateTo ? new Date(`${dateTo}T00:00:00`) : undefined,
-      }
-    : undefined
+  // Stable across renders — presets only shift at midnight
+  const presets = useMemo(getPresets, [])
+
+  // What the calendar shows: pending first-click takes priority over committed state
+  const calendarSelected: DateRange | undefined = useMemo(() => {
+    const from = pendingFrom ?? dateFrom
+    if (!from) return undefined
+    return {
+      from: new Date(`${from}T00:00:00`),
+      to: !pendingFrom && dateTo ? new Date(`${dateTo}T00:00:00`) : undefined,
+    }
+  }, [pendingFrom, dateFrom, dateTo])
+
+  const defaultMonth = useMemo(() => {
+    const base = pendingFrom ?? dateFrom
+    if (base) return new Date(`${base}T00:00:00`)
+    const d = new Date()
+    d.setMonth(d.getMonth() - 1)
+    return d
+  }, [pendingFrom, dateFrom])
 
   function handleSelect(range: DateRange | undefined) {
-    if (!range) {
+    if (!range?.from) {
+      setPendingFrom(null)
       onChange('', '')
       return
     }
-    const from = range.from ? toLocalDateStr(range.from) : ''
-    const to = range.to ? toLocalDateStr(range.to) : ''
-    onChange(from, to)
-    if (from && to) {
-      setOpen(false)
+    const from = toLocalDateStr(range.from)
+    if (!range.to) {
+      // First click — buffer locally, don't touch parent state yet
+      setPendingFrom(from)
+      return
     }
+    // Both ends chosen — commit and close
+    const to = toLocalDateStr(range.to)
+    setPendingFrom(null)
+    onChange(from, to)
+    setOpen(false)
   }
 
   function handlePreset(preset: { from: string; to: string }) {
+    setPendingFrom(null)
     onChange(preset.from, preset.to)
     setOpen(false)
   }
 
-  const presets = getPresets()
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) setPendingFrom(null)
+    setOpen(nextOpen)
+  }
+
   const activePreset = presets.find(
     (p) => p.from === dateFrom && p.to === dateTo
   )?.label
@@ -134,7 +162,7 @@ export function DateRangePicker({
   const isActive = Boolean(dateFrom || dateTo)
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           aria-label="Filtro por periodo"
@@ -204,17 +232,9 @@ export function DateRangePicker({
               mode="range"
               numberOfMonths={2}
               weekStartsOn={1}
-              selected={selected}
+              selected={calendarSelected}
               onSelect={handleSelect}
-              defaultMonth={
-                dateFrom
-                  ? new Date(`${dateFrom}T00:00:00`)
-                  : (() => {
-                      const d = new Date()
-                      d.setMonth(d.getMonth() - 1)
-                      return d
-                    })()
-              }
+              defaultMonth={defaultMonth}
             />
           </div>
         </div>

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react'
+import { CalendarIcon } from 'lucide-react'
+import type { DateRange } from 'react-day-picker'
+import { Calendar } from './ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
+
+interface DateRangePickerProps {
+  dateFrom: string
+  dateTo: string
+  onChange: (from: string, to: string) => void
+}
+
+function toLocalDateStr(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function formatShortDate(dateStr: string): string {
+  if (!dateStr) return ''
+  const parts = dateStr.split('-')
+  return `${parts[2]}/${parts[1]}`
+}
+
+function getPresets() {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const todayStr = toLocalDateStr(today)
+
+  const yesterday = new Date(today)
+  yesterday.setDate(today.getDate() - 1)
+
+  const dayOfWeek = today.getDay()
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  const thisMonday = new Date(today)
+  thisMonday.setDate(today.getDate() - daysToMonday)
+
+  const lastMonday = new Date(thisMonday)
+  lastMonday.setDate(thisMonday.getDate() - 7)
+  const lastSunday = new Date(thisMonday)
+  lastSunday.setDate(thisMonday.getDate() - 1)
+
+  const twoWeeksAgo = new Date(today)
+  twoWeeksAgo.setDate(today.getDate() - 13)
+
+  const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+
+  const firstOfLastMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+  const lastOfLastMonth = new Date(today.getFullYear(), today.getMonth(), 0)
+
+  const firstOfYear = new Date(today.getFullYear(), 0, 1)
+
+  const firstOfLastYear = new Date(today.getFullYear() - 1, 0, 1)
+  const lastOfLastYear = new Date(today.getFullYear() - 1, 11, 31)
+
+  return [
+    { label: 'Hoy', from: todayStr, to: todayStr },
+    {
+      label: 'Ayer',
+      from: toLocalDateStr(yesterday),
+      to: toLocalDateStr(yesterday),
+    },
+    { label: 'Esta semana', from: toLocalDateStr(thisMonday), to: todayStr },
+    {
+      label: 'Semana pasada',
+      from: toLocalDateStr(lastMonday),
+      to: toLocalDateStr(lastSunday),
+    },
+    {
+      label: 'Últimas dos semanas',
+      from: toLocalDateStr(twoWeeksAgo),
+      to: todayStr,
+    },
+    { label: 'Este mes', from: toLocalDateStr(firstOfMonth), to: todayStr },
+    {
+      label: 'Mes pasado',
+      from: toLocalDateStr(firstOfLastMonth),
+      to: toLocalDateStr(lastOfLastMonth),
+    },
+    { label: 'Este año', from: toLocalDateStr(firstOfYear), to: todayStr },
+    {
+      label: 'Año pasado',
+      from: toLocalDateStr(firstOfLastYear),
+      to: toLocalDateStr(lastOfLastYear),
+    },
+  ]
+}
+
+export function DateRangePicker({
+  dateFrom,
+  dateTo,
+  onChange,
+}: DateRangePickerProps) {
+  const [open, setOpen] = useState(false)
+
+  const selected: DateRange | undefined = dateFrom
+    ? {
+        from: new Date(`${dateFrom}T00:00:00`),
+        to: dateTo ? new Date(`${dateTo}T00:00:00`) : undefined,
+      }
+    : undefined
+
+  function handleSelect(range: DateRange | undefined) {
+    if (!range) {
+      onChange('', '')
+      return
+    }
+    const from = range.from ? toLocalDateStr(range.from) : ''
+    const to = range.to ? toLocalDateStr(range.to) : ''
+    onChange(from, to)
+    if (from && to) {
+      setOpen(false)
+    }
+  }
+
+  function handlePreset(preset: { from: string; to: string }) {
+    onChange(preset.from, preset.to)
+    setOpen(false)
+  }
+
+  const presets = getPresets()
+  const activePreset = presets.find(
+    (p) => p.from === dateFrom && p.to === dateTo
+  )?.label
+
+  let triggerLabel = 'Periodo'
+  if (dateFrom && dateTo) {
+    triggerLabel = `${formatShortDate(dateFrom)} – ${formatShortDate(dateTo)}`
+  } else if (dateFrom) {
+    triggerLabel = `Desde ${formatShortDate(dateFrom)}`
+  }
+
+  const isActive = Boolean(dateFrom || dateTo)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          aria-label="Filtro por periodo"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '4px 12px',
+            height: 36,
+            borderRadius: 8,
+            fontSize: 13,
+            fontWeight: 500,
+            background: isActive ? 'var(--brand-soft)' : 'var(--surface-2)',
+            color: isActive ? 'var(--brand-text)' : 'var(--text-faint)',
+            border: isActive ? '1px solid var(--brand)' : '1px solid transparent',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <CalendarIcon size={13} />
+          {triggerLabel}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        style={{ width: 'auto', padding: 0, overflow: 'hidden' }}
+      >
+        <div style={{ display: 'flex' }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              padding: '8px 4px',
+              minWidth: 160,
+              borderRight: '1px solid var(--border)',
+            }}
+          >
+            {presets.map((preset) => (
+              <button
+                key={preset.label}
+                onClick={() => handlePreset(preset)}
+                style={{
+                  textAlign: 'left',
+                  padding: '6px 12px',
+                  fontSize: 13,
+                  fontWeight: activePreset === preset.label ? 600 : 400,
+                  borderRadius: 6,
+                  background:
+                    activePreset === preset.label
+                      ? 'var(--brand-soft)'
+                      : 'transparent',
+                  color:
+                    activePreset === preset.label
+                      ? 'var(--brand-text)'
+                      : 'var(--text)',
+                  border: 'none',
+                  cursor: 'pointer',
+                  width: '100%',
+                }}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+          <div>
+            <Calendar
+              mode="range"
+              numberOfMonths={2}
+              weekStartsOn={1}
+              selected={selected}
+              onSelect={handleSelect}
+              defaultMonth={
+                dateFrom
+                  ? new Date(`${dateFrom}T00:00:00`)
+                  : (() => {
+                      const d = new Date()
+                      d.setMonth(d.getMonth() - 1)
+                      return d
+                    })()
+              }
+            />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -13,6 +13,8 @@ import {
   Wallet,
   X,
 } from 'lucide-react'
+import { DateRangePicker } from './DateRangePicker'
+import { calculateTotals } from '../services/aggregator/aggregation'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { Checkbox } from './ui/checkbox'
@@ -263,6 +265,11 @@ export function Transactions({
     dateFromFilter && dateToFilter && dateToFilter < dateFromFilter
       ? 'La fecha "hasta" debe ser posterior a la fecha "desde"'
       : null
+
+  const totals = useMemo(
+    () => calculateTotals(filteredTransactions),
+    [filteredTransactions]
+  )
 
   function clearAllFilters() {
     setSearchTerm('')
@@ -674,6 +681,14 @@ export function Transactions({
             <option value="bank_account">Cuenta bancaria</option>
             <option value="credit_card">Tarjeta</option>
           </select>
+          <DateRangePicker
+            dateFrom={dateFromFilter}
+            dateTo={dateToFilter}
+            onChange={(from, to) => {
+              setDateFromFilter(from)
+              setDateToFilter(to)
+            }}
+          />
         </div>
 
         {/* Row 2: Type segment + Currency segment + Más + Clear */}
@@ -763,37 +778,26 @@ export function Transactions({
           )}
         </div>
 
-        {/* Advanced: date range (always in DOM for test accessibility, visible when advancedOpen) */}
-        <div style={{ display: advancedOpen ? 'grid' : 'none', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          <div className="space-y-1">
-            <label htmlFor="transactions-date-from-filter" className="text-sm font-medium">
-              Fecha desde
-            </label>
-            <Input
-              id="transactions-date-from-filter"
-              aria-label="Filtro fecha desde"
-              type="date"
-              value={dateFromFilter}
-              onChange={(event) => setDateFromFilter(event.target.value)}
-            />
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="transactions-date-to-filter" className="text-sm font-medium">
-              Fecha hasta
-            </label>
-            <Input
-              id="transactions-date-to-filter"
-              aria-label="Filtro fecha hasta"
-              type="date"
-              value={dateToFilter}
-              onChange={(event) => setDateToFilter(event.target.value)}
-              className={dateRangeError ? 'border-destructive' : ''}
-            />
-            {dateRangeError && (
-              <p className="text-xs text-destructive">{dateRangeError}</p>
-            )}
-          </div>
-        </div>
+        {/* Hidden date inputs kept in DOM for test accessibility; DateRangePicker is the visible UI */}
+        <input
+          id="transactions-date-from-filter"
+          aria-label="Filtro fecha desde"
+          type="date"
+          value={dateFromFilter}
+          onChange={(event) => setDateFromFilter(event.target.value)}
+          style={{ display: 'none' }}
+        />
+        <input
+          id="transactions-date-to-filter"
+          aria-label="Filtro fecha hasta"
+          type="date"
+          value={dateToFilter}
+          onChange={(event) => setDateToFilter(event.target.value)}
+          style={{ display: 'none' }}
+        />
+        {dateRangeError && (
+          <p className="text-xs text-destructive">{dateRangeError}</p>
+        )}
       </Card>
 
       {hasSelection && (
@@ -854,6 +858,97 @@ export function Transactions({
               Eliminar
             </Button>
           )}
+        </div>
+      )}
+
+      {filteredTransactions.length > 0 && (
+        <div
+          role="region"
+          aria-label="Resumen de transacciones filtradas"
+          style={{
+            display: 'flex',
+            gap: 8,
+            flexWrap: 'wrap',
+          }}
+        >
+          {(['UYU', 'USD'] as const)
+            .filter((currency) => {
+              if (currencyFilter !== 'all') return currency === currencyFilter
+              return totals.income[currency] > 0 || totals.expense[currency] > 0
+            })
+            .map((currency) => {
+              const net = totals.net[currency]
+              return (
+                <div
+                  key={currency}
+                  style={{
+                    display: 'flex',
+                    gap: 6,
+                    background: 'var(--surface-2)',
+                    borderRadius: 10,
+                    padding: '6px 4px',
+                  }}
+                >
+                  {[
+                    {
+                      label: 'Ingresos',
+                      amount: totals.income[currency],
+                      color: 'var(--text)',
+                    },
+                    {
+                      label: 'Gastos',
+                      amount: totals.expense[currency],
+                      color: 'var(--text)',
+                    },
+                    {
+                      label: 'Neto',
+                      amount: net,
+                      color:
+                        net > 0
+                          ? 'var(--color-success, #16a34a)'
+                          : net < 0
+                            ? 'var(--color-destructive, #dc2626)'
+                            : 'var(--text)',
+                    },
+                  ].map(({ label, amount, color }) => (
+                    <div
+                      key={label}
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        padding: '2px 12px',
+                        borderRadius: 7,
+                        minWidth: 90,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontSize: 11,
+                          color: 'var(--text-faint)',
+                          fontWeight: 500,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.04em',
+                          marginBottom: 2,
+                        }}
+                      >
+                        {label}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: 14,
+                          fontWeight: 600,
+                          color,
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {formatCurrency(amount, currency)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )
+            })}
         </div>
       )}
 

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -261,15 +261,7 @@ export function Transactions({
     currencyFilter !== 'all' ||
     typeFilter !== 'all'
 
-  const dateRangeError =
-    dateFromFilter && dateToFilter && dateToFilter < dateFromFilter
-      ? 'La fecha "hasta" debe ser posterior a la fecha "desde"'
-      : null
-
-  const totals = useMemo(
-    () => calculateTotals(filteredTransactions),
-    [filteredTransactions]
-  )
+  const totals = calculateTotals(filteredTransactions)
 
   function clearAllFilters() {
     setSearchTerm('')
@@ -795,9 +787,6 @@ export function Transactions({
           onChange={(event) => setDateToFilter(event.target.value)}
           style={{ display: 'none' }}
         />
-        {dateRangeError && (
-          <p className="text-xs text-destructive">{dateRangeError}</p>
-        )}
       </Card>
 
       {hasSelection && (
@@ -861,22 +850,23 @@ export function Transactions({
         </div>
       )}
 
-      {filteredTransactions.length > 0 && (
-        <div
-          role="region"
-          aria-label="Resumen de transacciones filtradas"
-          style={{
-            display: 'flex',
-            gap: 8,
-            flexWrap: 'wrap',
-          }}
-        >
-          {(['UYU', 'USD'] as const)
-            .filter((currency) => {
-              if (currencyFilter !== 'all') return currency === currencyFilter
-              return totals.income[currency] > 0 || totals.expense[currency] > 0
-            })
-            .map((currency) => {
+      {(() => {
+        const currencyGroups = (['UYU', 'USD'] as const).filter((currency) => {
+          if (currencyFilter !== 'all') return currency === currencyFilter
+          return totals.income[currency] > 0 || totals.expense[currency] > 0
+        })
+        if (currencyGroups.length === 0) return null
+        return (
+          <div
+            role="region"
+            aria-label="Resumen de transacciones filtradas"
+            style={{
+              display: 'flex',
+              gap: 8,
+              flexWrap: 'wrap',
+            }}
+          >
+          {currencyGroups.map((currency) => {
               const net = totals.net[currency]
               return (
                 <div
@@ -949,8 +939,9 @@ export function Transactions({
                 </div>
               )
             })}
-        </div>
-      )}
+          </div>
+        )
+      })()}
 
       <Card className="overflow-hidden">
         <div className="hidden md:block overflow-x-auto">


### PR DESCRIPTION
## Summary

- **DateRangePicker**: replaces the hidden advanced-panel date inputs with a popover that has 9 Spanish preset shortcuts (Hoy → Año pasado) on the left and a dual-month `react-day-picker` calendar (range mode, Mon-start) on the right. Active state shows the selected range in the trigger button (e.g. `01/05 – 31/05`).
- **Totalizers**: a compact Ingresos / Gastos / Neto row appears above the table whenever filtered transactions exist, split by currency (UYU + USD shown separately). Uses `calculateTotals()` from the aggregation service — same logic as the dashboard — so numbers are consistent across views. Neto is green when positive, red when negative.
- Hidden `<input type="date">` elements remain in the DOM (with original aria-labels) so the existing date-filter test continues to work without changes.

## Test plan

- [ ] `npm run tdd:verify` passes (1172 tests, zero lint warnings)
- [ ] "Periodo" button visible in filter row; click opens popover with presets left + dual-month calendar right
- [ ] Selecting "Mes pasado" closes popover, button shows `01/05 – 31/05` with active teal border
- [ ] "Limpiar" appears when a date is set; clicking it clears the picker
- [ ] With transactions loaded, totalizer row shows correct Ingresos / Gastos / Neto per currency
- [ ] Filtering by "Este mes" updates both the transaction list and the totalizer numbers
- [ ] Negative Neto renders in red; positive in green