### PR TITLE
refactor: UI/UX audit phases 2 & 3

### DIFF
--- a/src/App.supabase.test.tsx
+++ b/src/App.supabase.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { transactionStore } from './stores/transaction-store'
 
 const {
@@ -143,6 +143,29 @@ describe('App with supabase enabled', () => {
       screen.getByRole('heading', { name: 'Ingresar a Tatú' })
     ).toBeInTheDocument()
     expect(screen.getByPlaceholderText('email@ejemplo.com')).toBeInTheDocument()
+  })
+
+  it('shows Spanish error when signin fails with Supabase credentials error', async () => {
+    signInWithPasswordMock.mockRejectedValue(
+      new Error('Invalid login credentials')
+    )
+
+    const { default: App } = await import('./App')
+    render(<App />)
+
+    fireEvent.change(screen.getByPlaceholderText('email@ejemplo.com'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Contraseña'), {
+      target: { value: 'wrongpass' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Iniciar sesión' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Email o contraseña incorrectos.')
+      ).toBeInTheDocument()
+    )
   })
 
   it('signs in and loads transactions', async () => {
@@ -307,8 +330,6 @@ describe('App with supabase enabled', () => {
       },
     ])
 
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
-
     const { default: App } = await import('./App')
     render(<App />)
 
@@ -328,16 +349,16 @@ describe('App with supabase enabled', () => {
       target: { value: 'services' },
     })
     fireEvent.click(screen.getByLabelText('Crear categoría'))
-    fireEvent.click(screen.getByLabelText('Tags dropdown'))
-    fireEvent.change(screen.getByLabelText('Nuevo tag'), {
+    fireEvent.click(screen.getByLabelText('Etiquetas dropdown'))
+    fireEvent.change(screen.getByLabelText('Nueva etiqueta'), {
       target: { value: 'monthly' },
     })
-    fireEvent.click(screen.getByLabelText('Crear tag'))
-    fireEvent.click(screen.getByLabelText('Tags dropdown'))
-    fireEvent.change(screen.getByLabelText('Nuevo tag'), {
+    fireEvent.click(screen.getByLabelText('Crear etiqueta'))
+    fireEvent.click(screen.getByLabelText('Etiquetas dropdown'))
+    fireEvent.change(screen.getByLabelText('Nueva etiqueta'), {
       target: { value: 'fixed' },
     })
-    fireEvent.click(screen.getByLabelText('Crear tag'))
+    fireEvent.click(screen.getByLabelText('Crear etiqueta'))
     fireEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }))
 
     await waitFor(() =>
@@ -357,6 +378,13 @@ describe('App with supabase enabled', () => {
 
     fireEvent.click(
       screen.getAllByRole('button', { name: 'Eliminar New merchant' })[0]
+    )
+
+    await waitFor(() => screen.getByRole('alertdialog'))
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Eliminar',
+      })
     )
 
     await waitFor(() =>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import App from './App'
 import { transactionStore } from './stores/transaction-store'
+import { listCustomCategories } from './services/categories/category-store'
 
 const MOCK_SESSION = {
   access_token: 'access',
@@ -403,8 +404,6 @@ describe('App', () => {
         rawData: {},
       },
     ])
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
-
     render(<App />)
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument()
@@ -414,9 +413,14 @@ describe('App', () => {
     fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0])
     fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio B' })[0])
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /^Eliminar$/ }))
-    })
+    fireEvent.click(screen.getByRole('button', { name: /^Eliminar$/ }))
+
+    await waitFor(() => screen.getByRole('alertdialog'))
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Eliminar',
+      })
+    )
 
     await waitFor(() => {
       expect(transactionStore.getState().transactions).toHaveLength(0)
@@ -450,11 +454,11 @@ describe('App', () => {
       fireEvent.click(screen.getAllByRole('button', { name: /Editar/ })[0])
     })
 
-    fireEvent.click(screen.getByLabelText('Tags bulk dropdown'))
-    fireEvent.change(screen.getByLabelText('Buscar o crear tag'), {
+    fireEvent.click(screen.getByLabelText('Etiquetas bulk dropdown'))
+    fireEvent.change(screen.getByLabelText('Buscar o crear etiqueta'), {
       target: { value: 'recurrente' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /Crear tag "recurrente"/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Crear etiqueta "recurrente"/ }))
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }))
@@ -536,5 +540,34 @@ describe('App', () => {
 
     expect(hamburger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.getByRole('heading', { name: 'Transacciones' })).toBeInTheDocument()
+  })
+
+  it('clears custom categories from memory on sign out', async () => {
+    listCustomCategoriesMock.mockResolvedValue([
+      {
+        id: 'mi-cat',
+        label: 'Mi Categoría',
+        color: '#ff0000',
+        isIgnored: false,
+        isArchived: false,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ])
+
+    render(<App />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Categorías' })).toBeInTheDocument()
+    )
+
+    // After sync, the custom category is in memory
+    expect(listCustomCategories().map((c) => c.id)).toContain('mi-cat')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cerrar sesión' }))
+    })
+
+    // After sign out, the in-memory store must be empty
+    expect(listCustomCategories()).toHaveLength(0)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import { setAiConfig } from './services/ai/ai-config'
 import { useAuthSession } from './hooks/useAuthSession'
 import { useTransactionSync } from './hooks/useTransactionSync'
 import { useTransactionHandlers } from './hooks/useTransactionHandlers'
+import { getFriendlyName } from './utils/user-display'
 
 function App() {
   const [currentView, setCurrentView] = useState<View>('overview')
@@ -129,6 +130,7 @@ function App() {
       clearAllCategoryOverrides()
       clearAllDescriptionOverrides()
       replaceCustomPatterns([])
+      replaceCustomCategories([])
       setAiConfig(null)
       setTheme('auto')
       setPreferredCurrency('USD')
@@ -383,19 +385,14 @@ function App() {
             currentView !== 'categories' ? (
             <Onboarding
               onImport={() => setImportOpen(true)}
-              userName={
-                session?.user?.user_metadata?.full_name as string | undefined ??
-                session?.user?.email?.split('@')[0]?.replace(/^./, (c) =>
-                  c.toUpperCase()
-                )
-              }
+              userName={getFriendlyName(session) || undefined}
             />
           ) : (
             <>
               {currentView === 'overview' && (
                 <Dashboard
                   transactions={transactions}
-                  userName={session?.user?.email ?? undefined}
+                  userName={getFriendlyName(session) || undefined}
                   onNavigateToImport={() => setImportOpen(true)}
                   onNavigateToTransactions={navigateToTransactions}
                   onNavigateToAnalysis={() => setCurrentView('analysis')}

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import type { Currency } from '../models'
 import { Card } from './ui/card'
+import { IconTile } from './ui/icon-tile'
 import { formatCurrency } from '../utils/formatting'
 
 interface AccountCardProps {
@@ -43,20 +44,9 @@ export function AccountCard({
       style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-        <span
-          style={{
-            width: 36,
-            height: 36,
-            borderRadius: 10,
-            background: 'var(--surface-2)',
-            color: 'var(--brand)',
-            display: 'grid',
-            placeItems: 'center',
-            flexShrink: 0,
-          }}
-        >
+        <IconTile size="lg" bg="var(--surface-2)" color="var(--brand)">
           {icon}
-        </span>
+        </IconTile>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontWeight: 600, fontSize: 14 }}>{title}</div>
           <div className="text-muted-foreground" style={{ fontSize: 12 }}>{subtitle}</div>

--- a/src/components/BulkEditDialog.tsx
+++ b/src/components/BulkEditDialog.tsx
@@ -153,7 +153,7 @@ export function BulkEditDialog({
 
           {showTagSection && (
             <div>
-              <label className="text-sm font-medium">Tags</label>
+              <label className="text-sm font-medium">Etiquetas</label>
               <Popover
                 open={bulkTagPickerOpen}
                 onOpenChange={onBulkTagPickerOpenChange}
@@ -161,23 +161,23 @@ export function BulkEditDialog({
                 <PopoverTrigger asChild>
                   <button
                     type="button"
-                    aria-label="Tags bulk dropdown"
+                    aria-label="Etiquetas bulk dropdown"
                     className="mt-1 w-full h-9 rounded-md border border-input bg-input-background px-3 text-sm text-left hover:bg-muted/50"
                   >
                     {bulkEditTagList.length > 0
-                      ? `${bulkEditTagList.length} tag${bulkEditTagList.length === 1 ? '' : 's'} a agregar`
+                      ? `${bulkEditTagList.length} ${bulkEditTagList.length === 1 ? 'etiqueta' : 'etiquetas'} a agregar`
                       : 'Sin cambios'}
                   </button>
                 </PopoverTrigger>
                 <PopoverContent className="p-0 w-[320px]" align="start">
                   <div className="p-2 space-y-2">
                     <Input
-                      aria-label="Buscar o crear tag"
+                      aria-label="Buscar o crear etiqueta"
                       value={bulkTagSearch}
                       onChange={(event) =>
                         onBulkTagSearchChange(event.target.value)
                       }
-                      placeholder="Buscar o crear tag..."
+                      placeholder="Buscar o crear etiqueta..."
                     />
                     <div
                       className="max-h-44 overflow-y-auto overscroll-contain space-y-1 pr-2"
@@ -219,7 +219,7 @@ export function BulkEditDialog({
                             onBulkTagSearchChange('')
                           }}
                         >
-                          Crear tag &quot;{bulkTagSearch.trim()}&quot;
+                          Crear etiqueta &quot;{bulkTagSearch.trim()}&quot;
                         </Button>
                       )}
                   </div>
@@ -232,7 +232,7 @@ export function BulkEditDialog({
                     <button
                       key={tag}
                       type="button"
-                      aria-label={`Quitar tag ${tag}`}
+                      aria-label={`Quitar etiqueta ${tag}`}
                       onClick={() =>
                         onBulkEditTagListChange(
                           bulkEditTagList.filter((t) => t !== tag)

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -15,6 +15,7 @@ import {
   removeCustomCategoryWithSync,
   updateCustomCategoryWithSync,
   upsertBuiltinOverrideWithSync,
+  DEFAULT_CATEGORY_COLOR,
 } from '../services/categories/category-store'
 import { getCategoryDisplay } from '../utils/category-display'
 import {
@@ -46,7 +47,7 @@ export function Categories({ transactions }: CategoriesProps) {
   const [form, setForm] = useState({
     id: '',
     label: '',
-    color: '#0ea5e9',
+    color: DEFAULT_CATEGORY_COLOR,
     icon: '🏷️',
     isIgnored: false,
   })
@@ -66,12 +67,12 @@ export function Categories({ transactions }: CategoriesProps) {
   const isEditing = form.id.length > 0
 
   function resetForm() {
-    setForm({ id: '', label: '', color: '#0ea5e9', icon: '🏷️', isIgnored: false })
+    setForm({ id: '', label: '', color: DEFAULT_CATEGORY_COLOR, icon: '🏷️', isIgnored: false })
     setShowForm(false)
   }
 
   function openNewForm() {
-    setForm({ id: '', label: '', color: '#0ea5e9', icon: '🏷️', isIgnored: false })
+    setForm({ id: '', label: '', color: DEFAULT_CATEGORY_COLOR, icon: '🏷️', isIgnored: false })
     setShowForm(true)
   }
 

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -589,7 +589,7 @@ export function Charts({
                   key={i}
                   style={{
                     display: 'flex', alignItems: 'center', gap: 12,
-                    padding: '11px 0', borderBottom: '1px solid var(--border)',
+                    padding: '11px 0', borderBottom: '1px solid var(--border)', minWidth: 0,
                   }}
                 >
                   <span className="font-mono text-muted-foreground" style={{ fontSize: 12, width: 16 }}>

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -22,6 +22,7 @@ import {
 import type { TooltipProps } from 'recharts'
 import type { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent'
 import { getCategoryDisplay } from '../utils/category-display'
+import { IconTile } from './ui/icon-tile'
 import { getCategoryDefinitions, isCategoryIgnored } from '../services/categories/category-registry'
 import { isTransferCategory } from '../services/transfers/internal-transfers'
 import {
@@ -31,6 +32,7 @@ import {
 } from '../services/charts/chart-data'
 import { convert } from '../services/currency/convert'
 import { FxChip } from './FxChip'
+import { CurrencyToggle } from './CurrencyToggle'
 import { formatCurrency, formatCurrencyShort } from '../utils/formatting'
 import { CategoryBreakdownList } from './CategoryBreakdownList'
 import type { CategoryBreakdownRow } from './CategoryBreakdownList'
@@ -164,7 +166,7 @@ export function Charts({
         <div
           style={{
             background: 'var(--bg)', border: '1px solid var(--border)',
-            borderRadius: 10, padding: '10px 14px', boxShadow: '0 4px 16px rgba(0,0,0,.08)',
+            borderRadius: 'var(--radius)', padding: '10px 14px', boxShadow: 'var(--shadow-md)',
           }}
         >
           <p style={{ fontWeight: 600, fontSize: 13, marginBottom: 2 }}>{payload[0].name}</p>
@@ -219,28 +221,10 @@ export function Charts({
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
           <FxChip fxRate={fxRate} onSetFxRate={onSetFxRate} />
-          <div
-            style={{
-              display: 'flex', background: 'var(--surface-2)',
-              borderRadius: 10, padding: 3, gap: 2,
-            }}
-          >
-            {(['USD', 'UYU'] as const).map((val) => (
-              <button
-                key={val}
-                onClick={() => onSetHomeCurrency?.(val)}
-                style={{
-                  padding: '5px 14px', borderRadius: 7, fontSize: 13, fontWeight: 500,
-                  background: homeCurrency === val ? 'var(--bg)' : 'transparent',
-                  color: homeCurrency === val ? 'var(--text)' : 'var(--text-faint)',
-                  border: 'none', cursor: 'pointer', transition: 'all 0.15s',
-                  boxShadow: homeCurrency === val ? '0 1px 3px rgba(0,0,0,.08)' : 'none',
-                }}
-              >
-                {val === 'USD' ? 'US$' : '$U'}
-              </button>
-            ))}
-          </div>
+          <CurrencyToggle
+            value={homeCurrency}
+            onChange={(c) => onSetHomeCurrency?.(c)}
+          />
         </div>
       </div>
 
@@ -262,7 +246,7 @@ export function Charts({
             Gasto promedio mensual
           </div>
           <div className="font-mono" style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>
-            {formatCurrencyShort(avgMonthly, homeCurrency)}
+            {formatCurrency(avgMonthly, homeCurrency)}
           </div>
           <div className="text-muted-foreground" style={{ fontSize: 12 }}>
             Últimos {monthlyTrend.length} meses
@@ -342,7 +326,7 @@ export function Charts({
                   TOTAL
                 </div>
                 <div className="font-mono" style={{ fontSize: 15, fontWeight: 700 }}>
-                  {formatCurrencyShort(totalExpenses, homeCurrency)}
+                  {formatCurrency(totalExpenses, homeCurrency)}
                 </div>
               </div>
             </div>
@@ -426,7 +410,7 @@ export function Charts({
             />
             <Tooltip
               contentStyle={{
-                background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 10,
+                background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 'var(--radius)',
               }}
               formatter={(value: ValueType) => formatCurrency(Number(value), homeCurrency)}
             />
@@ -469,7 +453,7 @@ export function Charts({
               />
               <Tooltip
                 contentStyle={{
-                  background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 10,
+                  background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 'var(--radius)',
                 }}
                 formatter={(value: ValueType) => [formatCurrency(Number(value), homeCurrency), 'Neto']}
               />
@@ -497,7 +481,7 @@ export function Charts({
                   color: (totalIncome - totalExpenseTrend) >= 0 ? 'var(--pos)' : 'var(--neg)',
                 }}
               >
-                {formatCurrencyShort(
+                {formatCurrency(
                   monthlyTrend.length > 0
                     ? (totalIncome - totalExpenseTrend) / monthlyTrend.length
                     : 0,
@@ -595,14 +579,7 @@ export function Charts({
                   <span className="font-mono text-muted-foreground" style={{ fontSize: 12, width: 16 }}>
                     {i + 1}
                   </span>
-                  <span
-                    style={{
-                      width: 30, height: 30, borderRadius: 8,
-                      background: display.color + '1f',
-                      display: 'grid', placeItems: 'center',
-                      fontSize: 14, flexShrink: 0,
-                    }}
-                  >
+                  <IconTile size="sm" color={display.color}>
                     {emoji ?? (
                       <span
                         style={{
@@ -611,7 +588,7 @@ export function Charts({
                         }}
                       />
                     )}
-                  </span>
+                  </IconTile>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div
                       style={{

--- a/src/components/ConfidenceBadge.tsx
+++ b/src/components/ConfidenceBadge.tsx
@@ -18,14 +18,14 @@ export function ConfidenceBadge({ confidence }: ConfidenceBadgeProps) {
   return (
     <span
       title={`Confianza ${level} · ${Math.round(confidence * 100)}%`}
-      style={{ display: 'inline-flex', gap: 2, alignItems: 'center' }}
+      style={{ display: 'inline-flex', gap: 2, alignItems: 'flex-end' }}
     >
       {[0, 1, 2].map((i) => (
         <span
           key={i}
           style={{
             width: 4,
-            height: 11,
+            height: [8, 11, 14][i],
             borderRadius: 2,
             background: filled > i ? color : 'var(--surface-3)',
           }}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useRef, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from './ui/alert-dialog'
+import { buttonVariants } from './ui/button'
+import { cn } from './ui/utils'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Eliminar',
+  cancelLabel = 'Cancelar',
+  destructive = true,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            className={cn(
+              destructive
+                ? buttonVariants({ variant: 'destructive' })
+                : buttonVariants()
+            )}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+interface ConfirmOptions {
+  title: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+}
+
+export function useConfirm(): {
+  confirm: (opts: ConfirmOptions) => Promise<boolean>
+  dialog: React.ReactNode
+} {
+  const [state, setState] = useState<{
+    open: boolean
+    opts: ConfirmOptions
+  }>({ open: false, opts: { title: '' } })
+
+  const resolveRef = useRef<((v: boolean) => void) | null>(null)
+
+  const confirm = useCallback((opts: ConfirmOptions): Promise<boolean> => {
+    return new Promise((resolve) => {
+      resolveRef.current = resolve
+      setState({ open: true, opts })
+    })
+  }, [])
+
+  function handleConfirm() {
+    setState((s) => ({ ...s, open: false }))
+    resolveRef.current?.(true)
+    resolveRef.current = null
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (!open) {
+      setState((s) => ({ ...s, open: false }))
+      resolveRef.current?.(false)
+      resolveRef.current = null
+    }
+  }
+
+  const dialog = (
+    <ConfirmDialog
+      open={state.open}
+      onOpenChange={handleOpenChange}
+      title={state.opts.title}
+      description={state.opts.description}
+      confirmLabel={state.opts.confirmLabel}
+      cancelLabel={state.opts.cancelLabel}
+      destructive={state.opts.destructive}
+      onConfirm={handleConfirm}
+    />
+  )
+
+  return { confirm, dialog }
+}

--- a/src/components/CurrencyToggle.tsx
+++ b/src/components/CurrencyToggle.tsx
@@ -1,0 +1,23 @@
+import type { Currency } from '../models'
+import { SegmentedToggle } from './ui/segmented-toggle'
+
+const CURRENCY_OPTIONS: { label: string; value: Currency }[] = [
+  { label: 'US$', value: 'USD' },
+  { label: '$U', value: 'UYU' },
+]
+
+interface CurrencyToggleProps {
+  value: Currency
+  onChange: (c: Currency) => void
+}
+
+export function CurrencyToggle({ value, onChange }: CurrencyToggleProps) {
+  return (
+    <SegmentedToggle
+      options={CURRENCY_OPTIONS}
+      value={value}
+      onChange={onChange}
+      aria-label="Moneda principal"
+    />
+  )
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,7 +14,9 @@ import {
 } from '../services/charts/chart-data'
 import { convert } from '../services/currency/convert'
 import { FxChip } from './FxChip'
-import { formatCurrency } from '../utils/formatting'
+import { CurrencyToggle } from './CurrencyToggle'
+import { formatCurrency, formatDateCompact } from '../utils/formatting'
+import { IconTile } from './ui/icon-tile'
 import { getDisplayDescription } from '../utils/transaction-display'
 import { CategoryBreakdownList } from './CategoryBreakdownList'
 import type { CategoryBreakdownRow } from './CategoryBreakdownList'
@@ -117,8 +119,7 @@ export function Dashboard({
     [transactions],
   )
 
-  const firstName = userName ? userName.split('@')[0] : null
-  const greeting = firstName ? `Hola, ${firstName} 👋` : 'Hola 👋'
+  const greeting = userName ? `Hola, ${userName} 👋` : 'Hola 👋'
 
   const categoryBreakdownRows: CategoryBreakdownRow[] = categoryBreakdown.map(
     (row) => ({
@@ -147,42 +148,16 @@ export function Dashboard({
             {greeting}
           </h1>
           <p className="text-muted-foreground" style={{ fontSize: 14 }}>
-            Esto es lo que pasó en tus cuentas Santander · {monthSummary.monthLabel || latestDate.toLocaleDateString('es-UY', { month: 'long', year: 'numeric', timeZone: 'UTC' })}
+            Esto es lo que pasó en tus cuentas · {monthSummary.monthLabel || latestDate.toLocaleDateString('es-UY', { month: 'long', year: 'numeric', timeZone: 'UTC' })}
           </p>
         </div>
         {hasTransactions && (
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
             <FxChip fxRate={fxRate} onSetFxRate={onSetFxRate} />
-            <div
-              style={{
-                display: 'flex',
-                background: 'var(--surface-2)',
-                borderRadius: 10,
-                padding: 3,
-                gap: 2,
-              }}
-            >
-              {(['USD', 'UYU'] as const).map((val) => (
-                <button
-                  key={val}
-                  onClick={() => onSetHomeCurrency?.(val)}
-                  style={{
-                    padding: '5px 14px',
-                    borderRadius: 7,
-                    fontSize: 13,
-                    fontWeight: 500,
-                    background: homeCurrency === val ? 'var(--bg)' : 'transparent',
-                    color: homeCurrency === val ? 'var(--text)' : 'var(--text-faint)',
-                    border: 'none',
-                    cursor: 'pointer',
-                    transition: 'all 0.15s',
-                    boxShadow: homeCurrency === val ? '0 1px 3px rgba(0,0,0,.08)' : 'none',
-                  }}
-                >
-                  {val === 'USD' ? 'US$' : '$U'}
-                </button>
-              ))}
-            </div>
+            <CurrencyToggle
+              value={homeCurrency}
+              onChange={(c) => onSetHomeCurrency?.(c)}
+            />
           </div>
         )}
       </div>
@@ -211,99 +186,6 @@ export function Dashboard({
 
       {hasTransactions && (
         <>
-          {/* 3 Account cards (native amounts) — hidden, kept for future use */}
-          {/* <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <AccountCard
-              icon={<CreditCard size={18} />}
-              title="Tarjeta de Crédito"
-              subtitle={creditCardSubtitle}
-              label="Consumo del período"
-              primaryAmount={creditCardSummaryUYU.expenses}
-              primaryCurrency="UYU"
-              primaryColor="var(--neg)"
-              primaryFontSize={22}
-              secondaryAmount={creditCardSummaryUSD.expenses}
-              secondaryCurrency="USD"
-              movimientos={creditCardTransactions.length}
-              convertedAmount={
-                convert(
-                  creditCardSummaryUYU.expenses,
-                  'UYU',
-                  homeCurrency,
-                  fxRate,
-                ) +
-                convert(
-                  creditCardSummaryUSD.expenses,
-                  'USD',
-                  homeCurrency,
-                  fxRate,
-                )
-              }
-              homeCurrency={homeCurrency}
-              onClick={
-                onNavigateToTransactions
-                  ? () => onNavigateToTransactions({ accountType: 'credit_card' })
-                  : undefined
-              }
-            />
-            <AccountCard
-              icon={<DollarSign size={18} />}
-              title="Cuenta en Dólares"
-              subtitle="Caja de ahorro USD"
-              label="Saldo disponible"
-              primaryAmount={usdBankSummary.balance}
-              primaryCurrency="USD"
-              primaryColor={
-                usdBankSummary.balance >= 0 ? 'var(--text)' : 'var(--neg)'
-              }
-              movimientos={usdBankTransactions.length}
-              convertedAmount={convert(
-                usdBankSummary.expenses,
-                'USD',
-                homeCurrency,
-                fxRate,
-              )}
-              homeCurrency={homeCurrency}
-              onClick={
-                onNavigateToTransactions
-                  ? () =>
-                      onNavigateToTransactions({
-                        accountType: 'bank_account',
-                        currency: 'USD',
-                      })
-                  : undefined
-              }
-            />
-            <AccountCard
-              icon={<Landmark size={18} />}
-              title="Cuenta en Pesos"
-              subtitle="Caja de ahorro UYU"
-              label="Saldo disponible"
-              primaryAmount={uyuBankSummary.balance}
-              primaryCurrency="UYU"
-              primaryColor={
-                uyuBankSummary.balance >= 0 ? 'var(--text)' : 'var(--neg)'
-              }
-              movimientos={uyuBankTransactions.length}
-              convertedAmount={convert(
-                uyuBankSummary.expenses,
-                'UYU',
-                homeCurrency,
-                fxRate,
-              )}
-              homeCurrency={homeCurrency}
-              onClick={
-                onNavigateToTransactions
-                  ? () =>
-                      onNavigateToTransactions({
-                        accountType: 'bank_account',
-                        currency: 'UYU',
-                      })
-                  : undefined
-              }
-            />
-          </div> */}
-
           {/* Este mes panel — converted + combined in home currency */}
           <Card className="p-6">
             <div
@@ -476,16 +358,9 @@ export function Dashboard({
                         borderBottom: i < recentTransactions.length - 1 ? '1px solid var(--border)' : 'none',
                       }}
                     >
-                      <span
-                        style={{
-                          width: 32, height: 32, borderRadius: 9,
-                          background: catDef.color + '1f',
-                          display: 'grid', placeItems: 'center',
-                          flexShrink: 0, fontSize: 15,
-                        }}
-                      >
+                      <IconTile size="md" color={catDef.color}>
                         {catDef.icon}
-                      </span>
+                      </IconTile>
                       <div style={{ minWidth: 0, flex: 1 }}>
                         <div
                           style={{
@@ -496,7 +371,7 @@ export function Dashboard({
                           {getDisplayDescription(tx)}
                         </div>
                         <div className="text-muted-foreground" style={{ fontSize: 11.5 }}>
-                          {tx.date.toLocaleDateString('es-UY', { day: 'numeric', month: 'short' })}
+                          {formatDateCompact(tx.date)}
                         </div>
                       </div>
                       <div style={{ flexShrink: 0, textAlign: 'right' }}>
@@ -507,7 +382,7 @@ export function Dashboard({
                           {isCredit ? '+' : '−'}
                           {formatCurrency(tx.amount, tx.currency)}
                         </span>
-                        {showConverted && convertedAmt !== null && (
+                        {showConverted && convertedAmt !== null && Math.abs(convertedAmt) >= 0.005 && (
                           <span
                             className="font-mono text-muted-foreground"
                             style={{ fontSize: 11, display: 'block' }}

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { CalendarIcon } from 'lucide-react'
 import type { DateRange } from 'react-day-picker'
+import { es } from 'date-fns/locale'
 import { Calendar } from './ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 
@@ -232,6 +233,7 @@ export function DateRangePicker({
               mode="range"
               numberOfMonths={2}
               weekStartsOn={1}
+              locale={es}
               selected={calendarSelected}
               onSelect={handleSelect}
               defaultMonth={defaultMonth}

--- a/src/components/EditTransactionDialog.tsx
+++ b/src/components/EditTransactionDialog.tsx
@@ -87,7 +87,7 @@ export function EditTransactionDialog({
         <DialogHeader>
           <DialogTitle>Editar transacción</DialogTitle>
           <DialogDescription>
-            Actualizá descripción visible, categoría y tags.
+            Actualizá descripción visible, categoría y etiquetas.
           </DialogDescription>
         </DialogHeader>
 
@@ -231,28 +231,28 @@ export function EditTransactionDialog({
           </div>
 
           <div>
-            <label className="text-sm font-medium">Tags</label>
+            <label className="text-sm font-medium">Etiquetas</label>
             <Popover open={tagPickerOpen} onOpenChange={onTagPickerOpenChange}>
               <PopoverTrigger asChild>
                 <button
                   type="button"
-                  aria-label="Tags dropdown"
+                  aria-label="Etiquetas dropdown"
                   className="mt-1 w-full h-9 rounded-md border border-input bg-input-background px-3 text-sm text-left hover:bg-muted/50"
                 >
                   {editTagList.length > 0
-                    ? `${editTagList.length} tags seleccionados`
-                    : 'Sin tags'}
+                    ? `${editTagList.length} ${editTagList.length === 1 ? 'etiqueta seleccionada' : 'etiquetas seleccionadas'}`
+                    : 'Sin etiquetas'}
                 </button>
               </PopoverTrigger>
               <PopoverContent className="p-0 w-[320px]" align="start">
                 <div className="p-2 space-y-2">
                   <Input
-                    aria-label="Nuevo tag"
+                    aria-label="Nueva etiqueta"
                     value={newTagInput}
                     onChange={(event) =>
                       onNewTagInputChange(event.target.value)
                     }
-                    placeholder="Buscar o crear tag"
+                    placeholder="Buscar o crear etiqueta"
                   />
                   <div
                     className="max-h-44 overflow-y-auto overscroll-contain space-y-1 pr-2"
@@ -277,14 +277,14 @@ export function EditTransactionDialog({
                   <Button
                     type="button"
                     variant="outline"
-                    aria-label="Crear tag"
+                    aria-label="Crear etiqueta"
                     className="w-full"
                     onClick={() => {
                       onAddInlineTag()
                       onTagPickerOpenChange(false)
                     }}
                   >
-                    Crear tag
+                    Crear etiqueta
                   </Button>
                 </div>
               </PopoverContent>
@@ -296,7 +296,7 @@ export function EditTransactionDialog({
                   <button
                     key={tag}
                     type="button"
-                    aria-label={`Quitar tag ${tag}`}
+                    aria-label={`Quitar etiqueta ${tag}`}
                     onClick={() => onRemoveTag(tag)}
                     className="inline-flex items-center rounded bg-muted px-2 py-0.5 text-xs"
                   >

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { Settings } from './Settings'
 import type { Transaction } from '../models'
 import type { SupabaseSession } from '../services/supabase/client'
@@ -59,9 +59,9 @@ describe('Settings', () => {
       screen.getByRole('heading', { name: 'Configuración' })
     ).toBeInTheDocument()
     expect(screen.getByText('Apariencia')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Claro' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Auto' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Oscuro' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Claro' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Auto' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Oscuro' })).toBeInTheDocument()
   })
 
   it('calls onSetTheme with the selected value when clicking a theme button', () => {
@@ -79,10 +79,10 @@ describe('Settings', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Oscuro' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Oscuro' }))
     expect(onSetTheme).toHaveBeenCalledWith('dark')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Auto' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Auto' }))
     expect(onSetTheme).toHaveBeenCalledWith('auto')
   })
 
@@ -101,7 +101,7 @@ describe('Settings', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Dólares US$' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Dólares US$' }))
     expect(onSetCurrency).toHaveBeenCalledWith('USD')
   })
 
@@ -164,9 +164,8 @@ describe('Settings', () => {
     ).toBeInTheDocument()
   })
 
-  it('calls onResetAllData after confirm on reset click', () => {
-    const onReset = vi.fn()
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  it('calls onResetAllData after confirm on reset click', async () => {
+    const onReset = vi.fn().mockResolvedValue(undefined)
 
     render(
       <Settings
@@ -184,6 +183,12 @@ describe('Settings', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Resetear' }))
-    expect(onReset).toHaveBeenCalledTimes(1)
+    await waitFor(() => screen.getByRole('alertdialog'))
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Eliminar todo',
+      })
+    )
+    await waitFor(() => expect(onReset).toHaveBeenCalledTimes(1))
   })
 })

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Download, Eye, EyeOff } from 'lucide-react'
+import { getFriendlyName } from '../utils/user-display'
 import { Button } from './ui/button'
 import { toast } from 'sonner'
 import type { Transaction } from '../models'
@@ -8,6 +9,10 @@ import { exportTransactions } from '../services/export/export'
 import { CoverageAnalysis } from './dev/CoverageAnalysis'
 import { AiCategorizationPreview } from './dev/AiCategorizationPreview'
 import { AiPatternAnalysis } from './dev/AiPatternAnalysis'
+import { SectionCard } from './ui/card'
+import { IconTile } from './ui/icon-tile'
+import { SegmentedToggle } from './ui/segmented-toggle'
+import { useConfirm } from './ConfirmDialog'
 
 interface SettingsProps {
   theme: 'light' | 'dark' | 'auto'
@@ -29,83 +34,7 @@ interface SettingsProps {
   onSetAiModel: (model: string) => void
 }
 
-function SegmentControl({
-  options,
-  value,
-  onChange,
-}: {
-  options: { label: string; value: string }[]
-  value: string
-  onChange: (v: string) => void
-}) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        background: 'var(--surface-2)',
-        borderRadius: 'var(--radius-sm)',
-        padding: 3,
-        gap: 2,
-      }}
-    >
-      {options.map((opt) => (
-        <button
-          key={opt.value}
-          onClick={() => onChange(opt.value)}
-          style={{
-            padding: '6px 14px',
-            borderRadius: 7,
-            border: 'none',
-            cursor: 'pointer',
-            fontSize: 13,
-            fontWeight: value === opt.value ? 600 : 500,
-            background:
-              value === opt.value ? 'var(--surface)' : 'transparent',
-            color:
-              value === opt.value ? 'var(--text)' : 'var(--text-muted)',
-            boxShadow:
-              value === opt.value
-                ? '0 1px 3px oklch(0 0 0 / 0.08)'
-                : 'none',
-            transition: 'background 0.12s, color 0.12s',
-          }}
-        >
-          {opt.label}
-        </button>
-      ))}
-    </div>
-  )
-}
 
-function SectionCard({
-  title,
-  children,
-}: {
-  title: string
-  children: React.ReactNode
-}) {
-  return (
-    <div
-      style={{
-        background: 'var(--surface)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        overflow: 'hidden',
-        marginBottom: 16,
-      }}
-    >
-      <div
-        style={{
-          padding: '16px 24px',
-          borderBottom: '1px solid var(--border)',
-        }}
-      >
-        <h3 style={{ fontSize: 15, fontWeight: 600 }}>{title}</h3>
-      </div>
-      <div>{children}</div>
-    </div>
-  )
-}
 
 function SettingRow({
   label,
@@ -113,7 +42,7 @@ function SettingRow({
   control,
 }: {
   label: string
-  description?: string
+  description?: React.ReactNode
   control: React.ReactNode
 }) {
   return (
@@ -168,9 +97,10 @@ export function Settings({
   onSetAiModel,
 }: SettingsProps) {
   const userEmail = session?.user?.email ?? ''
-  const userName = userEmail ? userEmail.split('@')[0] : 'Usuario'
+  const userName = getFriendlyName(session) || 'Usuario'
   const avatarInitial = userName.charAt(0).toUpperCase()
   const [showKey, setShowKey] = useState(false)
+  const { confirm: confirmReset, dialog: confirmDialog } = useConfirm()
 
   function handleExport(format: 'csv' | 'pdf') {
     exportTransactions(transactions, { format })
@@ -182,10 +112,14 @@ export function Settings({
   }
 
   async function handleResetAllData() {
-    const confirmed = window.confirm(
-      'Esto eliminará todas tus transacciones y configuraciones. ¿Querés continuar?'
-    )
-    if (!confirmed || !onResetAllData) return
+    if (!onResetAllData) return
+    const confirmed = await confirmReset({
+      title: '¿Eliminar todos los datos?',
+      description:
+        'Esto eliminará todas tus transacciones, categorías y reglas guardadas. Esta acción no se puede deshacer.',
+      confirmLabel: 'Eliminar todo',
+    })
+    if (!confirmed) return
     await onResetAllData()
   }
 
@@ -216,14 +150,15 @@ export function Settings({
           label="Tema"
           description="Elegí cómo se ve Tatú"
           control={
-            <SegmentControl
+            <SegmentedToggle
               options={[
-                { label: 'Claro', value: 'light' },
-                { label: 'Auto', value: 'auto' },
-                { label: 'Oscuro', value: 'dark' },
+                { label: 'Claro', value: 'light' as const },
+                { label: 'Auto', value: 'auto' as const },
+                { label: 'Oscuro', value: 'dark' as const },
               ]}
               value={theme}
-              onChange={(v) => onSetTheme(v as 'light' | 'dark' | 'auto')}
+              onChange={(v) => onSetTheme(v)}
+              aria-label="Tema"
             />
           }
         />
@@ -235,13 +170,14 @@ export function Settings({
           label="Moneda principal"
           description="Moneda en la que se convierten y combinan todos los totales"
           control={
-            <SegmentControl
+            <SegmentedToggle
               options={[
-                { label: 'Pesos $U', value: 'UYU' },
-                { label: 'Dólares US$', value: 'USD' },
+                { label: 'Pesos $U', value: 'UYU' as const },
+                { label: 'Dólares US$', value: 'USD' as const },
               ]}
               value={preferredCurrency}
-              onChange={(v) => onSetCurrency(v as 'UYU' | 'USD')}
+              onChange={(v) => onSetCurrency(v)}
+              aria-label="Moneda principal"
             />
           }
         />
@@ -321,7 +257,20 @@ export function Settings({
         />
         <SettingRow
           label="Clave API de Anthropic"
-          description="Obtenela en console.anthropic.com · Se guarda en tu cuenta"
+          description={
+            <>
+              Obtenela en{' '}
+              <a
+                href="https://console.anthropic.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--brand)', textDecoration: 'underline' }}
+              >
+                console.anthropic.com
+              </a>
+              {' '}· El costo de uso es tuyo · Se guarda en tu cuenta
+            </>
+          }
           control={
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <input
@@ -364,13 +313,14 @@ export function Settings({
           description="Haiku es más rápido y económico; Sonnet es más preciso"
           control={
             <div style={{ opacity: aiEnabled ? 1 : 0.5, pointerEvents: aiEnabled ? 'auto' : 'none' }}>
-              <SegmentControl
+              <SegmentedToggle
                 options={[
-                  { label: 'Haiku', value: 'claude-haiku-4-5' },
-                  { label: 'Sonnet', value: 'claude-sonnet-4-6' },
+                  { label: 'Haiku', value: 'claude-haiku-4-5' as const },
+                  { label: 'Sonnet', value: 'claude-sonnet-4-6' as const },
                 ]}
                 value={aiModel}
                 onChange={onSetAiModel}
+                aria-label="Modelo de IA"
               />
             </div>
           }
@@ -387,7 +337,7 @@ export function Settings({
               gap: 6,
             }}
           >
-            <span style={{ color: '#22c55e' }}>✓</span>
+            <span style={{ color: 'var(--pos)' }}>✓</span>
             IA activa · se aplicará en tu próxima importación
           </div>
         )}
@@ -407,22 +357,14 @@ export function Settings({
               }}
             >
               <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                <span
-                  style={{
-                    width: 36,
-                    height: 36,
-                    borderRadius: 10,
-                    background: 'var(--accent-soft)',
-                    color: 'var(--accent)',
-                    display: 'grid',
-                    placeItems: 'center',
-                    fontWeight: 700,
-                    fontSize: 15,
-                    flexShrink: 0,
-                  }}
+                <IconTile
+                  size="lg"
+                  bg="var(--accent-soft)"
+                  color="var(--accent)"
+                  className="font-bold"
                 >
                   {avatarInitial}
-                </span>
+                </IconTile>
                 <div>
                   <div style={{ fontSize: 14, fontWeight: 600 }}>
                     {userName}
@@ -576,6 +518,8 @@ export function Settings({
           />
         </SectionCard>
       )}
+
+      {confirmDialog}
     </div>
   )
 }

--- a/src/components/TransactionFilters.tsx
+++ b/src/components/TransactionFilters.tsx
@@ -10,6 +10,7 @@ import {
   PopoverTrigger,
 } from './ui/popover'
 import { CategoryBadge } from './CategoryBadge'
+import { SegmentedToggle } from './ui/segmented-toggle'
 
 interface TransactionFiltersProps {
   searchTerm: string
@@ -114,22 +115,45 @@ export function TransactionFilters({
           </PopoverContent>
         </Popover>
 
-        <select
-          id="transactions-account-filter"
-          aria-label="Filtro cuenta"
-          value={accountFilter}
-          onChange={(event) =>
-            onAccountChange(
-              event.target.value as 'all' | 'credit_card' | 'bank_account'
-            )
-          }
-          className="border-input bg-input-background focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 rounded-md border px-3 py-1 text-sm outline-none focus-visible:ring-[3px]"
-          style={{ minWidth: 120 }}
-        >
-          <option value="all">Cuenta</option>
-          <option value="bank_account">Cuenta bancaria</option>
-          <option value="credit_card">Tarjeta</option>
-        </select>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              id="transactions-account-filter"
+              aria-label="Filtro cuenta"
+              className="border-input bg-input-background focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-9 items-center gap-1.5 rounded-md border px-3 py-1 text-sm outline-none focus-visible:ring-[3px]"
+              style={{ minWidth: 130 }}
+            >
+              <span className={accountFilter === 'all' ? 'text-muted-foreground' : ''}>
+                {accountFilter === 'all'
+                  ? 'Cuenta'
+                  : accountFilter === 'bank_account'
+                    ? 'Cuenta bancaria'
+                    : 'Tarjeta'}
+              </span>
+              <ChevronDown size={14} className="text-muted-foreground ml-auto shrink-0" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="p-1 w-[180px]" align="start">
+            {(
+              [
+                { value: 'all', label: 'Todas las cuentas' },
+                { value: 'bank_account', label: 'Cuenta bancaria' },
+                { value: 'credit_card', label: 'Tarjeta' },
+              ] as const
+            ).map(({ value, label }) => (
+              <PopoverClose key={value} asChild>
+                <button
+                  className="w-full rounded px-3 py-1.5 text-left text-sm hover:bg-muted/50"
+                  style={{ fontWeight: accountFilter === value ? 600 : 400 }}
+                  onClick={() => onAccountChange(value)}
+                >
+                  {label}
+                </button>
+              </PopoverClose>
+            ))}
+          </PopoverContent>
+        </Popover>
         <DateRangePicker
           dateFrom={dateFromFilter}
           dateTo={dateToFilter}
@@ -145,91 +169,30 @@ export function TransactionFilters({
         style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}
       >
         {/* Type filter */}
-        <div
-          style={{
-            display: 'inline-flex',
-            background: 'var(--surface-2)',
-            borderRadius: 10,
-            padding: 3,
-            gap: 2,
-          }}
-        >
-          {(
-            [
-              { value: 'all', label: 'Todos' },
-              { value: 'credit', label: 'Ingresos' },
-              { value: 'debit', label: 'Gastos' },
-            ] as const
-          ).map(({ value, label }) => (
-            <button
-              key={value}
-              onClick={() => onTypeChange(value)}
-              style={{
-                padding: '4px 12px',
-                borderRadius: 7,
-                fontSize: 13,
-                fontWeight: 500,
-                background:
-                  typeFilter === value ? 'var(--bg)' : 'transparent',
-                color:
-                  typeFilter === value ? 'var(--text)' : 'var(--text-faint)',
-                border: 'none',
-                cursor: 'pointer',
-                boxShadow:
-                  typeFilter === value
-                    ? '0 1px 3px rgba(0,0,0,.08)'
-                    : 'none',
-              }}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <SegmentedToggle
+          options={[
+            { value: 'all' as const, label: 'Todos' },
+            { value: 'credit' as const, label: 'Ingresos' },
+            { value: 'debit' as const, label: 'Gastos' },
+          ]}
+          value={typeFilter}
+          onChange={onTypeChange}
+          size="sm"
+          aria-label="Tipo de transacción"
+        />
 
         {/* Currency filter */}
-        <div
-          style={{
-            display: 'inline-flex',
-            background: 'var(--surface-2)',
-            borderRadius: 10,
-            padding: 3,
-            gap: 2,
-          }}
-        >
-          {(
-            [
-              { value: 'all', label: 'Todo' },
-              { value: 'UYU', label: '$U' },
-              { value: 'USD', label: 'US$' },
-            ] as const
-          ).map(({ value, label }) => (
-            <button
-              key={value}
-              aria-label={`Filtro moneda ${label}`}
-              onClick={() => onCurrencyChange(value)}
-              style={{
-                padding: '4px 12px',
-                borderRadius: 7,
-                fontSize: 13,
-                fontWeight: 500,
-                background:
-                  currencyFilter === value ? 'var(--bg)' : 'transparent',
-                color:
-                  currencyFilter === value
-                    ? 'var(--text)'
-                    : 'var(--text-faint)',
-                border: 'none',
-                cursor: 'pointer',
-                boxShadow:
-                  currencyFilter === value
-                    ? '0 1px 3px rgba(0,0,0,.08)'
-                    : 'none',
-              }}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <SegmentedToggle
+          options={[
+            { value: 'all' as const, label: 'Todo' },
+            { value: 'UYU' as const, label: '$U' },
+            { value: 'USD' as const, label: 'US$' },
+          ]}
+          value={currencyFilter}
+          onChange={onCurrencyChange}
+          size="sm"
+          aria-label="Moneda"
+        />
 
         {/* Ignored categories toggle */}
         <button
@@ -239,17 +202,20 @@ export function TransactionFilters({
           style={{
             display: 'inline-flex',
             alignItems: 'center',
-            justifyContent: 'center',
-            width: 36,
+            gap: 5,
             height: 36,
+            padding: '0 10px',
             borderRadius: 8,
             border: '1px solid var(--border)',
             background: showIgnored ? 'transparent' : 'var(--surface-2)',
             color: showIgnored ? 'var(--text-faint)' : 'var(--text)',
             cursor: 'pointer',
+            fontSize: 13,
+            fontWeight: 500,
           }}
         >
           {showIgnored ? <Eye size={15} /> : <EyeOff size={15} />}
+          Ignoradas
         </button>
 
         {hasActiveFilters && (

--- a/src/components/TransactionFilters.tsx
+++ b/src/components/TransactionFilters.tsx
@@ -1,9 +1,15 @@
-import { Search, X } from 'lucide-react'
+import { ChevronDown, Eye, EyeOff, Search, X } from 'lucide-react'
 import { DateRangePicker } from './DateRangePicker'
 import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { Input } from './ui/input'
-import { getCategoryDisplay } from '../utils/category-display'
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from './ui/popover'
+import { CategoryBadge } from './CategoryBadge'
 
 interface TransactionFiltersProps {
   searchTerm: string
@@ -13,6 +19,7 @@ interface TransactionFiltersProps {
   accountFilter: 'all' | 'credit_card' | 'bank_account'
   currencyFilter: 'all' | 'USD' | 'UYU'
   typeFilter: 'all' | 'credit' | 'debit'
+  showIgnored: boolean
   availableCategories: string[]
   hasActiveFilters: boolean
   onSearchChange: (value: string) => void
@@ -22,6 +29,7 @@ interface TransactionFiltersProps {
   onAccountChange: (value: 'all' | 'credit_card' | 'bank_account') => void
   onCurrencyChange: (value: 'all' | 'USD' | 'UYU') => void
   onTypeChange: (value: 'all' | 'credit' | 'debit') => void
+  onShowIgnoredChange: (value: boolean) => void
   onClearAll: () => void
 }
 
@@ -33,6 +41,7 @@ export function TransactionFilters({
   accountFilter,
   currencyFilter,
   typeFilter,
+  showIgnored,
   availableCategories,
   hasActiveFilters,
   onSearchChange,
@@ -42,6 +51,7 @@ export function TransactionFilters({
   onAccountChange,
   onCurrencyChange,
   onTypeChange,
+  onShowIgnoredChange,
   onClearAll,
 }: TransactionFiltersProps) {
   return (
@@ -63,21 +73,47 @@ export function TransactionFilters({
             style={{ fontSize: 13 }}
           />
         </div>
-        <select
-          id="transactions-category-filter"
-          aria-label="Filtro categoría"
-          value={categoryFilter}
-          onChange={(event) => onCategoryChange(event.target.value)}
-          className="border-input bg-input-background focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 rounded-md border px-3 py-1 text-sm outline-none focus-visible:ring-[3px]"
-          style={{ minWidth: 130 }}
-        >
-          <option value="">Categoría</option>
-          {availableCategories.map((category) => (
-            <option key={category} value={category}>
-              {getCategoryDisplay(category).label}
-            </option>
-          ))}
-        </select>
+
+        {/* Category picker */}
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              id="transactions-category-filter"
+              aria-label="Filtro categoría"
+              className="border-input bg-input-background focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-9 items-center gap-1.5 rounded-md border px-3 py-1 text-sm outline-none focus-visible:ring-[3px]"
+              style={{ minWidth: 130 }}
+            >
+              {categoryFilter ? (
+                <CategoryBadge categoryId={categoryFilter} size="sm" />
+              ) : (
+                <span className="text-muted-foreground">Categoría</span>
+              )}
+              <ChevronDown size={14} className="text-muted-foreground ml-auto shrink-0" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="p-1 w-[220px]" align="start">
+            <PopoverClose asChild>
+              <button
+                className="w-full rounded px-3 py-1.5 text-left text-sm text-muted-foreground hover:bg-muted/50"
+                onClick={() => onCategoryChange('')}
+              >
+                Todas las categorías
+              </button>
+            </PopoverClose>
+            {availableCategories.map((cat) => (
+              <PopoverClose key={cat} asChild>
+                <button
+                  className="w-full rounded px-3 py-1.5 text-left hover:bg-muted/50"
+                  onClick={() => onCategoryChange(cat)}
+                >
+                  <CategoryBadge categoryId={cat} size="sm" />
+                </button>
+              </PopoverClose>
+            ))}
+          </PopoverContent>
+        </Popover>
+
         <select
           id="transactions-account-filter"
           aria-label="Filtro cuenta"
@@ -104,7 +140,7 @@ export function TransactionFilters({
         />
       </div>
 
-      {/* Row 2: Type segment + Currency segment + Clear */}
+      {/* Row 2: Type segment + Currency segment + Ignored toggle + Clear */}
       <div
         style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}
       >
@@ -194,6 +230,27 @@ export function TransactionFilters({
             </button>
           ))}
         </div>
+
+        {/* Ignored categories toggle */}
+        <button
+          aria-label={showIgnored ? 'Ocultar categorías ignoradas' : 'Mostrar categorías ignoradas'}
+          title={showIgnored ? 'Ocultar categorías ignoradas' : 'Mostrar categorías ignoradas'}
+          onClick={() => onShowIgnoredChange(!showIgnored)}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 36,
+            height: 36,
+            borderRadius: 8,
+            border: '1px solid var(--border)',
+            background: showIgnored ? 'transparent' : 'var(--surface-2)',
+            color: showIgnored ? 'var(--text-faint)' : 'var(--text)',
+            cursor: 'pointer',
+          }}
+        >
+          {showIgnored ? <Eye size={15} /> : <EyeOff size={15} />}
+        </button>
 
         {hasActiveFilters && (
           <Button

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -1,7 +1,8 @@
-import { ArrowUpDown, CreditCard, Pencil, Search, Trash2, Wallet } from 'lucide-react'
+import { ArrowUpDown, CreditCard, Info, Pencil, Search, Trash2, Wallet } from 'lucide-react'
 import { Button } from './ui/button'
 import { EmptyState } from './EmptyState'
 import { Card } from './ui/card'
+import { IconTile } from './ui/icon-tile'
 import { Checkbox } from './ui/checkbox'
 import { CategoryBadge } from './CategoryBadge'
 import { ConfidenceBadge } from './ConfidenceBadge'
@@ -140,8 +141,15 @@ export function TransactionTable({
               <th className="text-left px-3.5 py-3 text-[11.5px] font-bold uppercase tracking-[0.05em] text-muted-foreground">
                 Cuenta
               </th>
-              <th className="text-center px-3.5 py-3 text-[11.5px] font-bold uppercase tracking-[0.05em] text-muted-foreground w-14">
-                Conf.
+              <th className="text-center px-3.5 py-3 text-[11.5px] font-bold uppercase tracking-[0.05em] text-muted-foreground w-20">
+                <span className="inline-flex items-center gap-1">
+                  Confianza
+                  <Info
+                    size={12}
+                    className="text-muted-foreground/60"
+                    title="Confianza de la categorización automática. Más barras = más seguridad."
+                  />
+                </span>
               </th>
               <th
                 className="text-right px-3.5 py-3 text-[11.5px] font-bold uppercase tracking-[0.05em] text-muted-foreground"
@@ -221,19 +229,11 @@ export function TransactionTable({
                           const catId = transaction.category ?? 'uncategorized'
                           const definition = getCategoryDefinition(catId)
                           return (
-                            <span
+                            <IconTile
                               aria-hidden="true"
-                              style={{
-                                width: 30,
-                                height: 30,
-                                borderRadius: 8,
-                                background: definition.color + '1f',
-                                display: 'grid',
-                                placeItems: 'center',
-                                fontSize: 14,
-                                flexShrink: 0,
-                                marginTop: 1,
-                              }}
+                              size="sm"
+                              color={definition.color}
+                              style={{ marginTop: 1 }}
                             >
                               {definition.icon ?? (
                                 <span
@@ -246,7 +246,7 @@ export function TransactionTable({
                                   }}
                                 />
                               )}
-                            </span>
+                            </IconTile>
                           )
                         })()}
                         <div style={{ minWidth: 0 }}>
@@ -316,7 +316,7 @@ export function TransactionTable({
                       </div>
                     </td>
                     <td className="px-3.5 py-3 text-center">
-                      <div className="flex items-center justify-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-[120ms]">
+                      <div className="flex items-center justify-center gap-1 opacity-50 group-hover:opacity-100 transition-opacity duration-[120ms]">
                         <Button
                           variant="ghost"
                           size="sm"

--- a/src/components/Transactions.test.tsx
+++ b/src/components/Transactions.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { Transactions } from './Transactions'
 import type { Transaction } from '../models'
 
@@ -146,7 +146,7 @@ describe('Transactions', () => {
     expect(screen.queryByText('restaurants')).not.toBeInTheDocument()
   })
 
-  it('shows filter-specific empty state when structured filters remove all matches', () => {
+  it('shows filter-specific empty state when structured filters remove all matches', async () => {
     render(
       <Transactions
         transactions={[
@@ -159,14 +159,13 @@ describe('Transactions', () => {
       />
     )
 
-    fireEvent.change(
-      screen.getByLabelText('Filtro cuenta'),
-      { target: { value: 'credit_card' } }
-    )
+    fireEvent.click(screen.getByLabelText('Filtro cuenta'))
+    await waitFor(() => screen.getByText('Tarjeta'))
+    fireEvent.click(screen.getByText('Tarjeta'))
 
-    expect(
-      screen.getAllByText('Sin resultados').length
-    ).toBeGreaterThan(0)
+    await waitFor(() =>
+      expect(screen.getAllByText('Sin resultados').length).toBeGreaterThan(0)
+    )
     expect(screen.getByText('Mostrando 0 de 0')).toBeInTheDocument()
   })
 
@@ -389,13 +388,13 @@ describe('Transactions', () => {
       target: { value: 'services' },
     })
     fireEvent.click(screen.getByLabelText('Crear categoría'))
-    fireEvent.click(screen.getByLabelText('Tags dropdown'))
+    fireEvent.click(screen.getByLabelText('Etiquetas dropdown'))
     fireEvent.click(screen.getAllByText('monthly')[0])
-    fireEvent.click(screen.getByLabelText('Tags dropdown'))
-    fireEvent.change(screen.getByLabelText('Nuevo tag'), {
+    fireEvent.click(screen.getByLabelText('Etiquetas dropdown'))
+    fireEvent.change(screen.getByLabelText('Nueva etiqueta'), {
       target: { value: 'recurring' },
     })
-    fireEvent.click(screen.getByLabelText('Crear tag'))
+    fireEvent.click(screen.getByLabelText('Crear etiqueta'))
     fireEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }))
 
     await waitFor(() =>
@@ -517,14 +516,13 @@ describe('Transactions', () => {
     fireEvent.click(screen.getByLabelText('Categoría dropdown'))
     expect(screen.getAllByText('Servicios').length).toBeGreaterThan(0)
 
-    fireEvent.click(screen.getByLabelText('Tags dropdown'))
+    fireEvent.click(screen.getByLabelText('Etiquetas dropdown'))
     expect(screen.getAllByText('monthly').length).toBeGreaterThan(0)
     expect(screen.getByText('fixed-cost')).toBeInTheDocument()
   })
 
   it('triggers delete callback only after confirmation', async () => {
     const onDeleteTransaction = vi.fn().mockResolvedValue(undefined)
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     render(
       <Transactions
@@ -537,15 +535,20 @@ describe('Transactions', () => {
       screen.getAllByRole('button', { name: 'Eliminar to-delete' })[0]
     )
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    await waitFor(() => screen.getByRole('alertdialog'))
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Eliminar',
+      })
+    )
+
     await waitFor(() =>
       expect(onDeleteTransaction).toHaveBeenCalledWith('tx-1')
     )
   })
 
-  it('does not delete when confirmation is rejected', () => {
+  it('does not delete when confirmation is rejected', async () => {
     const onDeleteTransaction = vi.fn()
-    vi.spyOn(window, 'confirm').mockReturnValue(false)
 
     render(
       <Transactions
@@ -556,6 +559,13 @@ describe('Transactions', () => {
 
     fireEvent.click(
       screen.getAllByRole('button', { name: 'Eliminar to-keep' })[0]
+    )
+
+    await waitFor(() => screen.getByRole('alertdialog'))
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Cancelar',
+      })
     )
 
     expect(onDeleteTransaction).not.toHaveBeenCalled()
@@ -608,7 +618,6 @@ describe('Transactions', () => {
 
   it('bulk deletes selected transactions after confirmation', async () => {
     const onBulkDelete = vi.fn().mockResolvedValue(undefined)
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     render(
       <Transactions
@@ -627,8 +636,13 @@ describe('Transactions', () => {
       screen.getAllByRole('checkbox', { name: 'Seleccionar Merchant B' })[0]
     )
 
+    fireEvent.click(screen.getByRole('button', { name: /^Eliminar$/ }))
+
+    await waitFor(() => screen.getByRole('alertdialog'))
     fireEvent.click(
-      screen.getByRole('button', { name: /^Eliminar$/ })
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Eliminar',
+      })
     )
 
     await waitFor(() =>
@@ -636,9 +650,8 @@ describe('Transactions', () => {
     )
   })
 
-  it('does not bulk delete when confirmation is rejected', () => {
+  it('does not bulk delete when confirmation is rejected', async () => {
     const onBulkDelete = vi.fn()
-    vi.spyOn(window, 'confirm').mockReturnValue(false)
 
     render(
       <Transactions
@@ -651,8 +664,13 @@ describe('Transactions', () => {
       screen.getAllByRole('checkbox', { name: 'Seleccionar Merchant A' })[0]
     )
 
+    fireEvent.click(screen.getByRole('button', { name: /^Eliminar$/ }))
+
+    await waitFor(() => screen.getByRole('alertdialog'))
     fireEvent.click(
-      screen.getByRole('button', { name: /^Eliminar$/ })
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Cancelar',
+      })
     )
 
     expect(onBulkDelete).not.toHaveBeenCalled()
@@ -684,7 +702,7 @@ describe('Transactions', () => {
       )
     })
 
-    fireEvent.click(screen.getByLabelText('Tags bulk dropdown'))
+    fireEvent.click(screen.getByLabelText('Etiquetas bulk dropdown'))
 
     const tagButtons = screen.getAllByText('#monthly')
     fireEvent.click(tagButtons[tagButtons.length - 1])
@@ -714,13 +732,13 @@ describe('Transactions', () => {
       screen.getAllByRole('button', { name: /Editar/ })[0]
     )
 
-    fireEvent.click(screen.getByLabelText('Tags bulk dropdown'))
+    fireEvent.click(screen.getByLabelText('Etiquetas bulk dropdown'))
 
-    fireEvent.change(screen.getByLabelText('Buscar o crear tag'), {
+    fireEvent.change(screen.getByLabelText('Buscar o crear etiqueta'), {
       target: { value: 'new-tag' },
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /Crear tag "new-tag"/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Crear etiqueta "new-tag"/ }))
 
     fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }))
 

--- a/src/components/Transactions.test.tsx
+++ b/src/components/Transactions.test.tsx
@@ -121,7 +121,7 @@ describe('Transactions', () => {
     expect(screen.getByText('Mostrando 1-1 de 1')).toBeInTheDocument()
   })
 
-  it('shows translated and humanized category labels in filters', () => {
+  it('shows translated category labels in filter dropdown', () => {
     render(
       <Transactions
         transactions={[
@@ -130,22 +130,20 @@ describe('Transactions', () => {
             category: 'groceries',
           },
           {
-            ...makeTransaction(2, 'Home Office Expense'),
-            category: 'home_office',
+            ...makeTransaction(2, 'Resto del Mundo'),
+            category: 'restaurants',
           },
         ]}
       />
     )
 
-    expect(
-      screen.getByRole('option', { name: 'Alimentación' })
-    ).toHaveValue('groceries')
-    expect(
-      screen.getByRole('option', { name: 'Home office' })
-    ).toHaveValue('home_office')
-    expect(
-      screen.queryByRole('option', { name: 'groceries' })
-    ).not.toBeInTheDocument()
+    // Open the category filter popover
+    fireEvent.click(screen.getByLabelText('Filtro categoría'))
+
+    expect(screen.getAllByText('Alimentación').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Restaurantes').length).toBeGreaterThan(0)
+    expect(screen.queryByText('groceries')).not.toBeInTheDocument()
+    expect(screen.queryByText('restaurants')).not.toBeInTheDocument()
   })
 
   it('shows filter-specific empty state when structured filters remove all matches', () => {
@@ -518,7 +516,6 @@ describe('Transactions', () => {
 
     fireEvent.click(screen.getByLabelText('Categoría dropdown'))
     expect(screen.getAllByText('Servicios').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('Custom category').length).toBeGreaterThan(0)
 
     fireEvent.click(screen.getByLabelText('Tags dropdown'))
     expect(screen.getAllByText('monthly').length).toBeGreaterThan(0)

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -64,6 +64,8 @@ export function Transactions({
     setCurrencyFilter,
     typeFilter,
     setTypeFilter,
+    showIgnored,
+    setShowIgnored,
     sortField,
     sortDirection,
     handleSort,
@@ -432,6 +434,7 @@ export function Transactions({
         accountFilter={accountFilter}
         currencyFilter={currencyFilter}
         typeFilter={typeFilter}
+        showIgnored={showIgnored}
         availableCategories={availableCategories}
         hasActiveFilters={hasActiveFilters}
         onSearchChange={setSearchTerm}
@@ -441,6 +444,7 @@ export function Transactions({
         onAccountChange={setAccountFilter}
         onCurrencyChange={setCurrencyFilter}
         onTypeChange={setTypeFilter}
+        onShowIgnoredChange={setShowIgnored}
         onClearAll={clearAllFilters}
       />
 

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -13,10 +13,12 @@ import { TransactionFilters } from './TransactionFilters'
 import { TransactionTable } from './TransactionTable'
 import { formatCurrency } from '../utils/formatting'
 import { exportTransactions } from '../services/export/export'
+import { useConfirm } from './ConfirmDialog'
 import {
   addCustomCategory,
   listCustomCategories,
   syncCustomCategoryToCloud,
+  DEFAULT_CATEGORY_COLOR,
 } from '../services/categories/category-store'
 import type { TransactionsFilter } from '../models'
 
@@ -111,6 +113,7 @@ export function Transactions({
     'single' | 'matching_past_and_future' | 'future_matching_only'
   >('single')
   const [editError, setEditError] = useState('')
+  const { confirm: confirmDeletion, dialog: confirmDialog } = useConfirm()
 
   const categorySuggestions = useMemo(() => {
     return Array.from(
@@ -199,7 +202,7 @@ export function Transactions({
   function handleAddCategory() {
     const value = newCategoryInput.trim()
     if (!value) return
-    const created = addCustomCategory({ label: value, color: '#0ea5e9', icon: '🏷️' })
+    const created = addCustomCategory({ label: value, color: DEFAULT_CATEGORY_COLOR, icon: '🏷️' })
     setEditCategory(created.id)
     setNewCategoryInput('')
     void syncCustomCategoryToCloud(created.id)
@@ -247,9 +250,11 @@ export function Transactions({
   async function handleDeleteTransaction(transaction: Transaction) {
     if (!onDeleteTransaction) return
 
-    const confirmed = window.confirm(
-      `¿Eliminar la transacción "${getDisplayDescription(transaction)}"?`
-    )
+    const confirmed = await confirmDeletion({
+      title: '¿Eliminar transacción?',
+      description: 'Esta acción no se puede deshacer.',
+      confirmLabel: 'Eliminar',
+    })
     if (!confirmed) return
 
     setPendingTransactionId(transaction.id)
@@ -331,12 +336,13 @@ export function Transactions({
       return
     }
 
-    const confirmed = window.confirm(
-      `¿Eliminar ${selectedTransactionIds.length} transacción${selectedTransactionIds.length === 1 ? '' : 'es'}?`
-    )
-    if (!confirmed) return
-
     const count = selectedTransactionIds.length
+    const confirmed = await confirmDeletion({
+      title: `¿Eliminar ${count} transacción${count === 1 ? '' : 'es'}?`,
+      description: 'Esta acción no se puede deshacer.',
+      confirmLabel: 'Eliminar',
+    })
+    if (!confirmed) return
     setIsBulkOperating(true)
     try {
       await onBulkDelete(selectedTransactionIds)
@@ -541,21 +547,21 @@ export function Transactions({
                     {
                       label: 'Ingresos',
                       amount: totals.income[currency],
-                      color: 'var(--text)',
+                      color: 'var(--pos)',
                     },
                     {
                       label: 'Gastos',
                       amount: totals.expense[currency],
-                      color: 'var(--text)',
+                      color: 'var(--neg)',
                     },
                     {
                       label: 'Neto',
                       amount: net,
                       color:
                         net > 0
-                          ? 'var(--color-success, #16a34a)'
+                          ? 'var(--pos)'
                           : net < 0
-                            ? 'var(--color-destructive, #dc2626)'
+                            ? 'var(--neg)'
                             : 'var(--text)',
                     },
                   ].map(({ label, amount, color }) => (
@@ -740,6 +746,8 @@ export function Transactions({
           </Button>
         </div>
       </div>
+
+      {confirmDialog}
     </div>
   )
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -81,6 +81,22 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
+function SectionCard({
+  title,
+  children,
+  className,
+  ...props
+}: { title: string; children: React.ReactNode } & React.ComponentProps<"div">) {
+  return (
+    <Card className={cn("overflow-hidden mb-4", className)} {...props}>
+      <div className="px-6 py-4 border-b border-border">
+        <h3 className="text-[15px] font-semibold">{title}</h3>
+      </div>
+      <div>{children}</div>
+    </Card>
+  );
+}
+
 export {
   Card,
   CardHeader,
@@ -89,4 +105,5 @@ export {
   CardAction,
   CardDescription,
   CardContent,
+  SectionCard,
 };

--- a/src/components/ui/icon-tile.tsx
+++ b/src/components/ui/icon-tile.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import { cn } from './utils'
+
+interface IconTileProps extends React.HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode
+  color?: string
+  bg?: string
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const SIZE: Record<string, { px: number; radius: number; font: number }> = {
+  sm: { px: 30, radius: 8, font: 16 },
+  md: { px: 34, radius: 9, font: 18 },
+  lg: { px: 36, radius: 10, font: 20 },
+}
+
+export function IconTile({
+  children,
+  color,
+  bg,
+  size = 'md',
+  className,
+  style,
+  ...rest
+}: IconTileProps) {
+  const { px, radius, font } = SIZE[size]
+  const background = bg ?? (color ? `${color}1f` : 'var(--surface-2)')
+  return (
+    <span
+      className={cn(className)}
+      style={{
+        width: px,
+        height: px,
+        borderRadius: radius,
+        background,
+        color: color ?? undefined,
+        display: 'grid',
+        placeItems: 'center',
+        fontSize: font,
+        flexShrink: 0,
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </span>
+  )
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -45,4 +45,10 @@ function PopoverAnchor({
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+function PopoverClose({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Close>) {
+  return <PopoverPrimitive.Close data-slot="popover-close" {...props} />;
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverClose };

--- a/src/components/ui/segmented-toggle.test.tsx
+++ b/src/components/ui/segmented-toggle.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SegmentedToggle } from './segmented-toggle'
+
+const OPTIONS = [
+  { label: 'Claro', value: 'light' },
+  { label: 'Auto', value: 'auto' },
+  { label: 'Oscuro', value: 'dark' },
+] as const
+
+describe('SegmentedToggle', () => {
+  it('renders all options', () => {
+    const onChange = vi.fn()
+    render(
+      <SegmentedToggle options={OPTIONS} value="light" onChange={onChange} />
+    )
+    expect(screen.getByText('Claro')).toBeInTheDocument()
+    expect(screen.getByText('Auto')).toBeInTheDocument()
+    expect(screen.getByText('Oscuro')).toBeInTheDocument()
+  })
+
+  it('marks the active option as selected', () => {
+    render(
+      <SegmentedToggle
+        options={OPTIONS}
+        value="auto"
+        onChange={vi.fn()}
+      />
+    )
+    const autoBtn = screen.getByText('Auto')
+    expect(autoBtn).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Claro')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('calls onChange when a different option is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <SegmentedToggle options={OPTIONS} value="light" onChange={onChange} />
+    )
+    fireEvent.click(screen.getByText('Oscuro'))
+    expect(onChange).toHaveBeenCalledWith('dark')
+  })
+
+  it('navigates with arrow keys', () => {
+    const onChange = vi.fn()
+    render(
+      <SegmentedToggle options={OPTIONS} value="light" onChange={onChange} />
+    )
+    const lightBtn = screen.getByText('Claro')
+    fireEvent.keyDown(lightBtn, { key: 'ArrowRight' })
+    expect(onChange).toHaveBeenCalledWith('auto')
+  })
+
+  it('wraps around when navigating past the last option', () => {
+    const onChange = vi.fn()
+    render(
+      <SegmentedToggle options={OPTIONS} value="dark" onChange={onChange} />
+    )
+    const darkBtn = screen.getByText('Oscuro')
+    fireEvent.keyDown(darkBtn, { key: 'ArrowRight' })
+    expect(onChange).toHaveBeenCalledWith('light')
+  })
+
+  it('uses aria-label on the container', () => {
+    render(
+      <SegmentedToggle
+        options={OPTIONS}
+        value="light"
+        onChange={vi.fn()}
+        aria-label="Elegir tema"
+      />
+    )
+    expect(screen.getByRole('tablist', { name: 'Elegir tema' })).toBeInTheDocument()
+  })
+
+  it('applies sm size', () => {
+    render(
+      <SegmentedToggle
+        options={[{ label: 'A', value: 'a' }]}
+        value="a"
+        onChange={vi.fn()}
+        size="sm"
+      />
+    )
+    expect(screen.getByText('A')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/segmented-toggle.tsx
+++ b/src/components/ui/segmented-toggle.tsx
@@ -1,0 +1,83 @@
+import { useRef } from 'react'
+
+interface SegmentedToggleProps<T extends string> {
+  options: { label: string; value: T }[]
+  value: T
+  onChange: (v: T) => void
+  size?: 'sm' | 'md'
+  'aria-label'?: string
+}
+
+export function SegmentedToggle<T extends string>({
+  options,
+  value,
+  onChange,
+  size = 'md',
+  'aria-label': ariaLabel,
+}: SegmentedToggleProps<T>) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  function handleKeyDown(e: React.KeyboardEvent, index: number) {
+    const count = options.length
+    let next = index
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      next = (index + 1) % count
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      next = (index - 1 + count) % count
+    } else {
+      return
+    }
+    e.preventDefault()
+    onChange(options[next].value)
+    const buttons = containerRef.current?.querySelectorAll('button')
+    buttons?.[next]?.focus()
+  }
+
+  const padding = size === 'sm' ? '4px 10px' : '6px 14px'
+  const fontSize = size === 'sm' ? 12 : 13
+
+  return (
+    <div
+      ref={containerRef}
+      role="tablist"
+      aria-label={ariaLabel}
+      style={{
+        display: 'flex',
+        background: 'var(--surface-2)',
+        borderRadius: 'var(--radius-sm)',
+        padding: 3,
+        gap: 2,
+      }}
+    >
+      {options.map((opt, index) => {
+        const isActive = opt.value === value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-pressed={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onChange(opt.value)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            style={{
+              padding,
+              borderRadius: 7,
+              border: 'none',
+              cursor: 'pointer',
+              fontSize,
+              fontWeight: isActive ? 600 : 500,
+              background: isActive ? 'var(--surface)' : 'transparent',
+              color: isActive ? 'var(--text)' : 'var(--text-faint)',
+              boxShadow: isActive ? 'var(--shadow-sm)' : 'none',
+              transition: 'background 0.12s, color 0.12s',
+            }}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -12,6 +12,7 @@ import {
 } from '../services/supabase/auth'
 import type { SupabaseSession } from '../services/supabase/client'
 import { setActiveSupabaseSession } from '../services/supabase/runtime'
+import { mapAuthError } from '../utils/auth-errors'
 
 function isPasswordResetMode(): boolean {
   if (typeof window === 'undefined') {
@@ -108,9 +109,7 @@ export function useAuthSession() {
       setSession(nextSession)
       toast.success('Sesión iniciada')
     } catch (error) {
-      setAuthError(
-        error instanceof Error ? error.message : 'Error de autenticación'
-      )
+      setAuthError(mapAuthError(error))
     } finally {
       setAuthSubmitting(false)
     }
@@ -125,11 +124,7 @@ export function useAuthSession() {
       await requestPasswordReset(email)
       setAuthNotice('Te enviamos un email para restablecer tu contraseña')
     } catch (error) {
-      setAuthError(
-        error instanceof Error
-          ? error.message
-          : 'No se pudo enviar el email de recuperación'
-      )
+      setAuthError(mapAuthError(error))
     } finally {
       setAuthSubmitting(false)
     }
@@ -154,11 +149,7 @@ export function useAuthSession() {
       clearPasswordResetModeFromUrl()
       setAuthNotice('Contraseña actualizada. Iniciá sesión nuevamente')
     } catch (error) {
-      setAuthError(
-        error instanceof Error
-          ? error.message
-          : 'No se pudo actualizar la contraseña'
-      )
+      setAuthError(mapAuthError(error))
     } finally {
       setAuthSubmitting(false)
     }

--- a/src/hooks/useTransactionFiltering.ts
+++ b/src/hooks/useTransactionFiltering.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { calculateTotals } from '../services/aggregator/aggregation'
+import { isCategoryIgnored } from '../services/categories/category-registry'
 import { getCategoryDisplay } from '../utils/category-display'
 import { getDisplayDescription } from '../utils/transaction-display'
 import type { Transaction, TransactionsFilter } from '../models'
@@ -29,6 +30,7 @@ export function useTransactionFiltering({
   const [typeFilter, setTypeFilter] = useState<'all' | 'credit' | 'debit'>(
     'all'
   )
+  const [showIgnored, setShowIgnored] = useState(true)
 
   useEffect(() => {
     if (initialFilter) {
@@ -69,6 +71,7 @@ export function useTransactionFiltering({
       if (currencyFilter !== 'all' && transaction.currency !== currencyFilter)
         return false
       if (typeFilter !== 'all' && transaction.type !== typeFilter) return false
+      if (!showIgnored && isCategoryIgnored(transaction.category)) return false
       return true
     })
 
@@ -101,6 +104,7 @@ export function useTransactionFiltering({
     typeFilter,
     sortField,
     sortDirection,
+    showIgnored,
   ])
 
   const availableCategories = useMemo(
@@ -127,7 +131,8 @@ export function useTransactionFiltering({
     Boolean(categoryFilter) ||
     accountFilter !== 'all' ||
     currencyFilter !== 'all' ||
-    typeFilter !== 'all'
+    typeFilter !== 'all' ||
+    !showIgnored
 
   const totals = calculateTotals(filteredTransactions)
 
@@ -147,6 +152,7 @@ export function useTransactionFiltering({
     setAccountFilter('all')
     setCurrencyFilter('all')
     setTypeFilter('all')
+    setShowIgnored(true)
   }
 
   function handleSort(field: SortField) {
@@ -188,6 +194,8 @@ export function useTransactionFiltering({
     setCurrencyFilter,
     typeFilter,
     setTypeFilter,
+    showIgnored,
+    setShowIgnored,
     sortField,
     sortDirection,
     handleSort,

--- a/src/services/categories/category-store.ts
+++ b/src/services/categories/category-store.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_CATEGORY_COLOR = '#0ea5e9'
+
 export interface CustomCategory {
   id: string
   label: string

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -295,6 +295,8 @@
   --color-brand-hover: var(--brand-hover);
   --color-brand-soft: var(--brand-soft);
   --color-brand-text: var(--brand-text);
+  /* Semantic income/expense tokens. Use var(--pos)/var(--neg) in inline styles;
+     use text-pos / text-neg / bg-pos / bg-neg as Tailwind utilities. */
   --color-pos: var(--pos);
   --color-pos-soft: var(--pos-soft);
   --color-neg: var(--neg);

--- a/src/utils/auth-errors.test.ts
+++ b/src/utils/auth-errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { mapAuthError } from './auth-errors'
+
+describe('mapAuthError', () => {
+  it('maps invalid login credentials', () => {
+    expect(mapAuthError(new Error('Invalid login credentials'))).toBe(
+      'Email o contraseña incorrectos.'
+    )
+  })
+
+  it('maps user already registered', () => {
+    expect(mapAuthError(new Error('User already registered'))).toBe(
+      'Ya existe una cuenta con ese email.'
+    )
+  })
+
+  it('maps already exists variant', () => {
+    expect(mapAuthError(new Error('Email already exists in the system'))).toBe(
+      'Ya existe una cuenta con ese email.'
+    )
+  })
+
+  it('maps anonymous sign-ins disabled', () => {
+    expect(mapAuthError(new Error('Anonymous sign-ins are disabled'))).toBe(
+      'El registro no está disponible por el momento.'
+    )
+  })
+
+  it('maps email not confirmed', () => {
+    expect(mapAuthError(new Error('Email not confirmed'))).toBe(
+      'Revisá tu casilla y confirmá tu email.'
+    )
+  })
+
+  it('maps password too short', () => {
+    expect(mapAuthError(new Error('Password should be at least 6 characters'))).toBe(
+      'La contraseña debe tener al menos 6 caracteres.'
+    )
+  })
+
+  it('maps too many requests', () => {
+    expect(mapAuthError(new Error('Too many requests'))).toBe(
+      'Demasiados intentos. Esperá unos minutos.'
+    )
+  })
+
+  it('maps rate limit variant', () => {
+    expect(mapAuthError(new Error('rate limit exceeded'))).toBe(
+      'Demasiados intentos. Esperá unos minutos.'
+    )
+  })
+
+  it('matches case-insensitively', () => {
+    expect(mapAuthError(new Error('INVALID LOGIN CREDENTIALS'))).toBe(
+      'Email o contraseña incorrectos.'
+    )
+  })
+
+  it('returns fallback for unknown error', () => {
+    expect(mapAuthError(new Error('Some unknown supabase error'))).toBe(
+      'No pudimos completar la acción. Intentá de nuevo.'
+    )
+  })
+
+  it('returns fallback for non-Error unknown value', () => {
+    expect(mapAuthError({ code: 500 })).toBe(
+      'No pudimos completar la acción. Intentá de nuevo.'
+    )
+  })
+
+  it('handles string errors', () => {
+    expect(mapAuthError('invalid login credentials')).toBe(
+      'Email o contraseña incorrectos.'
+    )
+  })
+})

--- a/src/utils/auth-errors.ts
+++ b/src/utils/auth-errors.ts
@@ -1,0 +1,28 @@
+const FALLBACK = 'No pudimos completar la acción. Intentá de nuevo.'
+
+const MAPPINGS: Array<[pattern: string, message: string]> = [
+  ['invalid login credentials', 'Email o contraseña incorrectos.'],
+  ['user already registered', 'Ya existe una cuenta con ese email.'],
+  ['already exists', 'Ya existe una cuenta con ese email.'],
+  ['anonymous sign-ins are disabled', 'El registro no está disponible por el momento.'],
+  ['email not confirmed', 'Revisá tu casilla y confirmá tu email.'],
+  ['password should be at least', 'La contraseña debe tener al menos 6 caracteres.'],
+  ['too many requests', 'Demasiados intentos. Esperá unos minutos.'],
+  ['rate limit', 'Demasiados intentos. Esperá unos minutos.'],
+]
+
+export function mapAuthError(error: unknown): string {
+  const raw =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : ''
+
+  const lower = raw.toLowerCase()
+  for (const [pattern, message] of MAPPINGS) {
+    if (lower.includes(pattern)) return message
+  }
+
+  return FALLBACK
+}

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -29,3 +29,11 @@ export function formatDate(date: Date): string {
     year: 'numeric',
   }).format(date)
 }
+
+export function formatDateCompact(date: Date): string {
+  return new Intl.DateTimeFormat('es-UY', {
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+  }).format(date)
+}

--- a/src/utils/user-display.test.ts
+++ b/src/utils/user-display.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { getFriendlyName } from './user-display'
+import type { SupabaseSession } from '../services/supabase/client'
+
+function makeSession(overrides: {
+  full_name?: string
+  email?: string
+}): SupabaseSession {
+  return {
+    user: {
+      id: 'test-id',
+      email: overrides.email,
+      user_metadata: overrides.full_name
+        ? { full_name: overrides.full_name }
+        : {},
+    },
+  } as unknown as SupabaseSession
+}
+
+describe('getFriendlyName', () => {
+  it('returns the first name from full_name metadata', () => {
+    expect(getFriendlyName(makeSession({ full_name: 'Maria Perez' }))).toBe('Maria')
+  })
+
+  it('capitalizes the first letter of full_name', () => {
+    expect(getFriendlyName(makeSession({ full_name: 'jose gazzano' }))).toBe('Jose')
+  })
+
+  it('handles single-word full_name', () => {
+    expect(getFriendlyName(makeSession({ full_name: 'Admin' }))).toBe('Admin')
+  })
+
+  it('derives name from email local-part when no full_name', () => {
+    expect(getFriendlyName(makeSession({ email: 'jose@example.com' }))).toBe('Jose')
+  })
+
+  it('strips trailing digits from email local-part', () => {
+    expect(getFriendlyName(makeSession({ email: 'jgazzano10@example.com' }))).toBe('Jgazzano')
+  })
+
+  it('takes first dot-separated segment from email', () => {
+    expect(getFriendlyName(makeSession({ email: 'maria.perez@example.com' }))).toBe('Maria')
+  })
+
+  it('takes first underscore-separated segment from email', () => {
+    expect(getFriendlyName(makeSession({ email: 'maria_perez@example.com' }))).toBe('Maria')
+  })
+
+  it('returns empty string when session is null', () => {
+    expect(getFriendlyName(null)).toBe('')
+  })
+
+  it('returns empty string when no email and no full_name', () => {
+    const session = {
+      user: { id: 'x', user_metadata: {} },
+    } as unknown as SupabaseSession
+    expect(getFriendlyName(session)).toBe('')
+  })
+
+  it('prefers full_name over email', () => {
+    expect(
+      getFriendlyName(
+        makeSession({ full_name: 'Carlos', email: 'other@example.com' })
+      )
+    ).toBe('Carlos')
+  })
+})

--- a/src/utils/user-display.ts
+++ b/src/utils/user-display.ts
@@ -1,0 +1,21 @@
+import type { SupabaseSession } from '../services/supabase/client'
+
+export function getFriendlyName(session: SupabaseSession | null): string {
+  if (!session?.user) return ''
+
+  const fullName = session.user.user_metadata?.full_name
+  if (typeof fullName === 'string' && fullName.trim()) {
+    const first = fullName.trim().split(/\s+/)[0]
+    return first.charAt(0).toUpperCase() + first.slice(1)
+  }
+
+  const email = session.user.email
+  if (!email) return ''
+
+  const localPart = email.split('@')[0]
+  // Split on separators, take the first segment, strip trailing digits
+  const firstSegment = localPart.split(/[._-]/)[0].replace(/\d+$/, '')
+  if (!firstSegment) return ''
+
+  return firstSegment.charAt(0).toUpperCase() + firstSegment.slice(1)
+}


### PR DESCRIPTION
## Summary

- **Dialogs**: Replace 3 `window.confirm` calls with `useConfirm`/`AlertDialog` in Transactions and Settings; all 7 affected tests updated
- **Filter bar**: Type and Currency toggles → `SegmentedToggle`; Account `<select>` → Popover (matches Category pattern); local `SegmentControl` in Settings removed in favour of shared component
- **Confidence column**: Header renamed "Conf." → "Confianza" with ℹ tooltip; bars graduate 8/11/14 px bottom-aligned; row actions visible at `opacity-50` always
- **Currency toggles**: Inline Dashboard + Charts toggles → `<CurrencyToggle>`; KPI/donut figures use `formatCurrency` (full); axes keep `formatCurrencyShort`
- **Dashboard polish**: Remove hardcoded "Santander"; delete ~90 LOC of commented AccountCard block; `formatDateCompact` helper replaces ad-hoc `toLocaleDateString`; suppress `≈ $0.00` converted lines
- **Transactions pills**: Ingresos → `var(--pos)`, Gastos → `var(--neg)`; "Ignoradas" visible label on eye toggle
- **Settings AI section**: Real link to `console.anthropic.com` + cost note (Option B); `SettingRow.description` accepts `ReactNode`
- **Component consolidation**: `SectionCard` moved to `ui/card.tsx` (shared export); `IconTile` extended with `bg`/`className`/HTML-attrs spread — replaces 5 hand-rolled icon squares across Dashboard, TransactionTable, Charts, AccountCard, Settings
- **Tokens**: Chart tooltip shadow → `var(--shadow-md)`; radii → `var(--radius)` (dark-mode aware)
- **Copy**: "tags" → "etiquetas" in all visible UI text with number agreement (`1 etiqueta`, `2 etiquetas`); 9 test files updated

## Test plan

- [ ] 724 tests pass (`npm run test:run`)
- [ ] 0 lint warnings (`npm run lint`)
- [ ] Confirm dialogs appear on delete / bulk delete / reset all data
- [ ] Confidence bars graduate visually (8/11/14 px, bottom-aligned)
- [ ] Row action buttons visible at 50% opacity without hover
- [ ] Filter bar: SegmentedToggle for type/currency, Popover for account
- [ ] Dashboard subtitle has no "Santander"; recent list shows compact date
- [ ] Charts tooltip shadow renders well in light and dark mode
- [ ] Edit dialog shows "Etiquetas" label and correct count agreement