### PR TITLE
chore: add Supabase keep-alive workflow

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,23 @@
+name: Supabase Keep-Alive
+
+# Free-tier Supabase projects pause after 7 days without requests.
+# This pings the project daily so the inactivity timer never trips.
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # daily at 09:00 UTC
+  workflow_dispatch: # allow manual runs from the Actions tab
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ping Supabase
+        run: |
+          curl -sf \
+            "$SUPABASE_URL/auth/v1/health" \
+            -H "apikey: $SUPABASE_ANON_KEY"
+        env:
+          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}


### PR DESCRIPTION
## What

Adds a scheduled GitHub Actions workflow that pings the Supabase project daily to prevent free-tier pausing.

## Why

Free-tier Supabase projects pause after **7 days of inactivity** (no requests). A paused project takes the app offline until manually restored. This workflow keeps the inactivity timer from ever tripping.

## How

- Cron runs daily at 09:00 UTC; also supports `workflow_dispatch` for manual runs.
- Hits `$SUPABASE_URL/auth/v1/health` — RLS-independent, so it works regardless of table policies.
- Reads `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY` from repo secrets (already configured).

## Notes

- Scheduled triggers only fire from the default branch, so the daily run begins once this merges to `main`.
- Verify after merge: `gh workflow run supabase-keepalive.yml && gh run watch`.