### PR TITLE
fix: category listing drift with splits and legacy transfer rename

### DIFF
--- a/src/components/Categories.test.tsx
+++ b/src/components/Categories.test.tsx
@@ -54,6 +54,17 @@ describe('Categories', () => {
     expect(screen.getByText('1 movimiento')).toBeInTheDocument()
   })
 
+  it('excludes the inert split-parent row from the transaction count', () => {
+    const txs = [
+      makeTx({ id: '1', category: 'groceries', isSplitParent: true }),
+      makeTx({ id: '1_split_0', category: 'groceries', splitParentId: '1' }),
+      makeTx({ id: '1_split_1', category: 'restaurants', splitParentId: '1' }),
+    ]
+    render(<Categories transactions={txs} />)
+
+    expect(screen.getAllByText('1 movimiento')).toHaveLength(2)
+  })
+
   it('opens new category form when clicking Nueva categoría', () => {
     render(<Categories transactions={[]} />)
     fireEvent.click(

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -5,7 +5,7 @@ import { Input } from './ui/input'
 import { Badge } from './ui/badge'
 import { Checkbox } from './ui/checkbox'
 import type { Transaction } from '../models'
-import { Category } from '../models'
+import { Category, isSplitParentTx } from '../models'
 import {
   getCategoryDefinition,
   getCategoryDefinitions,
@@ -35,6 +35,7 @@ function getCategoryTransactionCount(
   categoryId: string
 ): number {
   return transactions.filter((tx) => {
+    if (isSplitParentTx(tx)) return false
     const txCat = getCategoryDisplay(tx.category).id
     const defCat = getCategoryDisplay(categoryId).id
     return txCat === defCat

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -112,6 +112,80 @@ describe('Dashboard', () => {
     expect(screen.queryByText('US$ 150,00')).not.toBeInTheDocument()
   })
 
+  it('excludes the inert split-parent row from recent transactions', () => {
+    const transactions = [
+      makeTransaction({
+        id: 'p1',
+        description: 'SUPER PARENT',
+        amount: 100,
+        currency: 'USD',
+        category: Category.Groceries,
+        isSplitParent: true,
+      }),
+      makeTransaction({
+        id: 'p1_split_0',
+        description: 'Super - parte 1',
+        amount: 60,
+        currency: 'USD',
+        category: Category.Groceries,
+        splitParentId: 'p1',
+      }),
+      makeTransaction({
+        id: 'p1_split_1',
+        description: 'Super - parte 2',
+        amount: 40,
+        currency: 'USD',
+        category: Category.Restaurants,
+        splitParentId: 'p1',
+      }),
+    ]
+
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+
+    expect(screen.queryByText('SUPER PARENT')).not.toBeInTheDocument()
+    expect(screen.getAllByText('Super - parte 1').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Super - parte 2').length).toBeGreaterThan(0)
+  })
+
+  it('does not double-count the split parent in top merchants totals', () => {
+    const transactions = [
+      makeTransaction({
+        id: 'p1',
+        description: 'SUPER',
+        amount: 100,
+        currency: 'USD',
+        type: 'debit',
+        category: Category.Groceries,
+        isSplitParent: true,
+      }),
+      makeTransaction({
+        id: 'p1_split_0',
+        description: 'SUPER',
+        amount: 60,
+        currency: 'USD',
+        type: 'debit',
+        category: Category.Groceries,
+        splitParentId: 'p1',
+      }),
+      makeTransaction({
+        id: 'p1_split_1',
+        description: 'SUPER',
+        amount: 40,
+        currency: 'USD',
+        type: 'debit',
+        category: Category.Restaurants,
+        splitParentId: 'p1',
+      }),
+    ]
+
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+
+    expect(screen.getAllByText('2 movimientos').length).toBeGreaterThan(0)
+    expect(screen.queryByText('3 movimientos')).not.toBeInTheDocument()
+    expect(screen.getAllByText('US$ 100,00').length).toBeGreaterThan(0)
+    expect(screen.queryByText('US$ 200,00')).not.toBeInTheDocument()
+  })
+
   it('does not show NaN/Infinity with credit-only transactions', () => {
     const transactions = [
       makeTransaction({

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
   Banknote,
 } from 'lucide-react'
 import type { Transaction, Currency, TransactionsFilter } from '../models'
+import { isSplitParentTx } from '../models'
 import { useMemo } from 'react'
 import {
   PieChart,
@@ -411,7 +412,9 @@ export function Dashboard({
     transactions
       .filter(
         (tx) =>
-          tx.type === 'debit' && !isCategoryIgnored(tx.category),
+          tx.type === 'debit' &&
+          !isCategoryIgnored(tx.category) &&
+          !isSplitParentTx(tx),
       )
       .forEach((tx) => {
         const key = getDisplayDescription(tx)
@@ -434,7 +437,7 @@ export function Dashboard({
   const recentTransactions = useMemo(
     () =>
       [...transactions]
-        .filter((tx) => !isCategoryIgnored(tx.category))
+        .filter((tx) => !isCategoryIgnored(tx.category) && !isSplitParentTx(tx))
         .sort((a, b) => b.date.getTime() - a.date.getTime())
         .slice(0, 6),
     [transactions],

--- a/src/components/SplitTransactionDialog.test.tsx
+++ b/src/components/SplitTransactionDialog.test.tsx
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { SplitTransactionDialog } from './SplitTransactionDialog'
 import type { Transaction } from '../models'
 import type { SplitPart } from '../services/supabase/transactions'
+import {
+  addCustomCategory,
+  replaceCustomCategories,
+  upsertBuiltinOverride,
+} from '../services/categories/category-store'
 
 function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
   return {
@@ -42,6 +47,30 @@ function renderDialog(props: {
 }
 
 describe('SplitTransactionDialog', () => {
+  beforeEach(() => {
+    replaceCustomCategories([])
+  })
+
+  it('offers a custom category in the split part category picker', async () => {
+    const custom = addCustomCategory({ label: 'Mascotas', color: '#00ff00' })
+    renderDialog({})
+
+    await waitFor(() => screen.getAllByPlaceholderText('0.00'))
+
+    fireEvent.click(screen.getAllByText('Categoría (opcional)')[0])
+    expect(screen.getByText(custom.label)).toBeInTheDocument()
+  })
+
+  it('shows the overridden label for a renamed built-in category', async () => {
+    upsertBuiltinOverride('groceries', { label: 'Super y almacén' })
+    renderDialog({})
+
+    await waitFor(() => screen.getAllByPlaceholderText('0.00'))
+
+    fireEvent.click(screen.getAllByText('Categoría (opcional)')[0])
+    expect(screen.getByText('Super y almacén')).toBeInTheDocument()
+  })
+
   it('renders title when open with a transaction', async () => {
     renderDialog({})
     await waitFor(() => {

--- a/src/components/SplitTransactionDialog.tsx
+++ b/src/components/SplitTransactionDialog.tsx
@@ -10,10 +10,10 @@ import {
   DialogTitle,
 } from './ui/dialog'
 import { CategoryBadge } from './CategoryBadge'
-import { Category, CATEGORY_LABELS } from '../models'
 import type { Transaction } from '../models'
 import { formatCurrency } from '../utils/formatting'
 import type { SplitPart } from '../services/supabase/transactions'
+import { getCategoryDefinitions } from '../services/categories/category-registry'
 
 interface SplitPartDraft {
   description: string
@@ -28,10 +28,6 @@ interface SplitTransactionDialogProps {
   onConfirm: (parts: SplitPart[]) => Promise<void>
   onCancel: () => void
 }
-
-const CATEGORIES = Object.values(Category).filter(
-  (c) => c !== Category.InternalTransfer && c !== Category.ExternalTransfer
-)
 
 function emptyPart(tx: Transaction | null): SplitPartDraft {
   return {
@@ -64,6 +60,8 @@ export function SplitTransactionDialog({
   }, [transaction?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!transaction) return null
+
+  const categoryOptions = getCategoryDefinitions().filter((c) => !c.isIgnored)
 
   const parentAmount = transaction.amount
   const currency = transaction.currency
@@ -227,12 +225,12 @@ export function SplitTransactionDialog({
                       >
                         Sin categoría
                       </button>
-                      {CATEGORIES.map((cat) => (
+                      {categoryOptions.map((cat) => (
                         <button
-                          key={cat}
+                          key={cat.id}
                           type="button"
                           onClick={() => {
-                            updatePart(idx, { category: cat })
+                            updatePart(idx, { category: cat.id })
                             setCategoryPickerIdx(null)
                           }}
                           style={{
@@ -244,7 +242,7 @@ export function SplitTransactionDialog({
                             padding: '5px 10px',
                             fontSize: 12,
                             background:
-                              part.category === cat
+                              part.category === cat.id
                                 ? 'var(--surface-hover)'
                                 : 'none',
                             border: 'none',
@@ -252,8 +250,7 @@ export function SplitTransactionDialog({
                             color: 'var(--text)',
                           }}
                         >
-                          <CategoryBadge categoryId={cat} />
-                          {CATEGORY_LABELS[cat] ?? cat}
+                          <CategoryBadge categoryId={cat.id} />
                         </button>
                       ))}
                     </div>

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -125,6 +125,45 @@ describe('getCategoryDefinitions', () => {
     const groceries = defs.find((d) => d.id === Category.Groceries)
     expect(groceries?.icon).toBe('🛒')
   })
+
+  it('folds a legacy-id custom row (pre-rename "transfer") into the current built-in instead of duplicating it', () => {
+    listCustomCategoriesMock.mockReturnValue([
+      { id: 'transfer', label: 'Transferencias internas', color: '#0284c7' },
+    ])
+
+    const defs = getCategoryDefinitions()
+    const transferEntries = defs.filter(
+      (d) => d.label === 'Transferencias internas'
+    )
+    expect(transferEntries).toHaveLength(1)
+    expect(transferEntries[0].id).toBe(Category.InternalTransfer)
+    expect(transferEntries[0].isCustom).toBe(false)
+    expect(defs.find((d) => d.id === 'transfer')).toBeUndefined()
+  })
+
+  it('carries over label/color overrides from a legacy-id row onto the current built-in', () => {
+    listCustomCategoriesMock.mockReturnValue([
+      { id: 'transfer', label: 'Mis transferencias', color: '#123456' },
+    ])
+
+    const defs = getCategoryDefinitions()
+    const internalTransfer = defs.find(
+      (d) => d.id === Category.InternalTransfer
+    )
+    expect(internalTransfer?.label).toBe('Mis transferencias')
+    expect(internalTransfer?.color).toBe('#123456')
+  })
+
+  it('folds a legacy-id custom row ("transfers" -> external transfer) into the current built-in', () => {
+    listCustomCategoriesMock.mockReturnValue([
+      { id: 'transfers', label: 'Transferencias externas', color: '#7c3aed' },
+    ])
+
+    const defs = getCategoryDefinitions()
+    const matches = defs.filter((d) => d.label === 'Transferencias externas')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].id).toBe(Category.ExternalTransfer)
+  })
 })
 
 describe('getCategoryDefinition', () => {

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -30,11 +30,17 @@ export const ID_ALIASES: Partial<Record<string, Category>> = {
   transfers: Category.ExternalTransfer,
 }
 
+function resolveBuiltinAlias(id: string): string {
+  return ID_ALIASES[id.toLowerCase()] ?? id
+}
+
 export function getCategoryDefinitions(): CategoryDefinition[] {
   const customList = listCustomCategories()
   const builtinIds = new Set(Object.values(Category) as string[])
   const overrideMap = new Map(
-    customList.filter((c) => builtinIds.has(c.id)).map((c) => [c.id, c])
+    customList
+      .map((c) => [resolveBuiltinAlias(c.id), c] as const)
+      .filter(([resolvedId]) => builtinIds.has(resolvedId))
   )
 
   const builtin = Object.values(Category).map((category) => {
@@ -52,7 +58,7 @@ export function getCategoryDefinitions(): CategoryDefinition[] {
   const seenCustomIds = new Set<string>()
   const custom = customList
     .filter((c) => {
-      if (builtinIds.has(c.id)) return false
+      if (builtinIds.has(resolveBuiltinAlias(c.id))) return false
       if (seenCustomIds.has(c.id)) return false
       seenCustomIds.add(c.id)
       return true


### PR DESCRIPTION
## Summary
- Wire `SplitTransactionDialog`'s category picker to `getCategoryDefinitions()` instead of a hardcoded `Category` enum list, so custom categories can be assigned to split parts and renamed built-ins show their current label.
- Guard `Categories.tsx`'s transaction-count and `Dashboard.tsx`'s top-merchants/recent-transactions against the inert split-parent row so it isn't double-counted alongside its split children.
- Fix `getCategoryDefinitions()` to resolve legacy category ids (e.g. pre-rename `transfer`) through `ID_ALIASES` before comparing against builtin ids, so a stale override row folds into the current built-in (`internal_transfer`) instead of rendering as a duplicate "Transferencias internas" card.

## Test plan
- [x] `npm run tdd:verify` (758 tests + lint, zero warnings)
- [x] `npm run build` (typecheck + Vite build)
- [x] New regression tests: split-part custom category selection, split-parent exclusion from category counts/dashboard, legacy-id alias folding in category registry