### PR TITLE
fix: stop full refetch when browser tab regains focus

### DIFF
--- a/src/components/SplitTransactionDialog.test.tsx
+++ b/src/components/SplitTransactionDialog.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { SplitTransactionDialog } from './SplitTransactionDialog'
 import type { Transaction } from '../models'
+import type { SplitPart } from '../services/supabase/transactions'
 
 function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
   return {
@@ -24,7 +25,11 @@ function renderDialog(props: {
   onConfirm?: ReturnType<typeof vi.fn>
   onCancel?: ReturnType<typeof vi.fn>
 }) {
-  const onConfirm = props.onConfirm ?? vi.fn().mockResolvedValue(undefined)
+  const onConfirm = (props.onConfirm ??
+    vi.fn(async () => {})) as unknown as ((
+    parts: SplitPart[]
+  ) => Promise<void>) &
+    ReturnType<typeof vi.fn>
   const onCancel = props.onCancel ?? vi.fn()
 
   render(

--- a/src/components/SplitTransactionDialog.test.tsx
+++ b/src/components/SplitTransactionDialog.test.tsx
@@ -22,14 +22,10 @@ function renderDialog(props: {
   open?: boolean
   transaction?: Transaction | null
   pending?: boolean
-  onConfirm?: ReturnType<typeof vi.fn>
+  onConfirm?: (parts: SplitPart[]) => Promise<void>
   onCancel?: ReturnType<typeof vi.fn>
 }) {
-  const onConfirm = (props.onConfirm ??
-    vi.fn(async () => {})) as unknown as ((
-    parts: SplitPart[]
-  ) => Promise<void>) &
-    ReturnType<typeof vi.fn>
+  const onConfirm = props.onConfirm ?? vi.fn(async () => {})
   const onCancel = props.onCancel ?? vi.fn()
 
   render(
@@ -118,5 +114,4 @@ describe('SplitTransactionDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
     expect(onCancel).toHaveBeenCalled()
   })
-
 })

--- a/src/hooks/useTransactionSync.test.ts
+++ b/src/hooks/useTransactionSync.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { SupabaseSession } from '../services/supabase/client'
+
+// Supabase loaders — resolve with empty payloads; we only assert call counts.
+const loadUserTransactions = vi.fn(async () => [])
+const listCategoryOverrides = vi.fn(async () => [])
+const listRemoteDescriptionOverrides = vi.fn(async () => [])
+const listSupabaseCustomPatterns = vi.fn(async () => [])
+const listCustomCategories = vi.fn(async () => [])
+const loadUserPreferences = vi.fn(async () => null)
+
+vi.mock('../services/supabase/transactions', () => ({
+  loadUserTransactions: () => loadUserTransactions(),
+}))
+vi.mock('../services/supabase/category-overrides', () => ({
+  listCategoryOverrides: () => listCategoryOverrides(),
+}))
+vi.mock('../services/supabase/description-overrides', () => ({
+  listDescriptionOverrides: () => listRemoteDescriptionOverrides(),
+}))
+vi.mock('../services/supabase/custom-patterns', () => ({
+  listCustomPatterns: () => listSupabaseCustomPatterns(),
+}))
+vi.mock('../services/supabase/custom-categories', () => ({
+  listCustomCategories: () => listCustomCategories(),
+}))
+vi.mock('../services/supabase/user-preferences', () => ({
+  loadUserPreferences: () => loadUserPreferences(),
+}))
+
+// Store-replacement side effects — stubbed so the test stays focused on sync.
+vi.mock('../services/categorizer/category-overrides', () => ({
+  replaceMerchantCategoryOverrides: vi.fn(),
+}))
+vi.mock('../services/descriptions/description-overrides', () => ({
+  replaceDescriptionOverrides: vi.fn(),
+}))
+vi.mock('../services/categories/category-store', () => ({
+  replaceCustomCategories: vi.fn(),
+}))
+vi.mock('../services/categorizer/custom-patterns', () => ({
+  replaceCustomPatterns: vi.fn(),
+}))
+
+import { useTransactionSync } from './useTransactionSync'
+
+function makeSession(userId: string): SupabaseSession {
+  // New object identity each call — mirrors what Supabase hands us on refocus.
+  return { user: { id: userId, email: 'jose@example.uy' } } as SupabaseSession
+}
+
+function makeProps(session: SupabaseSession | null) {
+  return {
+    session,
+    authMode: 'signin' as const,
+    syncKey: 0,
+    markPrefsLoaded: vi.fn(),
+    setError: vi.fn(),
+    setNotice: vi.fn(),
+    setSyncStatus: vi.fn(),
+    setTheme: vi.fn(),
+    setPreferredCurrency: vi.fn(),
+    setFxRate: vi.fn(),
+    setClaudeApiKey: vi.fn(),
+    setAiEnabled: vi.fn(),
+    setAiModel: vi.fn(),
+  }
+}
+
+describe('useTransactionSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not refetch when a new session object arrives with the same user id (token refresh / tab refocus)', async () => {
+    const props = makeProps(makeSession('user-1'))
+    const { rerender } = renderHook((p) => useTransactionSync(p), {
+      initialProps: props,
+    })
+
+    await waitFor(() => expect(loadUserTransactions).toHaveBeenCalledTimes(1))
+
+    // Simulate Supabase emitting TOKEN_REFRESHED on refocus: a brand-new
+    // session object with an identical user id.
+    rerender({ ...props, session: makeSession('user-1') })
+
+    // Give any (unwanted) re-run a chance to fire before asserting.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(loadUserTransactions).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches when the user id changes (real user switch)', async () => {
+    const props = makeProps(makeSession('user-1'))
+    const { rerender } = renderHook((p) => useTransactionSync(p), {
+      initialProps: props,
+    })
+
+    await waitFor(() => expect(loadUserTransactions).toHaveBeenCalledTimes(1))
+
+    rerender({ ...props, session: makeSession('user-2') })
+
+    await waitFor(() => expect(loadUserTransactions).toHaveBeenCalledTimes(2))
+  })
+})

--- a/src/hooks/useTransactionSync.ts
+++ b/src/hooks/useTransactionSync.ts
@@ -146,5 +146,10 @@ export function useTransactionSync({
     return () => {
       cancelled = true
     }
-  }, [authMode, session, syncKey]) // eslint-disable-line react-hooks/exhaustive-deps
+    // Depend on the stable user id, not the whole session object. Supabase's
+    // autoRefreshToken hands us a new session object on every window refocus
+    // (TOKEN_REFRESHED); keying on session identity would refetch everything
+    // each time the tab regains focus. The user id only changes on real
+    // login/logout/user-switch, which are the only cases that need a re-sync.
+  }, [authMode, session?.user?.id, syncKey]) // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/src/hooks/useUserPreferences.test.ts
+++ b/src/hooks/useUserPreferences.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import type { SupabaseSession } from '../services/supabase/client'
+
+const saveUserPreferences = vi.fn(async () => {})
+
+vi.mock('../services/supabase/user-preferences', () => ({
+  saveUserPreferences: () => saveUserPreferences(),
+}))
+vi.mock('../services/ai/ai-config', () => ({ setAiConfig: vi.fn() }))
+
+import { useUserPreferences } from './useUserPreferences'
+
+function makeSession(userId: string): SupabaseSession {
+  // New object identity each call — mirrors the session Supabase hands us on refocus.
+  return { user: { id: userId, email: 'jose@example.uy' } } as SupabaseSession
+}
+
+describe('useUserPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not re-save preferences when a new session object arrives with the same user id', () => {
+    const { result, rerender } = renderHook(
+      (s: SupabaseSession | null) => useUserPreferences(s),
+      { initialProps: makeSession('user-1') }
+    )
+
+    // Preferences have been loaded from Supabase — saves are now allowed.
+    act(() => {
+      result.current.markPrefsLoaded()
+    })
+
+    // Simulate a token refresh / tab refocus: new session object, same user id.
+    rerender(makeSession('user-1'))
+
+    expect(saveUserPreferences).not.toHaveBeenCalled()
+  })
+
+  it('saves when a preference value actually changes', () => {
+    const { result } = renderHook(
+      (s: SupabaseSession | null) => useUserPreferences(s),
+      { initialProps: makeSession('user-1') }
+    )
+
+    act(() => {
+      result.current.markPrefsLoaded()
+    })
+
+    act(() => {
+      result.current.setFxRate(42)
+    })
+
+    expect(saveUserPreferences).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useUserPreferences.ts
+++ b/src/hooks/useUserPreferences.ts
@@ -64,7 +64,19 @@ export function useUserPreferences(session: SupabaseSession | null) {
       console.error('preferences save failed:', err)
       toast.error('No se pudieron guardar las preferencias. Intentá de nuevo.')
     })
-  }, [session, theme, preferredCurrency, fxRate, claudeApiKey, aiEnabled, aiModel])
+    // Key on the stable user id, not the session object — Supabase hands us a
+    // new session on every tab refocus (token refresh), which would otherwise
+    // fire a redundant preferences save each time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    session?.user?.id,
+    theme,
+    preferredCurrency,
+    fxRate,
+    claudeApiKey,
+    aiEnabled,
+    aiModel,
+  ])
 
   return {
     theme,


### PR DESCRIPTION
## Problem

Switching away from the browser tab and returning flashed the loading skeletons and re-fetched **all** data (transactions, categories, overrides, patterns, preferences). It looked like a reload but was a React state-driven refetch.

## Root cause

Supabase's client runs with `autoRefreshToken: true`, so GoTrue emits a `TOKEN_REFRESHED`/`SIGNED_IN` event carrying a **new session object** every time the tab regains focus. `useAuthSession` calls `setSession(...)` with it, changing the object identity even though the same user is logged in. Both `useTransactionSync` and `useUserPreferences` keyed their effects on the whole `session` object, so refocus re-ran:

- `useTransactionSync` → `setSyncStatus('loading')` (skeletons) → a 6-query `Promise.all` resync
- `useUserPreferences` → a redundant preferences save

## Fix

Key both effects on the stable primitive `session?.user?.id` instead of the `session` object. Token refreshes change the object and access token but never the user id, so the effects only fire on real **login / logout / user-switch**. `setSession` is left untouched, so React state keeps the fresh token for `signOut` / `setActiveSupabaseSession` — no stale-token risk (the effect closure is rebuilt with the current session on every render and only invoked when a real dep changes).

We deliberately did **not** filter events in `auth.ts`: a genuine refresh does change the access token, so that filter wouldn't stop the refetch and would risk keeping a stale token in state.

## Tests

- `useTransactionSync.test.ts` / `useUserPreferences.test.ts`: a new session object with the **same** `user.id` triggers **no** refetch/re-save; a **different** id still does. Both were confirmed to fail on the pre-fix code.
- Full suite: **750 passing**, lint clean, build green.

## Also included

A separate commit fixes a **pre-existing** `tsc` failure in `SplitTransactionDialog.test.tsx` (an `onConfirm` mock typed as `ReturnType<typeof vi.fn>` → returns `unknown`) that was breaking `npm run build` on `main`, independent of this change.

## Verification

`npm run dev`, log in, switch tabs for a few seconds, return → view stays put, no skeleton flash, no new Supabase queries on refocus.