### PR TITLE
docs: document manual schema.sql apply step

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,45 @@
+# Supabase schema
+
+`schema.sql` is the single source of truth for the database structure (tables,
+columns, constraints, RLS policies). It is written to be **idempotent** — every
+statement uses `create ... if not exists` / `add column if not exists` guards, so
+it is safe to run repeatedly.
+
+## ⚠️ It is NOT applied automatically
+
+Nothing in the app or CI runs `schema.sql` against the live database. Editing
+this file changes the *intended* schema only. Until you apply it manually, the
+live database and the app code disagree — and PostgREST (Supabase's REST layer)
+will reject any request that references a missing column with:
+
+```
+Could not find the '<column>' column of 'transactions' in the schema cache
+```
+
+## Applying a change
+
+Whenever `schema.sql` changes (or after pulling a branch that changed it):
+
+1. Open the Supabase Dashboard → your project → **SQL Editor** → **New query**.
+2. Paste the **entire** contents of `schema.sql` and **Run**. The `if not exists`
+   guards mean already-applied statements are no-ops, so running the whole file
+   is the safe default — you don't have to isolate just the new lines.
+3. Run the cache reload so PostgREST picks up the change immediately (otherwise
+   it can take a few minutes, or you may keep seeing the schema-cache error):
+
+   ```sql
+   notify pgrst, 'reload schema';
+   ```
+
+4. Retry the action in the app. No redeploy is needed — schema changes are
+   database-only.
+
+## Checklist for adding a new column
+
+- [ ] Add the column to `schema.sql` with `add column if not exists`.
+- [ ] Map it in `src/services/supabase/transactions.ts` (both the row type and
+      the to/from-DB converters).
+- [ ] Add/adjust the model field in `src/models/`.
+- [ ] Apply `schema.sql` in the SQL Editor (steps above) **before** shipping the
+      feature — code that writes the column will 400 until the DB has it.
+- [ ] `notify pgrst, 'reload schema';`

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,5 +1,12 @@
 -- Tatu schema (Core + Next, soft delete)
 -- Safe to run multiple times.
+--
+-- IMPORTANT: this file is NOT auto-applied to the live database. Whenever it
+-- changes (new column, table, constraint, etc.), paste the full file into the
+-- Supabase SQL Editor and run it, then run `notify pgrst, 'reload schema';` so
+-- PostgREST refreshes its cached schema. Skipping this is what produces
+-- "Could not find the '<column>' column ... in the schema cache" errors in the
+-- app. See supabase/README.md for the checklist.
 
 create extension if not exists pgcrypto;
 


### PR DESCRIPTION
## What

Documents that `supabase/schema.sql` must be applied manually to the live database, so schema changes don't silently diverge from the app code.

- Header note in `schema.sql` explaining it's not auto-applied.
- New `supabase/README.md` with the apply procedure and an add-a-column checklist.

## Why

The split-transaction feature added `is_split_parent` / `split_parent_id` to `schema.sql` and the code, but the columns were never applied to the live DB — producing `Could not find the 'is_split_parent' column of 'transactions' in the schema cache` when splitting a category. This is docs-only to prevent the next schema change from repeating it.

## Note

Docs-only — no code or DB changes in this PR. The actual `is_split_parent` columns still need to be applied in the Supabase SQL Editor (tracked separately).