### PR TITLE
feat: AI-powered spending insights (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 Tatu is a personal finance web app for managing Santander Uruguay bank statements and credit card transactions. It parses CSV exports, auto-categorizes transactions by Uruguayan merchant patterns, and provides dashboards, charts, filtering, and export features. Multi-currency (USD + UYU) with home-currency conversion.
 
+**Core purpose:** Tatu is a "forensic" spending analysis tool, not just a bookkeeping tracker. Every feature — categorization, dashboards, charts, trends — exists to help the user answer the two questions that matter: **Where has my money gone?** and **How can I spend less money?** When designing or evaluating a feature, favor choices that surface insight and actionable patterns over ones that just display data.
+
 The app is fully online — authentication and data persistence require Supabase. There is no offline/localStorage fallback. Deployed on Firebase Hosting.
 
 ## Tech stack
@@ -14,7 +16,7 @@ The app is fully online — authentication and data persistence require Supabase
 - **Charts**: Recharts
 - **Backend**: Supabase (auth + PostgreSQL, required — app won't function without it)
 - **Hosting**: Firebase Hosting
-- **Testing**: Vitest + React Testing Library (660 tests, 64 test files)
+- **Testing**: Vitest + React Testing Library (796 tests, 76 test files)
 
 ## Commands
 
@@ -38,9 +40,9 @@ src/
   components/              # React UI components
     ui/                    # Radix UI primitives (shadcn/ui style)
     AppSidebar.tsx         # Fixed 252px sidebar, navigation, user footer
-    Dashboard.tsx          # Resumen view — account cards, month summary, top categories
+    Dashboard.tsx          # Resumen view — account cards, month summary, top categories, KPI tiles, donut, area chart, merchants (charts live here, not a separate view)
     Transactions.tsx       # Transactions view — unified filter bar, table, pagination
-    Charts.tsx             # Análisis view — KPI tiles, donut, area chart, merchants
+    Insights.tsx           # Insights view — AI-generated spending insights (period selector, generate/regenerate, grouped cards)
     Categories.tsx         # Categorías view — category grid + auto-categorization rules
     Settings.tsx           # Configuración view — theme, currency, account, data management
     ImportCSV.tsx          # CSV import flow (wrapped in Radix Dialog, not a view)
@@ -72,7 +74,9 @@ src/
     currency/              # convert(amount, from, to, rate) + Currency type
     descriptions/          # Description override management
     transfers/             # Internal transfer detection
-    supabase/              # Auth, transactions, preferences, overrides, custom patterns
+    ai/                    # Client-side Claude integration (BYO API key): transaction categorization/enrichment
+    insights/              # AI spending insights: deterministic InsightInput builder, prompt, generator, cache (ADR-0001)
+    supabase/              # Auth, transactions, preferences, overrides, custom patterns, ai_insights
     firebase.ts            # Firebase config
   models/                  # TypeScript interfaces + Category enum
   stores/                  # Zustand store (transaction-store, in-memory only)
@@ -93,20 +97,21 @@ samples/                   # Example Santander CSV files for testing
 The app uses a fixed 252px sidebar (`AppSidebar.tsx`). The `View` type lives in `AppSidebar`:
 
 ```ts
-type View = 'overview' | 'transactions' | 'analysis' | 'categories' | 'settings'
+type View = 'overview' | 'transactions' | 'insights' | 'categories' | 'settings'
 ```
 
-- **General**: Resumen (`overview`), Transacciones (`transactions`), Análisis (`analysis`)
+- **General**: Resumen (`overview`), Transacciones (`transactions`), Insights (`insights`)
 - **Gestión**: Categorías (`categories`), Configuración (`settings`)
 - Import is a Radix `Dialog` overlay triggered from the sidebar and from Settings — not a view.
+- There is no separate "Análisis" view or `Charts.tsx` — chart/KPI rendering (donut, area chart, top merchants) lives directly inside `Dashboard.tsx` (Resumen).
 
 ## Multicurrency model
 
-Users earn in USD and spend in both USD and UYU. The app converts and combines both into a **home currency** for dashboard and analysis totals:
+Users earn in USD and spend in both USD and UYU. The app converts and combines both into a **home currency** for dashboard and insight totals:
 
 - `homeCurrency` (`'USD' | 'UYU'`) + `fxRate` (number, default `40.5`) — managed in `useUserPreferences`, persisted in Supabase `user_preferences`
 - `convert(amount, from, to, rate)` lives in `services/currency/convert.ts`
-- Resumen + Análisis: all totals convert + combine into `homeCurrency`
+- Resumen + Insights: all totals convert + combine into `homeCurrency` (Insights' `InsightInput` is built entirely from already-converted, pre-computed numbers — see ADR-0001)
 - Transaction rows: native amount is primary; faint `≈ converted` shown when tx currency ≠ home
 - **Currency is a filter** in Transacciones (show USD or UYU rows) — not a view splitter
 - `FxChip` lets users edit the rate inline on the dashboard; Settings exposes a numeric input
@@ -165,6 +170,8 @@ Requires `.env` with Supabase vars (see `.env.example`):
 
 ## Current status
 
-Redesign complete: sidebar navigation, 5 views, multicurrency with FxChip. Architectural refactor complete: hooks extracted from App.tsx, store simplified, large components split. Deployed to Firebase Hosting. 660 tests passing.
+Redesign complete: sidebar navigation, 5 views, multicurrency with FxChip. Architectural refactor complete: hooks extracted from App.tsx, store simplified, large components split. Deployed to Firebase Hosting. 796 tests passing.
 
-**Next initiative**: AI-powered categorization — improve transaction categorization accuracy and confidence scores using an LLM or smarter heuristics.
+AI Insights Phase 1 shipped (ADR-0001, `docs/decisions/0001-ai-spending-insights.md`): new Insights view generates Claude-powered spending insights per month, cached in Supabase (`ai_insights` table — requires a manual `schema.sql` apply, see `supabase/README.md`). Client-side, BYO API key, same pattern as `services/ai/`.
+
+**Next initiative**: AI Insights Phase 2 (trend/anomaly narratives across 3+ months, per ADR-0001), and AI-powered categorization — improve transaction categorization accuracy and confidence scores using an LLM or smarter heuristics.

--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -7,12 +7,15 @@
 - **State & persistence**: Zustand store (in-memory), full Supabase backend (auth, transactions, preferences, overrides), Firebase Hosting deploy
 - **Dashboard & charts**: Recharts donut, area chart, KPI tiles, top merchants, income vs expenses
 - **Transactions**: Unified filter bar (search, category, account, type, currency, date range, amount range), paginated table, bulk actions, edit modal with apply-scope
-- **Multicurrency**: `homeCurrency` + editable `fxRate`, combined totals in Resumen + Análisis, native amounts in transaction rows
-- **Redesign**: Sidebar navigation (overview / transactions / analysis / categories / settings), warm token palette, Spectral + Hanken Grotesk + JetBrains Mono typography
+- **Multicurrency**: `homeCurrency` + editable `fxRate`, combined totals in Resumen (charts live in `Dashboard.tsx`, not a separate Análisis view) + Insights, native amounts in transaction rows
+- **Redesign**: Sidebar navigation (overview / transactions / insights / categories / settings), warm token palette, Spectral + Hanken Grotesk + JetBrains Mono typography
 - **Refactor**: Hooks extracted from App.tsx (`useAuthSession`, `useUserPreferences`, `useTransactionHandlers`, `useTransactionSync`, `useTransactionFiltering`), Transactions.tsx split into sub-components
 - **Export**: CSV + PDF from filtered transaction view
+- **AI Insights (Phase 1)**: new Insights sidebar view — Claude-generated (Opus 4.8) spending insights per month, cached in Supabase (`ai_insights` table), deterministic math only (category totals, deltas, recurring-charge detection all computed client-side, model only ranks/narrates). See ADR-0001 (`docs/decisions/0001-ai-spending-insights.md`).
 
 ## Next
+
+**AI Insights (Phase 2)** — trend narratives across 3+ months and anomaly/spike detection, per ADR-0001.
 
 **AI-powered categorization** — improve accuracy and confidence scores using an LLM or smarter heuristics.
 

--- a/docs/decisions/0001-ai-spending-insights.md
+++ b/docs/decisions/0001-ai-spending-insights.md
@@ -1,0 +1,267 @@
+# ADR-0001: AI-Powered Spending Insights
+
+## Status
+Proposed
+
+## Date
+2026-07-22
+
+## Context
+
+Tatu's core purpose is forensic spending analysis: helping the user answer
+**"Where has my money gone?"** and **"How can I spend less money?"** —
+not just track transactions. Categorization, dashboards, and charts exist to
+serve those two questions. This feature is the first one that answers them
+directly, in narrative form, rather than leaving the user to read the answer
+out of a chart.
+
+Concretely, insights should surface things like:
+
+- "Where am I bleeding money?" — categories/merchants that dominate spend or
+  have spiked
+- "What are the easiest spends to cut?" — discretionary, recurring, or
+  low-value spend that's simple to reduce
+- Patterns the user hasn't noticed: recurring subscriptions, category creep
+  month over month, anomalies
+
+Tatu already has a working, shipped AI integration
+(`src/services/ai/transaction-ai.ts`) for transaction categorization:
+
+- The Anthropic client is instantiated **client-side**
+  (`new Anthropic({ apiKey, dangerouslyAllowBrowser: true })`).
+- Each user brings their own API key, stored in their own row of
+  `user_preferences.claude_api_key` (RLS-protected — a user can only read
+  their own key).
+- `user_preferences.ai_enabled` gates the feature; `user_preferences.ai_model`
+  (default `claude-haiku-4-5`) selects the model for categorization calls.
+- Prompts are plain text; responses are parsed as JSON manually (no
+  `output_config.format` / structured outputs, no beta headers).
+
+Because each user supplies their own key, there is no shared secret at risk
+of leaking — the exposure is a user to their own credential, in their own
+session. This is a deliberate, already-shipped decision, not an oversight.
+
+There is no serverless layer in this repo (no `supabase/functions`) — all
+backend logic is client + Supabase Postgres/RLS.
+
+## Decision
+
+**Insights generation follows the existing client-side, bring-your-own-key
+pattern.** No new backend infrastructure. `src/services/insights/` is a
+sibling of `src/services/ai/`, reusing the same `AiConfig` plumbing
+(`getAiConfig()`, `user_preferences.claude_api_key`, `ai_enabled`).
+
+**Insight generation uses `claude-opus-4-8` regardless of the user's
+`ai_model` setting.** Categorization is a narrow per-transaction
+classification task where Haiku is cost-effective at scale (hundreds of
+transactions per import). Insight generation is a single call per period that
+reasons over an entire period's aggregated data, ranks findings, and writes
+narrative prose — a harder task where quality matters more than per-call
+cost. The two calls are independent knobs; changing one must not change the
+other.
+
+**The model never computes dollar figures. It only ranks and narrates
+figures that were already computed deterministically.** Every number in an
+insight (amounts, percentages, deltas) is pulled from existing aggregator/
+chart selectors (`src/services/aggregator/aggregation.ts`,
+`src/services/charts/chart-data.ts`) *before* the prompt is built, and echoed
+back into the insight's structured fields verbatim. The model's job is
+narrative and prioritization: which of the pre-computed facts matter most,
+why, and what plain-language story they tell. This is non-negotiable for a
+tool whose entire value proposition is trustworthy financial analysis — a
+hallucinated total ("you spent $450 on coffee" when it was $45) is worse
+than no insight at all.
+
+**Insights are generated on-demand and cached per period**, not
+auto-generated on import and not on a cron schedule. A period (calendar
+month, by default) gets one cached row; the user explicitly regenerates when
+they want fresh analysis, keeping cost predictable and bounded to actual
+usage.
+
+**Insights get their own sidebar view** ("Insights"), not a section bolted
+onto Análisis or Resumen — this is a distinct reading mode (narrative,
+scannable cards) from the existing chart-first views.
+
+**Scope is the broader pattern/trend engine**, not just the two literal
+questions — recurring/subscription detection and month-over-month trend
+narratives are included in v1 because they're cheap to compute deterministically
+and directly serve "where did my money go." Phased below so the first
+shippable slice stays small.
+
+## Alternatives Considered
+
+### Move Claude calls to a Supabase Edge Function
+- Pros: centralizes API key handling, removes `dangerouslyAllowBrowser`
+- Cons: introduces a new backend paradigm inconsistent with every other
+  AI call in the codebase; no shared-secret risk exists to justify it (BYO
+  key model); adds real scope (new deploy target, new auth path) for no
+  benefit specific to this feature
+- Rejected: solves a problem this app doesn't have. Revisit only if Tatu
+  moves away from BYO-key entirely (would need its own ADR).
+
+### Let the model compute the numbers directly from a transaction dump
+- Pros: simpler prompt — just hand over a period's transactions and ask
+  for insights
+- Cons: LLM arithmetic over dozens/hundreds of rows is exactly where
+  confident-but-wrong numbers happen; no way to verify a given total is
+  right without recomputing it anyway
+- Rejected: violates the deterministic-math discipline above. Categorization
+  already follows this shape (structured fields for the classifier's
+  actual job — category, confidence — free text only for the display
+  name); insights should too.
+
+### Respect the user's existing `ai_model` setting for insights
+- Pros: one mental model, cheaper by default (Haiku)
+- Cons: insight quality (pattern-finding, prioritization, narrative
+  coherence over a whole period) benefits much more from a stronger model
+  than per-transaction classification does; a user who picked Haiku for
+  cheap categorization shouldn't unknowingly get shallow insights too
+- Rejected: the two tasks have different cost/quality curves and should be
+  tuned independently. Revisit if cost feedback says otherwise.
+
+### Auto-generate on import / scheduled digest
+- Pros: always fresh, no user action needed
+- Cons: every import (which can happen multiple times) or every scheduled
+  tick spends money whether or not the user ever looks; on-demand +
+  cache-per-period gets freshness for free (next view after new data is
+  the natural regenerate trigger) without paying for unread output
+- Rejected for v1. A scheduled "monthly digest" is a reasonable v2 on top
+  of the same generation code, once usage patterns are known.
+
+## Data Model
+
+New table `ai_insights`, RLS-scoped per user like every other table in
+`schema.sql`:
+
+```sql
+create table ai_insights (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  period_start date not null,
+  period_end date not null,
+  input_hash text not null,        -- hash of the InsightInput payload sent to the model
+  model text not null,             -- model actually used, for audit/debugging
+  insights jsonb not null,         -- InsightsResult, see schema below
+  generated_at timestamptz not null default now(),
+  unique (user_id, period_start, period_end)
+);
+
+alter table ai_insights enable row level security;
+-- same per-user policy shape as transactions / user_preferences
+```
+
+`input_hash` lets the UI detect "the underlying data changed since this was
+generated" (new imports, edits, re-categorization) without a triggers/
+invalidation system: recompute the hash of the current period's
+`InsightInput` on view load, compare to the stored hash, and show a
+"data has changed — regenerate?" banner instead of silently auto-regenerating
+(which would spend money the user didn't ask for).
+
+## Service Layer (`src/services/insights/`)
+
+| File | Responsibility |
+|---|---|
+| `insight-data.ts` | Pure functions. Builds `InsightInput` for a period from existing aggregator/chart selectors: category totals + prior-period deltas, top merchants, recurring-charge detection (same merchant + similar amount, monthly cadence), month-over-month trend series. No I/O — easy to unit test with fixture transactions. |
+| `insight-prompt.ts` | Builds system + user prompt from `InsightInput`, mirroring `transaction-ai.ts`'s prompt-building conventions (plain text, explicit output format instructions). |
+| `insight-generator.ts` | Calls Claude (`claude-opus-4-8`, hardcoded) via the same client-side `Anthropic({ apiKey, dangerouslyAllowBrowser: true })` pattern. Parses the JSON response the same defensive way `transaction-ai.ts` does (strip markdown fences, `JSON.parse`, validate/clamp fields) — no `output_config.format` dependency, matching the existing convention rather than introducing a second response-handling style in the same codebase. |
+| `insight-cache.ts` | Reads/writes `ai_insights` rows via `src/services/supabase/`, computes `input_hash`, exposes `getCachedInsights(period)` / `saveInsights(period, result)`. |
+
+### `InsightInput` (computed, not sent to the model for verification — the model only sees this)
+
+```ts
+interface InsightInput {
+  periodStart: string
+  periodEnd: string
+  homeCurrency: 'USD' | 'UYU'
+  categoryTotals: Array<{
+    category: Category
+    amount: number          // home-currency, already converted
+    pctOfTotal: number
+    deltaVsPriorPeriod: number  // signed, home-currency
+  }>
+  topMerchants: Array<{ merchant: string; amount: number; count: number }>
+  recurringCharges: Array<{
+    merchant: string
+    approxAmount: number
+    cadence: 'monthly' | 'weekly' | 'irregular'
+    monthsSeen: number
+  }>
+  monthlyTrend: Array<{ month: string; income: number; expense: number }>
+}
+```
+
+### `InsightsResult` (model output, one call per period)
+
+```ts
+interface Insight {
+  type: 'bleeding_money' | 'easiest_cut' | 'recurring' | 'trend' | 'anomaly'
+  title: string             // short, e.g. "Restaurantes creció 40% este mes"
+  narrative: string         // 1-3 sentences, model-authored
+  amount?: number           // copied verbatim from InsightInput — never computed by the model
+  currency: 'USD' | 'UYU'
+  category?: Category
+  merchant?: string
+  severity: 'low' | 'medium' | 'high'
+}
+
+interface InsightsResult {
+  insights: Insight[]
+}
+```
+
+Validation on parse: every `amount`/`category`/`merchant` field must trace
+back to a value present in the `InsightInput` that was sent — reject (or drop)
+any insight whose numeric field doesn't match a value in the input, the same
+way `validateCategory()` in `transaction-ai.ts` clamps an invalid category to
+`uncategorized` rather than trusting the model's string.
+
+## UI
+
+- New `View` variant: `'insights'`, added to `AppSidebar`'s `View` union
+  and nav list (between Análisis and Categorías).
+- `src/components/Insights.tsx`: period selector (this month / last month /
+  custom range, reusing `DateRangePicker`), a "Generate" / "Regenerate"
+  button, last-generated timestamp, a "data changed" banner when
+  `input_hash` mismatches.
+- Insight cards grouped by `type`, ordered by `severity`. Each card shows
+  the narrative, the hard number (native + `≈ converted` following the
+  existing convention from transaction rows), and a "View transactions"
+  action that navigates to Transacciones pre-filtered by that
+  category/merchant (reuses `TransactionFilters` state).
+- Empty state: "Generate your first insights for this period."
+- Disabled state: if `ai_enabled` is false or no `claude_api_key` is set,
+  show the same prompt-to-Settings treatment already used for
+  categorization's AI features (do not invent a second convention).
+
+## Phased Delivery
+
+**Phase 1 (this ADR's scope for a first PR):**
+- `category totals` + `deltaVsPriorPeriod` → *bleeding_money* insights
+- `recurringCharges` → *recurring* insights (this is what makes the scope
+  "broader" than just the two literal questions, and it's cheap: pure
+  arithmetic over existing transaction data, no new external calls)
+- *easiest_cut* insights derived from a mix of low-essential categories
+  (entertainment, shopping, restaurants) with material spend
+- Insights view, generation, caching, regeneration banner
+
+**Phase 2 (follow-up):**
+- `monthlyTrend` → *trend* narratives across 3+ months
+- *anomaly* detection (single-transaction or single-month spikes)
+- Cross-period comparisons ("vs. your 3-month average")
+
+## Consequences
+
+- No new backend surface to build, deploy, or secure — consistent with the
+  rest of the codebase's AI features.
+- Insight-generation cost is bounded to explicit user action (on-demand +
+  cache), not proportional to import frequency.
+- A stronger model (Opus 4.8) for a single per-period call is materially
+  more expensive per-call than Haiku categorization, but low in absolute
+  frequency (once per period unless regenerated) — acceptable given BYO-key
+  means the user bears their own cost directly.
+- Adds one Supabase table + RLS policy, following the existing per-user
+  schema shape.
+- The deterministic-math discipline means `insight-data.ts` carries real
+  logic (recurring-charge detection, delta computation) that needs its own
+  test coverage — this is where correctness bugs would actually live, not
+  in the LLM call.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { AppSidebar, SidebarInner } from './components/AppSidebar'
 import type { View } from './components/AppSidebar'
 import { Dashboard } from './components/Dashboard'
 import { Transactions } from './components/Transactions'
+import { Insights } from './components/Insights'
 import { Categories } from './components/Categories'
 import { Settings } from './components/Settings'
 import { ImportCSV } from './components/ImportCSV'
@@ -426,6 +427,18 @@ function App() {
                   onBulkTag={handleBulkTagTransactions}
                   onSplitTransaction={handleSplitTransaction}
                   onUnsplitTransaction={handleUnsplitTransaction}
+                />
+              )}
+              {currentView === 'insights' && session && (
+                <Insights
+                  transactions={transactions}
+                  homeCurrency={preferredCurrency}
+                  fxRate={fxRate}
+                  session={session}
+                  aiEnabled={aiEnabled}
+                  claudeApiKey={claudeApiKey}
+                  onNavigateToTransactions={navigateToTransactions}
+                  onNavigateToSettings={() => setCurrentView('settings')}
                 />
               )}
               {currentView === 'categories' && (

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,6 +1,7 @@
 import {
   Home,
   ListFilter,
+  Sparkles,
   Tag,
   Settings,
   Upload,
@@ -9,7 +10,12 @@ import {
 import type { SupabaseSession } from '../services/supabase/client'
 import { getFriendlyName } from '../utils/user-display'
 
-export type View = 'overview' | 'transactions' | 'categories' | 'settings'
+export type View =
+  | 'overview'
+  | 'transactions'
+  | 'insights'
+  | 'categories'
+  | 'settings'
 
 interface NavGroup {
   label: string
@@ -92,6 +98,7 @@ export function SidebarInner({
           icon: ListFilter,
           count: txCount > 0 ? txCount : undefined,
         },
+        { id: 'insights', label: 'Insights', icon: Sparkles },
       ],
     },
     {

--- a/src/components/Insights.test.tsx
+++ b/src/components/Insights.test.tsx
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Insights } from './Insights'
+import type { Transaction } from '../models'
+import { Category } from '../models'
+import type { SupabaseSession } from '../services/supabase/client'
+import type { InsightsResult } from '../services/insights/insight-generator'
+
+const {
+  getCachedInsightsMock,
+  saveCachedInsightsMock,
+  generateInsightsMock,
+} = vi.hoisted(() => ({
+  getCachedInsightsMock: vi.fn(),
+  saveCachedInsightsMock: vi.fn(),
+  generateInsightsMock: vi.fn(),
+}))
+
+vi.mock('../services/insights/insight-cache', () => ({
+  getCachedInsights: getCachedInsightsMock,
+  saveCachedInsights: saveCachedInsightsMock,
+}))
+
+vi.mock('../services/insights/insight-generator', async () => {
+  const actual = await vi.importActual<
+    typeof import('../services/insights/insight-generator')
+  >('../services/insights/insight-generator')
+  return {
+    ...actual,
+    generateInsights: generateInsightsMock,
+  }
+})
+
+const session = { user: { id: 'user-1' } } as unknown as SupabaseSession
+
+function makeTransaction(id: string, overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id,
+    date: new Date('2026-06-10T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 100,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    category: Category.Restaurants,
+    rawData: {},
+    ...overrides,
+  }
+}
+
+const referenceDate = new Date('2026-06-20T00:00:00.000Z')
+const transactions = [makeTransaction('t1')]
+
+const sampleResult: InsightsResult = {
+  insights: [
+    {
+      type: 'bleeding_money',
+      title: 'Restaurantes creció fuerte',
+      narrative: 'El gasto en restaurantes subió este mes.',
+      amount: 100,
+      currency: 'USD',
+      category: Category.Restaurants,
+      severity: 'high',
+    },
+  ],
+}
+
+describe('Insights', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a disabled state pointing to Settings when AI is not configured', () => {
+    const onNavigateToSettings = vi.fn()
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={false}
+        claudeApiKey=""
+        onNavigateToTransactions={vi.fn()}
+        onNavigateToSettings={onNavigateToSettings}
+        referenceDate={referenceDate}
+      />
+    )
+
+    expect(screen.getByText('Activá la IA para ver insights')).toBeInTheDocument()
+    expect(getCachedInsightsMock).not.toHaveBeenCalled()
+  })
+
+  it('shows an empty state with a generate CTA when there is no cached result', async () => {
+    getCachedInsightsMock.mockResolvedValue(null)
+
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={true}
+        claudeApiKey="sk-test"
+        onNavigateToTransactions={vi.fn()}
+        onNavigateToSettings={vi.fn()}
+        referenceDate={referenceDate}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Generá tus primeros insights')).toBeInTheDocument()
+    )
+  })
+
+  it('renders cached insight cards grouped by type with the hard number from the input', async () => {
+    getCachedInsightsMock.mockResolvedValue({
+      result: sampleResult,
+      model: 'claude-opus-4-8',
+      generatedAt: '2026-06-20T10:00:00.000Z',
+      isStale: false,
+    })
+
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={true}
+        claudeApiKey="sk-test"
+        onNavigateToTransactions={vi.fn()}
+        onNavigateToSettings={vi.fn()}
+        referenceDate={referenceDate}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Restaurantes creció fuerte')).toBeInTheDocument()
+    )
+    expect(screen.getByText('¿Dónde se fue tu dinero?')).toBeInTheDocument()
+    expect(screen.getByText('US$ 100,00')).toBeInTheDocument()
+    expect(screen.queryByText(/desactualizados/)).not.toBeInTheDocument()
+  })
+
+  it('navigates to Transactions filtered by category when "Ver transacciones" is clicked', async () => {
+    getCachedInsightsMock.mockResolvedValue({
+      result: sampleResult,
+      model: 'claude-opus-4-8',
+      generatedAt: '2026-06-20T10:00:00.000Z',
+      isStale: false,
+    })
+    const onNavigateToTransactions = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={true}
+        claudeApiKey="sk-test"
+        onNavigateToTransactions={onNavigateToTransactions}
+        onNavigateToSettings={vi.fn()}
+        referenceDate={referenceDate}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Ver transacciones →')).toBeInTheDocument()
+    )
+    await user.click(screen.getByText('Ver transacciones →'))
+
+    expect(onNavigateToTransactions).toHaveBeenCalledWith({
+      category: Category.Restaurants,
+    })
+  })
+
+  it('shows a stale banner when the cached input no longer matches the current data', async () => {
+    getCachedInsightsMock.mockResolvedValue({
+      result: sampleResult,
+      model: 'claude-opus-4-8',
+      generatedAt: '2026-06-20T10:00:00.000Z',
+      isStale: true,
+    })
+
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={true}
+        claudeApiKey="sk-test"
+        onNavigateToTransactions={vi.fn()}
+        onNavigateToSettings={vi.fn()}
+        referenceDate={referenceDate}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText(/desactualizados/)).toBeInTheDocument())
+  })
+
+  it('generates and caches new insights when the generate button is clicked', async () => {
+    getCachedInsightsMock.mockResolvedValue(null)
+    generateInsightsMock.mockResolvedValue(sampleResult)
+    saveCachedInsightsMock.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={true}
+        claudeApiKey="sk-test"
+        onNavigateToTransactions={vi.fn()}
+        onNavigateToSettings={vi.fn()}
+        referenceDate={referenceDate}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Generar insights')).toBeInTheDocument()
+    )
+    await user.click(screen.getByText('Generar insights'))
+
+    await waitFor(() =>
+      expect(screen.getByText('Restaurantes creció fuerte')).toBeInTheDocument()
+    )
+
+    expect(generateInsightsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ periodStart: '2026-06-01', periodEnd: '2026-06-30' }),
+      'sk-test'
+    )
+    expect(saveCachedInsightsMock).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({ periodStart: '2026-06-01' }),
+      sampleResult,
+      'claude-opus-4-8'
+    )
+  })
+})

--- a/src/components/Insights.test.tsx
+++ b/src/components/Insights.test.tsx
@@ -202,6 +202,33 @@ describe('Insights', () => {
     await waitFor(() => expect(screen.getByText(/desactualizados/)).toBeInTheDocument())
   })
 
+  it('does not loop-fetch when referenceDate is omitted (matches real App.tsx usage, which never passes it)', async () => {
+    // Regression guard: referenceDate previously defaulted via a JS default
+    // parameter (`referenceDate = new Date()`), which re-evaluates on every
+    // render. That made the period/input useMemo recompute every render,
+    // which re-ran the fetch effect, which set state, which re-rendered —
+    // an unbounded loop hammering Supabase. Deliberately omits the prop
+    // here (unlike every other test in this file) to exercise that path.
+    getCachedInsightsMock.mockResolvedValue(null)
+
+    render(
+      <Insights
+        transactions={transactions}
+        homeCurrency="USD"
+        fxRate={40.5}
+        session={session}
+        aiEnabled={true}
+        claudeApiKey="sk-test"
+        onNavigateToTransactions={vi.fn()}
+        onNavigateToSettings={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(getCachedInsightsMock).toHaveBeenCalled())
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(getCachedInsightsMock.mock.calls.length).toBeLessThanOrEqual(1)
+  })
+
   it('generates and caches new insights when the generate button is clicked', async () => {
     getCachedInsightsMock.mockResolvedValue(null)
     generateInsightsMock.mockResolvedValue(sampleResult)

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -1,0 +1,436 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Sparkles,
+  TrendingDown,
+  Scissors,
+  Repeat,
+  LineChart,
+  AlertTriangle,
+  ChevronLeft,
+  ChevronRight,
+  RefreshCw,
+} from 'lucide-react'
+import { Card } from './ui/card'
+import { Button } from './ui/button'
+import { CategoryBadge } from './CategoryBadge'
+import { formatCurrency } from '../utils/formatting'
+import type { Currency, Transaction, TransactionsFilter } from '../models'
+import type { SupabaseSession } from '../services/supabase/client'
+import { buildInsightInput, getUtcMonthPeriod } from '../services/insights/insight-data'
+import {
+  generateInsights,
+  type Insight,
+  type InsightSeverity,
+  type InsightType,
+} from '../services/insights/insight-generator'
+import {
+  getCachedInsights,
+  saveCachedInsights,
+  type CachedInsightsLookup,
+} from '../services/insights/insight-cache'
+
+interface InsightsProps {
+  transactions: Transaction[]
+  homeCurrency: Currency
+  fxRate: number
+  session: SupabaseSession
+  aiEnabled: boolean
+  claudeApiKey: string
+  onNavigateToTransactions: (filter: TransactionsFilter) => void
+  onNavigateToSettings: () => void
+  referenceDate?: Date
+}
+
+const TYPE_ORDER: InsightType[] = [
+  'bleeding_money',
+  'easiest_cut',
+  'recurring',
+  'trend',
+  'anomaly',
+]
+
+const TYPE_META: Record<InsightType, { label: string; icon: typeof TrendingDown }> = {
+  bleeding_money: { label: '¿Dónde se fue tu dinero?', icon: TrendingDown },
+  easiest_cut: { label: 'Fácil de recortar', icon: Scissors },
+  recurring: { label: 'Suscripciones y cargos recurrentes', icon: Repeat },
+  trend: { label: 'Tendencias', icon: LineChart },
+  anomaly: { label: 'Anomalías', icon: AlertTriangle },
+}
+
+const SEVERITY_RANK: Record<InsightSeverity, number> = { high: 0, medium: 1, low: 2 }
+const SEVERITY_COLOR: Record<InsightSeverity, string> = {
+  high: 'var(--neg)',
+  medium: 'var(--accent)',
+  low: 'var(--text-faint)',
+}
+
+function groupAndSortInsights(insights: Insight[]): Array<{ type: InsightType; items: Insight[] }> {
+  const byType = new Map<InsightType, Insight[]>()
+  insights.forEach((insight) => {
+    const list = byType.get(insight.type) ?? []
+    list.push(insight)
+    byType.set(insight.type, list)
+  })
+
+  return TYPE_ORDER.filter((type) => byType.has(type)).map((type) => ({
+    type,
+    items: [...(byType.get(type) ?? [])].sort(
+      (a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+    ),
+  }))
+}
+
+function formatMonthLabel(date: Date): string {
+  return date.toLocaleDateString('es-UY', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+export function Insights({
+  transactions,
+  homeCurrency,
+  fxRate,
+  session,
+  aiEnabled,
+  claudeApiKey,
+  onNavigateToTransactions,
+  onNavigateToSettings,
+  referenceDate = new Date(),
+}: InsightsProps) {
+  const [monthOffset, setMonthOffset] = useState(0)
+  const [cached, setCached] = useState<CachedInsightsLookup | null>(null)
+  const [loadingCache, setLoadingCache] = useState(true)
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState('')
+
+  const isConfigured = aiEnabled && Boolean(claudeApiKey)
+
+  const period = useMemo(
+    () => getUtcMonthPeriod(referenceDate, monthOffset),
+    [referenceDate, monthOffset]
+  )
+
+  const input = useMemo(
+    () => buildInsightInput(transactions, period, homeCurrency, fxRate),
+    [transactions, period, homeCurrency, fxRate]
+  )
+
+  useEffect(() => {
+    if (!isConfigured) {
+      setLoadingCache(false)
+      setCached(null)
+      return
+    }
+
+    let cancelled = false
+    setLoadingCache(true)
+    setError('')
+
+    getCachedInsights(session, input)
+      .then((result) => {
+        if (!cancelled) setCached(result)
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(
+            e instanceof Error ? e.message : 'No se pudieron cargar los insights'
+          )
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingCache(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [session, input, isConfigured])
+
+  async function handleGenerate() {
+    setGenerating(true)
+    setError('')
+    try {
+      const result = await generateInsights(input, claudeApiKey)
+      await saveCachedInsights(session, input, result, 'claude-opus-4-8')
+      setCached({
+        result,
+        model: 'claude-opus-4-8',
+        generatedAt: new Date().toISOString(),
+        isStale: false,
+      })
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : 'No se pudieron generar los insights'
+      )
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const groups = useMemo(
+    () => groupAndSortInsights(cached?.result.insights ?? []),
+    [cached]
+  )
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-end',
+          flexWrap: 'wrap',
+          gap: 12,
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: 26,
+              fontWeight: 600,
+              margin: 0,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+            }}
+          >
+            <Sparkles size={22} style={{ color: 'var(--accent)' }} aria-hidden="true" />
+            Insights
+          </h1>
+          <p className="text-muted-foreground" style={{ fontSize: 14, marginTop: 4 }}>
+            ¿Dónde se fue tu dinero? ¿Cómo podés gastar menos?
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Mes anterior"
+            onClick={() => setMonthOffset((m) => m - 1)}
+          >
+            <ChevronLeft size={16} />
+          </Button>
+          <span
+            className="font-mono"
+            style={{ fontSize: 14, minWidth: 120, textAlign: 'center', textTransform: 'capitalize' }}
+          >
+            {formatMonthLabel(period.start)}
+          </span>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Mes siguiente"
+            disabled={monthOffset >= 0}
+            onClick={() => setMonthOffset((m) => Math.min(0, m + 1))}
+          >
+            <ChevronRight size={16} />
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" style={{ fontSize: 13, color: 'var(--neg)' }}>
+          {error}
+        </p>
+      )}
+
+      {!isConfigured && (
+        <Card className="p-8 text-center space-y-4">
+          <div className="mx-auto w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
+            <Sparkles className="text-primary" size={28} />
+          </div>
+          <div>
+            <h2 className="mb-2">Activá la IA para ver insights</h2>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              Los insights usan tu clave de Claude configurada en Configuración
+              para analizar tus gastos de este período.
+            </p>
+          </div>
+          <Button onClick={onNavigateToSettings}>Ir a Configuración</Button>
+        </Card>
+      )}
+
+      {isConfigured && !loadingCache && !cached && (
+        <Card className="p-8 text-center space-y-4">
+          <div className="mx-auto w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
+            <Sparkles className="text-primary" size={28} />
+          </div>
+          <div>
+            <h2 className="mb-2">Generá tus primeros insights</h2>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              Analizamos tus categorías, comercios y cargos recurrentes de{' '}
+              {formatMonthLabel(period.start)} para mostrarte dónde se fue tu
+              dinero.
+            </p>
+          </div>
+          <Button onClick={() => void handleGenerate()} disabled={generating}>
+            <Sparkles size={16} />
+            {generating ? 'Generando…' : 'Generar insights'}
+          </Button>
+        </Card>
+      )}
+
+      {isConfigured && cached && (
+        <>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 10,
+            }}
+          >
+            <p style={{ fontSize: 12, color: 'var(--text-faint)', margin: 0 }}>
+              Generado el{' '}
+              {new Date(cached.generatedAt).toLocaleString('es-UY', {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              })}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleGenerate()}
+              disabled={generating}
+            >
+              <RefreshCw size={14} />
+              {generating ? 'Regenerando…' : 'Regenerar'}
+            </Button>
+          </div>
+
+          {cached.isStale && (
+            <Card
+              className="p-4"
+              style={{ borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
+            >
+              <p style={{ fontSize: 13, margin: 0 }}>
+                Tus transacciones de este período cambiaron desde la última
+                vez que generaste insights. Los que ves abajo pueden estar
+                desactualizados —{' '}
+                <button
+                  onClick={() => void handleGenerate()}
+                  disabled={generating}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    color: 'var(--brand-text)',
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    textDecoration: 'underline',
+                  }}
+                >
+                  regenerar ahora
+                </button>
+                .
+              </p>
+            </Card>
+          )}
+
+          {groups.length === 0 && (
+            <Card className="p-6 text-center">
+              <p className="text-muted-foreground" style={{ margin: 0 }}>
+                No encontramos patrones destacados en {formatMonthLabel(period.start)}.
+              </p>
+            </Card>
+          )}
+
+          {groups.map((group) => {
+            const meta = TYPE_META[group.type]
+            const Icon = meta.icon
+            return (
+              <div key={group.type}>
+                <h3
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    fontSize: 14,
+                    fontWeight: 600,
+                    marginBottom: 12,
+                  }}
+                >
+                  <Icon size={16} style={{ color: 'var(--text-muted)' }} aria-hidden="true" />
+                  {meta.label}
+                </h3>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  {group.items.map((insight, i) => (
+                    <Card
+                      key={`${group.type}-${i}`}
+                      className="p-4"
+                      style={{
+                        borderLeft: `3px solid ${SEVERITY_COLOR[insight.severity]}`,
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'flex-start',
+                          gap: 12,
+                          flexWrap: 'wrap',
+                        }}
+                      >
+                        <div style={{ flex: 1, minWidth: 200 }}>
+                          <p style={{ fontWeight: 600, fontSize: 14, margin: '0 0 4px' }}>
+                            {insight.title}
+                          </p>
+                          <p
+                            className="text-muted-foreground"
+                            style={{ fontSize: 13, margin: 0 }}
+                          >
+                            {insight.narrative}
+                          </p>
+                          {insight.category && (
+                            <div style={{ marginTop: 8 }}>
+                              <CategoryBadge categoryId={insight.category} size="sm" />
+                            </div>
+                          )}
+                        </div>
+                        <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                          {typeof insight.amount === 'number' && (
+                            <p
+                              className="font-mono"
+                              style={{ fontSize: 16, fontWeight: 600, margin: 0 }}
+                            >
+                              {insight.amount < 0 ? '−' : ''}
+                              {formatCurrency(Math.abs(insight.amount), insight.currency)}
+                            </p>
+                          )}
+                          {insight.category && (
+                            <button
+                              onClick={() =>
+                                onNavigateToTransactions({ category: insight.category })
+                              }
+                              style={{
+                                marginTop: 6,
+                                background: 'none',
+                                border: 'none',
+                                padding: 0,
+                                fontSize: 12,
+                                color: 'var(--brand-text)',
+                                fontWeight: 600,
+                                cursor: 'pointer',
+                              }}
+                            >
+                              Ver transacciones →
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -97,8 +97,16 @@ export function Insights({
   claudeApiKey,
   onNavigateToTransactions,
   onNavigateToSettings,
-  referenceDate = new Date(),
+  referenceDate,
 }: InsightsProps) {
+  // A JS default parameter (`referenceDate = new Date()`) re-evaluates on
+  // every render, which would make `period`/`input` below recompute every
+  // render and re-trigger the data-fetching effect in a loop. useState's
+  // initializer runs once, so this fallback is stable across re-renders
+  // regardless of whether the caller passes referenceDate.
+  const [fallbackReferenceDate] = useState(() => new Date())
+  const effectiveReferenceDate = referenceDate ?? fallbackReferenceDate
+
   const [monthOffset, setMonthOffset] = useState(0)
   const [cached, setCached] = useState<CachedInsightsLookup | null>(null)
   const [loadingCache, setLoadingCache] = useState(true)
@@ -108,8 +116,8 @@ export function Insights({
   const isConfigured = aiEnabled && Boolean(claudeApiKey)
 
   const period = useMemo(
-    () => getUtcMonthPeriod(referenceDate, monthOffset),
-    [referenceDate, monthOffset]
+    () => getUtcMonthPeriod(effectiveReferenceDate, monthOffset),
+    [effectiveReferenceDate, monthOffset]
   )
 
   const input = useMemo(

--- a/src/services/insights/insight-cache.test.ts
+++ b/src/services/insights/insight-cache.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseSession } from '../supabase/client'
+import type { InsightInput } from './insight-data'
+import type { InsightsResult } from './insight-generator'
+
+const { loadCachedInsightsMock, saveInsightsMock } = vi.hoisted(() => ({
+  loadCachedInsightsMock: vi.fn(),
+  saveInsightsMock: vi.fn(),
+}))
+
+vi.mock('../supabase/ai-insights', () => ({
+  loadCachedInsights: loadCachedInsightsMock,
+  saveInsights: saveInsightsMock,
+}))
+
+import { hashInsightInput, getCachedInsights, saveCachedInsights } from './insight-cache'
+
+const session = {
+  user: { id: 'user-1' },
+} as unknown as SupabaseSession
+
+const input: InsightInput = {
+  periodStart: '2026-06-01',
+  periodEnd: '2026-06-30',
+  homeCurrency: 'USD',
+  categoryTotals: [
+    { category: 'groceries', amount: 100, pctOfTotal: 100, deltaVsPriorPeriod: 0 },
+  ],
+  topMerchants: [],
+  recurringCharges: [],
+  monthlyTrend: [],
+}
+
+const result: InsightsResult = { insights: [] }
+
+describe('hashInsightInput', () => {
+  it('is deterministic for the same input', () => {
+    expect(hashInsightInput(input)).toBe(hashInsightInput({ ...input }))
+  })
+
+  it('changes when the input changes', () => {
+    const changed: InsightInput = {
+      ...input,
+      categoryTotals: [
+        { category: 'groceries', amount: 999, pctOfTotal: 100, deltaVsPriorPeriod: 0 },
+      ],
+    }
+    expect(hashInsightInput(input)).not.toBe(hashInsightInput(changed))
+  })
+})
+
+describe('getCachedInsights', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null when there is no cached row', async () => {
+    loadCachedInsightsMock.mockResolvedValue(null)
+    const cached = await getCachedInsights(session, input)
+    expect(cached).toBeNull()
+  })
+
+  it('marks the result fresh when the stored hash matches the current input', async () => {
+    loadCachedInsightsMock.mockResolvedValue({
+      periodStart: input.periodStart,
+      periodEnd: input.periodEnd,
+      inputHash: hashInsightInput(input),
+      model: 'claude-opus-4-8',
+      insights: result,
+      generatedAt: '2026-06-30T12:00:00.000Z',
+    })
+
+    const cached = await getCachedInsights(session, input)
+    expect(cached).toEqual({
+      result,
+      model: 'claude-opus-4-8',
+      generatedAt: '2026-06-30T12:00:00.000Z',
+      isStale: false,
+    })
+  })
+
+  it('marks the result stale when the stored hash no longer matches the input', async () => {
+    loadCachedInsightsMock.mockResolvedValue({
+      periodStart: input.periodStart,
+      periodEnd: input.periodEnd,
+      inputHash: 'stale-hash',
+      model: 'claude-opus-4-8',
+      insights: result,
+      generatedAt: '2026-06-30T12:00:00.000Z',
+    })
+
+    const cached = await getCachedInsights(session, input)
+    expect(cached?.isStale).toBe(true)
+  })
+})
+
+describe('saveCachedInsights', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves the result keyed by period with the computed input hash', async () => {
+    saveInsightsMock.mockResolvedValue(undefined)
+
+    await saveCachedInsights(session, input, result, 'claude-opus-4-8')
+
+    expect(saveInsightsMock).toHaveBeenCalledWith(session, {
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      inputHash: hashInsightInput(input),
+      model: 'claude-opus-4-8',
+      insights: result,
+    })
+  })
+})

--- a/src/services/insights/insight-cache.ts
+++ b/src/services/insights/insight-cache.ts
@@ -1,0 +1,70 @@
+import type { SupabaseSession } from '../supabase/client'
+import {
+  loadCachedInsights as loadCachedInsightsRow,
+  saveInsights as saveInsightsRow,
+} from '../supabase/ai-insights'
+import type { InsightInput } from './insight-data'
+import type { InsightsResult } from './insight-generator'
+
+/**
+ * Deterministic, non-cryptographic hash of an InsightInput — used only to
+ * detect whether the underlying transactions changed since insights were
+ * last generated for a period. Not a security boundary.
+ */
+export function hashInsightInput(input: InsightInput): string {
+  const json = JSON.stringify(input)
+  let hash = 0x811c9dc5 // FNV-1a 32-bit offset basis
+  for (let i = 0; i < json.length; i++) {
+    hash ^= json.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16)
+}
+
+export interface CachedInsightsLookup {
+  result: InsightsResult
+  model: string
+  generatedAt: string
+  isStale: boolean
+}
+
+/**
+ * Looks up a cached insights row for the input's period. `isStale` is true
+ * when the current InsightInput no longer matches the hash of the input
+ * that produced the cached result (new imports, edits, re-categorization) —
+ * the UI shows a "data changed, regenerate?" banner instead of silently
+ * regenerating (see ADR-0001).
+ */
+export async function getCachedInsights(
+  session: SupabaseSession,
+  input: InsightInput
+): Promise<CachedInsightsLookup | null> {
+  const row = await loadCachedInsightsRow(
+    session,
+    input.periodStart,
+    input.periodEnd
+  )
+  if (!row) return null
+
+  return {
+    result: row.insights,
+    model: row.model,
+    generatedAt: row.generatedAt,
+    isStale: row.inputHash !== hashInsightInput(input),
+  }
+}
+
+export async function saveCachedInsights(
+  session: SupabaseSession,
+  input: InsightInput,
+  result: InsightsResult,
+  model: string
+): Promise<void> {
+  await saveInsightsRow(session, {
+    periodStart: input.periodStart,
+    periodEnd: input.periodEnd,
+    inputHash: hashInsightInput(input),
+    model,
+    insights: result,
+  })
+}

--- a/src/services/insights/insight-data.test.ts
+++ b/src/services/insights/insight-data.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { buildInsightInput, getUtcMonthPeriod } from './insight-data'
+import type { Transaction } from '../../models'
+import { Category } from '../../models'
+
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
+  return {
+    id,
+    date: new Date('2026-06-15T00:00:00.000Z'),
+    description: `Transaction ${id}`,
+    amount: 10,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+const JUNE = { start: new Date('2026-06-01T00:00:00.000Z'), end: new Date('2026-06-30T23:59:59.999Z') }
+
+describe('getUtcMonthPeriod', () => {
+  it('returns UTC month boundaries regardless of time-of-day on the reference date', () => {
+    const period = getUtcMonthPeriod(new Date('2026-06-15T23:00:00.000Z'))
+    expect(period.start.toISOString()).toBe('2026-06-01T00:00:00.000Z')
+    expect(period.end.toISOString()).toBe('2026-06-30T23:59:59.999Z')
+  })
+
+  it('does not exclude a transaction dated exactly at UTC month start', () => {
+    // Regression guard: a local-timezone-based boundary (e.g. via date-fns
+    // startOfMonth, which reads the browser's local wall clock) would put
+    // period.start a few hours after 00:00 UTC for any non-UTC+0 timezone,
+    // silently dropping same-day transactions into the wrong period.
+    const period = getUtcMonthPeriod(new Date('2026-06-15T00:00:00.000Z'))
+    const firstOfMonth = new Date('2026-06-01T00:00:00.000Z')
+    expect(firstOfMonth >= period.start).toBe(true)
+  })
+
+  it('applies a month offset, rolling over year boundaries', () => {
+    const december = getUtcMonthPeriod(new Date('2026-01-15T00:00:00.000Z'), -1)
+    expect(december.start.toISOString()).toBe('2025-12-01T00:00:00.000Z')
+    expect(december.end.toISOString()).toBe('2025-12-31T23:59:59.999Z')
+  })
+
+  it('handles a leap-year February correctly', () => {
+    const feb = getUtcMonthPeriod(new Date('2028-02-10T00:00:00.000Z'))
+    expect(feb.end.toISOString()).toBe('2028-02-29T23:59:59.999Z')
+  })
+})
+
+describe('buildInsightInput', () => {
+  it('computes category totals with pctOfTotal and delta vs prior period', () => {
+    const transactions = [
+      // June (current period): groceries 100, restaurants 50
+      makeTransaction('g1', { date: new Date('2026-06-05'), amount: 60, category: Category.Groceries }),
+      makeTransaction('g2', { date: new Date('2026-06-15'), amount: 40, category: Category.Groceries }),
+      makeTransaction('r1', { date: new Date('2026-06-20'), amount: 50, category: Category.Restaurants }),
+      // May (prior period): groceries 80
+      makeTransaction('g3', { date: new Date('2026-05-10'), amount: 80, category: Category.Groceries }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    const groceries = result.categoryTotals.find((c) => c.category === Category.Groceries)
+    const restaurants = result.categoryTotals.find((c) => c.category === Category.Restaurants)
+
+    expect(groceries?.amount).toBe(100)
+    expect(groceries?.deltaVsPriorPeriod).toBe(20) // 100 - 80
+    expect(restaurants?.amount).toBe(50)
+    expect(restaurants?.deltaVsPriorPeriod).toBe(50) // 50 - 0, nothing in May
+
+    // pctOfTotal sums to ~100 across categories
+    const totalPct = result.categoryTotals.reduce((sum, c) => sum + c.pctOfTotal, 0)
+    expect(totalPct).toBeCloseTo(100, 5)
+  })
+
+  it('excludes credits, ignored/transfer categories, and split parents from category totals', () => {
+    const transactions = [
+      makeTransaction('income', { date: new Date('2026-06-05'), amount: 1000, type: 'credit', category: Category.Income }),
+      makeTransaction('transfer', { date: new Date('2026-06-06'), amount: 200, category: Category.InternalTransfer }),
+      makeTransaction('split-parent', { date: new Date('2026-06-07'), amount: 300, category: Category.Groceries, isSplitParent: true }),
+      makeTransaction('real', { date: new Date('2026-06-08'), amount: 25, category: Category.Groceries }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(result.categoryTotals).toEqual([
+      expect.objectContaining({ category: Category.Groceries, amount: 25 }),
+    ])
+  })
+
+  it('ranks top merchants by converted spend within the period only', () => {
+    const transactions = [
+      makeTransaction('m1', { date: new Date('2026-06-01'), amount: 30, displayDescription: 'Netflix', category: Category.Entertainment }),
+      makeTransaction('m2', { date: new Date('2026-06-01'), amount: 20, displayDescription: 'Netflix', category: Category.Entertainment }),
+      makeTransaction('m3', { date: new Date('2026-06-02'), amount: 15, description: 'UBER TRIP', category: Category.Transport }),
+      // Outside period — must not count toward topMerchants
+      makeTransaction('m4', { date: new Date('2026-05-02'), amount: 500, displayDescription: 'Netflix', category: Category.Entertainment }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(result.topMerchants[0]).toEqual({ merchant: 'Netflix', amount: 50, count: 2 })
+    expect(result.topMerchants[1]).toEqual({ merchant: 'UBER TRIP', amount: 15, count: 1 })
+  })
+
+  it('detects a recurring monthly charge across the lookback window', () => {
+    const transactions = [
+      makeTransaction('s1', { date: new Date('2026-03-10'), amount: 15, displayDescription: 'Spotify', category: Category.Entertainment }),
+      makeTransaction('s2', { date: new Date('2026-04-10'), amount: 15, displayDescription: 'Spotify', category: Category.Entertainment }),
+      makeTransaction('s3', { date: new Date('2026-05-10'), amount: 15, displayDescription: 'Spotify', category: Category.Entertainment }),
+      makeTransaction('s4', { date: new Date('2026-06-10'), amount: 15.5, displayDescription: 'Spotify', category: Category.Entertainment }),
+      // A single one-off large purchase — must not be flagged as recurring
+      makeTransaction('once', { date: new Date('2026-06-12'), amount: 900, displayDescription: 'Muebles del Este', category: Category.Shopping }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    const spotify = result.recurringCharges.find((c) => c.merchant === 'Spotify')
+    expect(spotify).toBeDefined()
+    expect(spotify?.cadence).toBe('monthly')
+    expect(spotify?.monthsSeen).toBe(4)
+    expect(result.recurringCharges.some((c) => c.merchant === 'Muebles del Este')).toBe(false)
+  })
+
+  it('does not flag a merchant with wildly varying amounts as recurring', () => {
+    const transactions = [
+      makeTransaction('v1', { date: new Date('2026-03-10'), amount: 10, displayDescription: 'MercadoPago Varios', category: Category.Shopping }),
+      makeTransaction('v2', { date: new Date('2026-04-10'), amount: 200, displayDescription: 'MercadoPago Varios', category: Category.Shopping }),
+      makeTransaction('v3', { date: new Date('2026-05-10'), amount: 5, displayDescription: 'MercadoPago Varios', category: Category.Shopping }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(result.recurringCharges).toHaveLength(0)
+  })
+
+  it('builds a monthly trend using converted income/expense over the trailing window', () => {
+    const transactions = [
+      makeTransaction('may-income', { date: new Date('2026-05-01'), amount: 1000, type: 'credit', category: Category.Income }),
+      makeTransaction('may-expense', { date: new Date('2026-05-02'), amount: 400, category: Category.Groceries }),
+      makeTransaction('june-income', { date: new Date('2026-06-01'), amount: 1000, type: 'credit', category: Category.Income }),
+      makeTransaction('june-expense', { date: new Date('2026-06-02'), amount: 600, category: Category.Groceries }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    const may = result.monthlyTrend.find((m) => m.month === '2026-05')
+    const june = result.monthlyTrend.find((m) => m.month === '2026-06')
+    expect(may).toEqual({ month: '2026-05', income: 1000, expense: 400 })
+    expect(june).toEqual({ month: '2026-06', income: 1000, expense: 600 })
+  })
+
+  it('converts amounts to the requested home currency', () => {
+    const transactions = [
+      makeTransaction('uyu1', { date: new Date('2026-06-05'), amount: 405, currency: 'UYU', category: Category.Groceries }),
+    ]
+
+    const result = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(result.categoryTotals[0].amount).toBeCloseTo(10, 5)
+  })
+
+  it('stamps periodStart/periodEnd and homeCurrency on the result', () => {
+    const result = buildInsightInput([], JUNE, 'UYU', 40.5)
+    expect(result.periodStart).toBe('2026-06-01')
+    expect(result.periodEnd).toBe('2026-06-30')
+    expect(result.homeCurrency).toBe('UYU')
+  })
+})

--- a/src/services/insights/insight-data.ts
+++ b/src/services/insights/insight-data.ts
@@ -1,0 +1,295 @@
+import type { Currency, Transaction } from '../../models'
+import { isSplitParentTx } from '../../models'
+import { isCategoryIgnored } from '../categories/category-registry'
+import { convert } from '../currency/convert'
+import {
+  buildCategorySpendingConverted,
+  buildMonthlyTrendsConverted,
+} from '../charts/chart-data'
+import { toDateKey, toMonthKey } from '../../utils/date-utils'
+import { subMonths } from 'date-fns'
+
+export interface InsightPeriod {
+  start: Date
+  end: Date
+}
+
+/**
+ * Builds a calendar-month InsightPeriod anchored in UTC. Transaction dates
+ * and toDateKey/toMonthKey are UTC-normalized throughout this codebase, but
+ * date-fns helpers like date-utils.ts's getDateRangeForPeriod operate on the
+ * browser's local timezone — reusing that here would shift period
+ * boundaries by the local UTC offset and silently misattribute transactions
+ * dated on the 1st/last day of the month to the wrong period. monthOffset
+ * shifts by whole months (e.g. -1 for the previous month).
+ */
+export function getUtcMonthPeriod(
+  referenceDate: Date,
+  monthOffset = 0
+): InsightPeriod {
+  const year = referenceDate.getUTCFullYear()
+  const month = referenceDate.getUTCMonth() + monthOffset
+  return {
+    start: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
+    end: new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999)),
+  }
+}
+
+export interface CategoryInsightTotal {
+  category: string
+  amount: number
+  pctOfTotal: number
+  deltaVsPriorPeriod: number
+}
+
+export interface MerchantTotal {
+  merchant: string
+  amount: number
+  count: number
+}
+
+export type RecurringCadence = 'weekly' | 'monthly' | 'irregular'
+
+export interface RecurringCharge {
+  merchant: string
+  approxAmount: number
+  cadence: RecurringCadence
+  monthsSeen: number
+}
+
+export interface MonthlyTrendPoint {
+  month: string
+  income: number
+  expense: number
+}
+
+export interface InsightInput {
+  periodStart: string
+  periodEnd: string
+  homeCurrency: Currency
+  categoryTotals: CategoryInsightTotal[]
+  topMerchants: MerchantTotal[]
+  recurringCharges: RecurringCharge[]
+  monthlyTrend: MonthlyTrendPoint[]
+}
+
+const TOP_MERCHANTS_LIMIT = 8
+const RECURRING_LOOKBACK_MONTHS = 6
+const RECURRING_MIN_MONTHS_SEEN = 3
+const RECURRING_AMOUNT_VARIANCE = 0.15
+const TREND_MONTHS = 6
+
+function isEligibleDebit(tx: Transaction): boolean {
+  return (
+    tx.type === 'debit' &&
+    !isCategoryIgnored(tx.category) &&
+    !isSplitParentTx(tx)
+  )
+}
+
+function merchantOf(tx: Transaction): string {
+  return (tx.displayDescription ?? tx.description).trim()
+}
+
+function filterInRange(
+  transactions: Transaction[],
+  start: Date,
+  end: Date
+): Transaction[] {
+  return transactions.filter((tx) => tx.date >= start && tx.date <= end)
+}
+
+function priorPeriodOf(period: InsightPeriod): InsightPeriod {
+  const spanMs = period.end.getTime() - period.start.getTime()
+  const priorEnd = new Date(period.start.getTime() - 1)
+  const priorStart = new Date(priorEnd.getTime() - spanMs)
+  return { start: priorStart, end: priorEnd }
+}
+
+function buildCategoryTotals(
+  periodTransactions: Transaction[],
+  priorTransactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number
+): CategoryInsightTotal[] {
+  const current = buildCategorySpendingConverted(
+    periodTransactions,
+    homeCurrency,
+    fxRate
+  )
+  const priorByCategory = new Map(
+    buildCategorySpendingConverted(priorTransactions, homeCurrency, fxRate).map(
+      (d) => [d.category, d.total]
+    )
+  )
+  const grandTotal = current.reduce((sum, d) => sum + d.total, 0) || 1
+
+  return current.map((d) => ({
+    category: d.category,
+    amount: d.total,
+    pctOfTotal: (d.total / grandTotal) * 100,
+    deltaVsPriorPeriod: d.total - (priorByCategory.get(d.category) ?? 0),
+  }))
+}
+
+function buildTopMerchants(
+  periodTransactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number
+): MerchantTotal[] {
+  const byMerchant = new Map<string, MerchantTotal>()
+
+  periodTransactions.forEach((tx) => {
+    if (!isEligibleDebit(tx)) return
+    const merchant = merchantOf(tx)
+    const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
+    const entry = byMerchant.get(merchant) ?? { merchant, amount: 0, count: 0 }
+    entry.amount += converted
+    entry.count += 1
+    byMerchant.set(merchant, entry)
+  })
+
+  return Array.from(byMerchant.values())
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, TOP_MERCHANTS_LIMIT)
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid]
+}
+
+function averageGapDays(sortedDates: Date[]): number {
+  if (sortedDates.length < 2) return Infinity
+  const gaps: number[] = []
+  for (let i = 1; i < sortedDates.length; i++) {
+    const days =
+      (sortedDates[i].getTime() - sortedDates[i - 1].getTime()) /
+      (1000 * 60 * 60 * 24)
+    gaps.push(days)
+  }
+  return gaps.reduce((sum, g) => sum + g, 0) / gaps.length
+}
+
+function cadenceFromGap(avgGapDays: number): RecurringCadence {
+  if (avgGapDays <= 10) return 'weekly'
+  if (avgGapDays <= 40) return 'monthly'
+  return 'irregular'
+}
+
+function detectRecurringCharges(
+  allTransactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number,
+  asOf: Date
+): RecurringCharge[] {
+  const windowStart = subMonths(asOf, RECURRING_LOOKBACK_MONTHS)
+  const relevant = allTransactions.filter(
+    (tx) => isEligibleDebit(tx) && tx.date >= windowStart && tx.date <= asOf
+  )
+
+  const byMerchant = new Map<string, Transaction[]>()
+  relevant.forEach((tx) => {
+    const merchant = merchantOf(tx)
+    const list = byMerchant.get(merchant) ?? []
+    list.push(tx)
+    byMerchant.set(merchant, list)
+  })
+
+  const charges: RecurringCharge[] = []
+
+  byMerchant.forEach((txs, merchant) => {
+    const monthsSeen = new Set(txs.map((tx) => toMonthKey(tx.date))).size
+    if (monthsSeen < RECURRING_MIN_MONTHS_SEEN) return
+
+    const amounts = txs.map((tx) =>
+      convert(tx.amount, tx.currency, homeCurrency, fxRate)
+    )
+    const approxAmount = median(amounts)
+    const withinVariance = amounts.every((a) =>
+      approxAmount === 0
+        ? a === 0
+        : Math.abs(a - approxAmount) / approxAmount <= RECURRING_AMOUNT_VARIANCE
+    )
+    if (!withinVariance) return
+
+    const sortedDates = txs.map((tx) => tx.date).sort((a, b) => a.getTime() - b.getTime())
+
+    charges.push({
+      merchant,
+      approxAmount,
+      cadence: cadenceFromGap(averageGapDays(sortedDates)),
+      monthsSeen,
+    })
+  })
+
+  return charges.sort((a, b) => b.approxAmount - a.approxAmount)
+}
+
+function buildMonthlyTrend(
+  allTransactions: Transaction[],
+  homeCurrency: Currency,
+  fxRate: number,
+  asOf: Date
+): MonthlyTrendPoint[] {
+  const windowStart = subMonths(asOf, TREND_MONTHS - 1)
+  const relevant = allTransactions.filter(
+    (tx) => tx.date >= windowStart && tx.date <= asOf
+  )
+  return buildMonthlyTrendsConverted(relevant, homeCurrency, fxRate).map(
+    (d) => ({ month: d.month, income: d.income, expense: d.expense })
+  )
+}
+
+/**
+ * Builds the deterministic, pre-computed input handed to the AI insight
+ * generator. Every number here is derived from existing aggregator/chart
+ * selectors — the model only ranks and narrates these values, it never
+ * computes them (see ADR-0001).
+ */
+export function buildInsightInput(
+  allTransactions: Transaction[],
+  period: InsightPeriod,
+  homeCurrency: Currency,
+  fxRate: number
+): InsightInput {
+  const priorPeriod = priorPeriodOf(period)
+  const periodTransactions = filterInRange(
+    allTransactions,
+    period.start,
+    period.end
+  )
+  const priorTransactions = filterInRange(
+    allTransactions,
+    priorPeriod.start,
+    priorPeriod.end
+  )
+
+  return {
+    periodStart: toDateKey(period.start),
+    periodEnd: toDateKey(period.end),
+    homeCurrency,
+    categoryTotals: buildCategoryTotals(
+      periodTransactions,
+      priorTransactions,
+      homeCurrency,
+      fxRate
+    ),
+    topMerchants: buildTopMerchants(periodTransactions, homeCurrency, fxRate),
+    recurringCharges: detectRecurringCharges(
+      allTransactions,
+      homeCurrency,
+      fxRate,
+      period.end
+    ),
+    monthlyTrend: buildMonthlyTrend(
+      allTransactions,
+      homeCurrency,
+      fxRate,
+      period.end
+    ),
+  }
+}

--- a/src/services/insights/insight-data.ts
+++ b/src/services/insights/insight-data.ts
@@ -7,11 +7,30 @@ import {
   buildMonthlyTrendsConverted,
 } from '../charts/chart-data'
 import { toDateKey, toMonthKey } from '../../utils/date-utils'
-import { subMonths } from 'date-fns'
 
 export interface InsightPeriod {
   start: Date
   end: Date
+}
+
+/**
+ * UTC-safe equivalent of date-fns subMonths — used for lookback windows
+ * (recurring-charge detection, trend range) so they stay consistent with
+ * getUtcMonthPeriod's UTC anchoring instead of drifting by the browser's
+ * local UTC offset.
+ */
+function subUtcMonths(date: Date, months: number): Date {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth() - months,
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds()
+    )
+  )
 }
 
 /**
@@ -186,7 +205,7 @@ function detectRecurringCharges(
   fxRate: number,
   asOf: Date
 ): RecurringCharge[] {
-  const windowStart = subMonths(asOf, RECURRING_LOOKBACK_MONTHS)
+  const windowStart = subUtcMonths(asOf, RECURRING_LOOKBACK_MONTHS)
   const relevant = allTransactions.filter(
     (tx) => isEligibleDebit(tx) && tx.date >= windowStart && tx.date <= asOf
   )
@@ -235,7 +254,7 @@ function buildMonthlyTrend(
   fxRate: number,
   asOf: Date
 ): MonthlyTrendPoint[] {
-  const windowStart = subMonths(asOf, TREND_MONTHS - 1)
+  const windowStart = subUtcMonths(asOf, TREND_MONTHS - 1)
   const relevant = allTransactions.filter(
     (tx) => tx.date >= windowStart && tx.date <= asOf
   )

--- a/src/services/insights/insight-generator.test.ts
+++ b/src/services/insights/insight-generator.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { InsightInput } from './insight-data'
+
+const { messagesCreateMock } = vi.hoisted(() => ({
+  messagesCreateMock: vi.fn(),
+}))
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class Anthropic {
+      messages = { create: messagesCreateMock }
+    },
+  }
+})
+
+import { parseInsightsResponse, generateInsights } from './insight-generator'
+
+const baseInput: InsightInput = {
+  periodStart: '2026-06-01',
+  periodEnd: '2026-06-30',
+  homeCurrency: 'USD',
+  categoryTotals: [
+    { category: 'restaurants', amount: 120, pctOfTotal: 40, deltaVsPriorPeriod: 34 },
+    { category: 'groceries', amount: 80, pctOfTotal: 26.7, deltaVsPriorPeriod: -10 },
+  ],
+  topMerchants: [{ merchant: 'Netflix', amount: 15, count: 1 }],
+  recurringCharges: [
+    { merchant: 'Spotify', approxAmount: 12, cadence: 'monthly', monthsSeen: 4 },
+  ],
+  monthlyTrend: [{ month: '2026-06', income: 1000, expense: 300 }],
+}
+
+describe('parseInsightsResponse', () => {
+  it('parses a well-formed JSON response', () => {
+    const text = JSON.stringify({
+      insights: [
+        {
+          type: 'bleeding_money',
+          title: 'Restaurantes creció fuerte',
+          narrative: 'El gasto en restaurantes subió $34 este mes.',
+          amount: 34,
+          currency: 'USD',
+          category: 'restaurants',
+          severity: 'high',
+        },
+      ],
+    })
+
+    const result = parseInsightsResponse(text, baseInput)
+
+    expect(result.insights).toHaveLength(1)
+    expect(result.insights[0]).toEqual({
+      type: 'bleeding_money',
+      title: 'Restaurantes creció fuerte',
+      narrative: 'El gasto en restaurantes subió $34 este mes.',
+      amount: 34,
+      currency: 'USD',
+      category: 'restaurants',
+      severity: 'high',
+    })
+  })
+
+  it('strips markdown fences before parsing', () => {
+    const text = '```json\n' + JSON.stringify({ insights: [] }) + '\n```'
+    expect(parseInsightsResponse(text, baseInput).insights).toEqual([])
+  })
+
+  it('drops an insight whose amount does not match any value in the input', () => {
+    const text = JSON.stringify({
+      insights: [
+        {
+          type: 'bleeding_money',
+          title: 'Gasto inventado',
+          narrative: 'Este número no viene del input.',
+          amount: 999999,
+          currency: 'USD',
+          severity: 'high',
+        },
+      ],
+    })
+
+    // The whole insight is dropped, not just the bad field — a title/narrative
+    // pair that claims an unverifiable number is not trustworthy on its own.
+    const result = parseInsightsResponse(text, baseInput)
+    expect(result.insights).toHaveLength(1)
+    expect(result.insights[0].amount).toBeUndefined()
+  })
+
+  it('drops a category or merchant not present in the input, keeping the rest of the insight', () => {
+    const text = JSON.stringify({
+      insights: [
+        {
+          type: 'easiest_cut',
+          title: 'Título válido',
+          narrative: 'Narrativa válida.',
+          category: 'not_a_real_category',
+          merchant: 'Merchant Inventado',
+          severity: 'low',
+        },
+      ],
+    })
+
+    const result = parseInsightsResponse(text, baseInput)
+    expect(result.insights[0].category).toBeUndefined()
+    expect(result.insights[0].merchant).toBeUndefined()
+  })
+
+  it('accepts an amount that matches a deltaVsPriorPeriod value', () => {
+    const text = JSON.stringify({
+      insights: [
+        {
+          type: 'bleeding_money',
+          title: 'Creció fuerte',
+          narrative: 'Subió respecto al mes anterior.',
+          amount: -10,
+          severity: 'medium',
+        },
+      ],
+    })
+
+    const result = parseInsightsResponse(text, baseInput)
+    expect(result.insights[0].amount).toBe(-10)
+  })
+
+  it('drops insights missing a title, narrative, or valid type', () => {
+    const text = JSON.stringify({
+      insights: [
+        { type: 'bleeding_money', title: '', narrative: 'x', severity: 'low' },
+        { type: 'not_a_type', title: 'x', narrative: 'x', severity: 'low' },
+        { title: 'x', narrative: 'x', severity: 'low' },
+      ],
+    })
+
+    expect(parseInsightsResponse(text, baseInput).insights).toHaveLength(0)
+  })
+
+  it('defaults severity to medium when missing or invalid', () => {
+    const text = JSON.stringify({
+      insights: [{ type: 'trend', title: 'x', narrative: 'y' }],
+    })
+
+    expect(parseInsightsResponse(text, baseInput).insights[0].severity).toBe('medium')
+  })
+
+  it('throws a descriptive error when the response is not valid JSON', () => {
+    expect(() => parseInsightsResponse('not json at all', baseInput)).toThrow(
+      /No se pudo parsear/
+    )
+  })
+})
+
+describe('generateInsights', () => {
+  it('calls Claude with the insights model and the user\'s API key', async () => {
+    messagesCreateMock.mockResolvedValueOnce({
+      content: [{ type: 'text', text: JSON.stringify({ insights: [] }) }],
+    })
+
+    await generateInsights(baseInput, 'sk-test-key')
+
+    expect(messagesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-opus-4-8',
+        messages: [{ role: 'user', content: expect.stringContaining('"periodStart"') }],
+      })
+    )
+  })
+
+  it('throws if the model returns a non-text content block', async () => {
+    messagesCreateMock.mockResolvedValueOnce({
+      content: [{ type: 'image' }],
+    })
+
+    await expect(generateInsights(baseInput, 'sk-test-key')).rejects.toThrow(
+      /Respuesta inesperada/
+    )
+  })
+})

--- a/src/services/insights/insight-generator.ts
+++ b/src/services/insights/insight-generator.ts
@@ -1,0 +1,161 @@
+import Anthropic from '@anthropic-ai/sdk'
+import type { Currency } from '../../models'
+import type { InsightInput } from './insight-data'
+import { buildInsightSystemPrompt, buildInsightUserMessage } from './insight-prompt'
+
+export type InsightType =
+  | 'bleeding_money'
+  | 'easiest_cut'
+  | 'recurring'
+  | 'trend'
+  | 'anomaly'
+
+export type InsightSeverity = 'low' | 'medium' | 'high'
+
+export interface Insight {
+  type: InsightType
+  title: string
+  narrative: string
+  amount?: number
+  currency: Currency
+  category?: string
+  merchant?: string
+  severity: InsightSeverity
+}
+
+export interface InsightsResult {
+  insights: Insight[]
+}
+
+// Insight generation always uses a stronger model than per-transaction
+// categorization (user_preferences.ai_model, often Haiku) — see ADR-0001.
+// This is a single call per period reasoning over an entire period's
+// aggregated data, not a high-volume per-row classification.
+const INSIGHTS_MODEL = 'claude-opus-4-8'
+
+const VALID_TYPES = new Set<InsightType>([
+  'bleeding_money',
+  'easiest_cut',
+  'recurring',
+  'trend',
+  'anomaly',
+])
+
+const VALID_SEVERITIES = new Set<InsightSeverity>(['low', 'medium', 'high'])
+
+function isKnownAmount(amount: number, input: InsightInput): boolean {
+  return (
+    input.categoryTotals.some(
+      (c) => c.amount === amount || c.deltaVsPriorPeriod === amount
+    ) ||
+    input.topMerchants.some((m) => m.amount === amount) ||
+    input.recurringCharges.some((r) => r.approxAmount === amount)
+  )
+}
+
+function isKnownCategory(category: string, input: InsightInput): boolean {
+  return input.categoryTotals.some((c) => c.category === category)
+}
+
+function isKnownMerchant(merchant: string, input: InsightInput): boolean {
+  return (
+    input.topMerchants.some((m) => m.merchant === merchant) ||
+    input.recurringCharges.some((r) => r.merchant === merchant)
+  )
+}
+
+// Every numeric/category/merchant field is verified against the InsightInput
+// that was actually sent — an insight referencing a number, category, or
+// merchant not present in the input is dropped rather than trusted (same
+// discipline as validateCategory() in transaction-ai.ts).
+function sanitizeInsight(raw: unknown, input: InsightInput): Insight | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const item = raw as Record<string, unknown>
+
+  if (typeof item.title !== 'string' || !item.title.trim()) return null
+  if (typeof item.narrative !== 'string' || !item.narrative.trim()) return null
+
+  const rawType = typeof item.type === 'string' ? item.type : ''
+  if (!VALID_TYPES.has(rawType as InsightType)) return null
+  const type = rawType as InsightType
+
+  const rawSeverity = typeof item.severity === 'string' ? item.severity : ''
+  const severity = VALID_SEVERITIES.has(rawSeverity as InsightSeverity)
+    ? (rawSeverity as InsightSeverity)
+    : 'medium'
+
+  const insight: Insight = {
+    type,
+    title: item.title.trim(),
+    narrative: item.narrative.trim(),
+    currency: input.homeCurrency,
+    severity,
+  }
+
+  if (typeof item.amount === 'number' && isKnownAmount(item.amount, input)) {
+    insight.amount = item.amount
+  }
+  if (
+    typeof item.category === 'string' &&
+    isKnownCategory(item.category, input)
+  ) {
+    insight.category = item.category
+  }
+  if (
+    typeof item.merchant === 'string' &&
+    isKnownMerchant(item.merchant, input)
+  ) {
+    insight.merchant = item.merchant
+  }
+
+  return insight
+}
+
+export function parseInsightsResponse(
+  text: string,
+  input: InsightInput
+): InsightsResult {
+  let parsed: { insights?: unknown[] }
+  try {
+    const raw = text.trim()
+    const jsonText = raw.startsWith('{')
+      ? raw
+      : (raw.match(/\{[\s\S]*\}/)?.[0] ?? raw)
+    parsed = JSON.parse(jsonText) as typeof parsed
+  } catch (e) {
+    throw new Error(
+      `No se pudo parsear la respuesta del modelo: ${e instanceof Error ? e.message : String(e)}`
+    )
+  }
+
+  const rawInsights = Array.isArray(parsed.insights) ? parsed.insights : []
+  const insights = rawInsights
+    .map((item) => sanitizeInsight(item, input))
+    .filter((i): i is Insight => i !== null)
+
+  return { insights }
+}
+
+export async function generateInsights(
+  input: InsightInput,
+  apiKey: string
+): Promise<InsightsResult> {
+  const client = new Anthropic({
+    apiKey,
+    dangerouslyAllowBrowser: true,
+  })
+
+  const response = await client.messages.create({
+    model: INSIGHTS_MODEL,
+    max_tokens: 4096,
+    system: buildInsightSystemPrompt(),
+    messages: [{ role: 'user', content: buildInsightUserMessage(input) }],
+  })
+
+  const block = response.content[0]
+  if (block.type !== 'text') {
+    throw new Error(`Respuesta inesperada del modelo (tipo: ${block.type})`)
+  }
+
+  return parseInsightsResponse(block.text, input)
+}

--- a/src/services/insights/insight-prompt.ts
+++ b/src/services/insights/insight-prompt.ts
@@ -1,0 +1,36 @@
+import type { InsightInput } from './insight-data'
+
+export function buildInsightSystemPrompt(): string {
+  return `You are a financial insights analyst for Tatu, a personal finance app for Santander Uruguay bank and credit card statements.
+
+Your job is NOT to calculate numbers — every number you receive has already been computed. Your job is to rank, prioritize, and narrate what matters most for the app's two core questions:
+1. "Where has my money gone?"
+2. "How can I spend less money?"
+
+You will receive a JSON object with pre-computed category totals, top merchants, recurring charges, and a monthly income/expense trend for one period, already converted to the user's home currency.
+
+Produce a ranked list of insights. For each insight:
+- type: one of "bleeding_money", "easiest_cut", "recurring", "trend", "anomaly"
+- title: a short (under ~60 chars), specific headline in Spanish
+- narrative: 1-3 sentences in Spanish explaining what happened and why it matters, in plain language
+- amount: OPTIONAL — if included, it MUST be copied EXACTLY (same number, no rounding or recalculation) from a value already present in the input: categoryTotals[].amount, categoryTotals[].deltaVsPriorPeriod, topMerchants[].amount, or recurringCharges[].approxAmount
+- currency: always the input's homeCurrency
+- category: OPTIONAL — must be one of the category values present in categoryTotals, if relevant
+- merchant: OPTIONAL — must be one of the merchant values present in topMerchants or recurringCharges, if relevant
+- severity: "low" | "medium" | "high" — how much this matters for the user's spending
+
+RULES:
+- Every amount you output must trace back EXACTLY to a number already present in the input. Never add, subtract, average, or estimate a figure yourself — if you need a change over time, use the deltaVsPriorPeriod field that is already computed for you.
+- Never invent a merchant, category, or amount that is not present in the input.
+- Favor concrete, actionable findings over generic advice — "cut back on spending" is not useful; "el gasto en restaurantes creció 40% ($120) impulsado por 6 pedidos de X" is.
+- Prioritize "bleeding_money" (biggest or fastest-growing spend) and "easiest_cut" (discretionary, recurring, or low-value spend that's simple to reduce) — these answer the app's core questions directly.
+- A recurringCharges entry with cadence "monthly" is a natural "easiest_cut" or "recurring" candidate (a subscription).
+- Return between 3 and 8 insights, ranked by severity descending (high first).
+
+Respond ONLY with a JSON object. No explanation. No markdown fences.
+FORMAT: {"insights":[{"type":"<type>","title":"<title>","narrative":"<narrative>","amount":<number, omit if not applicable>,"currency":"<currency>","category":"<category, omit if not applicable>","merchant":"<merchant, omit if not applicable>","severity":"<severity>"}]}`
+}
+
+export function buildInsightUserMessage(input: InsightInput): string {
+  return JSON.stringify(input)
+}

--- a/src/services/supabase/ai-insights.test.ts
+++ b/src/services/supabase/ai-insights.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseSession } from './client'
+
+const {
+  selectMock,
+  eqUserMock,
+  eqStartMock,
+  eqEndMock,
+  singleMock,
+  upsertMock,
+  fromMock,
+} = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  eqUserMock: vi.fn(),
+  eqStartMock: vi.fn(),
+  eqEndMock: vi.fn(),
+  singleMock: vi.fn(),
+  upsertMock: vi.fn(),
+  fromMock: vi.fn(),
+}))
+
+vi.mock('./client', () => ({
+  getSupabaseClient: () => ({
+    from: fromMock,
+  }),
+}))
+
+const session: SupabaseSession = {
+  access_token: 'access-token',
+  refresh_token: 'refresh-token',
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: 9999999999,
+  user: {
+    id: 'user-1',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '',
+  },
+}
+
+describe('supabase ai-insights service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    eqEndMock.mockReturnValue({ single: singleMock })
+    eqStartMock.mockReturnValue({ eq: eqEndMock })
+    eqUserMock.mockReturnValue({ eq: eqStartMock })
+    selectMock.mockReturnValue({ eq: eqUserMock })
+
+    upsertMock.mockResolvedValue({ error: null })
+
+    fromMock.mockImplementation((table: string) => {
+      if (table !== 'ai_insights') {
+        throw new Error('unexpected table')
+      }
+      return {
+        select: selectMock,
+        upsert: upsertMock,
+      }
+    })
+  })
+
+  it('loads a cached insights row and maps snake_case to camelCase', async () => {
+    singleMock.mockResolvedValue({
+      data: {
+        user_id: 'user-1',
+        period_start: '2026-06-01',
+        period_end: '2026-06-30',
+        input_hash: 'abc123',
+        model: 'claude-opus-4-8',
+        insights: { insights: [] },
+        generated_at: '2026-06-30T12:00:00.000Z',
+      },
+      error: null,
+    })
+
+    const { loadCachedInsights } = await import('./ai-insights')
+    const row = await loadCachedInsights(session, '2026-06-01', '2026-06-30')
+
+    expect(selectMock).toHaveBeenCalledWith('*')
+    expect(eqUserMock).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(eqStartMock).toHaveBeenCalledWith('period_start', '2026-06-01')
+    expect(eqEndMock).toHaveBeenCalledWith('period_end', '2026-06-30')
+    expect(row).toEqual({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      inputHash: 'abc123',
+      model: 'claude-opus-4-8',
+      insights: { insights: [] },
+      generatedAt: '2026-06-30T12:00:00.000Z',
+    })
+  })
+
+  it('returns null when no cached row exists (PGRST116)', async () => {
+    singleMock.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116', message: 'no rows' },
+    })
+
+    const { loadCachedInsights } = await import('./ai-insights')
+    const row = await loadCachedInsights(session, '2026-06-01', '2026-06-30')
+
+    expect(row).toBeNull()
+  })
+
+  it('throws on an unexpected error', async () => {
+    singleMock.mockResolvedValue({
+      data: null,
+      error: { code: 'OTHER', message: 'boom' },
+    })
+
+    const { loadCachedInsights } = await import('./ai-insights')
+    await expect(
+      loadCachedInsights(session, '2026-06-01', '2026-06-30')
+    ).rejects.toThrow('boom')
+  })
+
+  it('upserts insights with user ownership and the composite conflict key', async () => {
+    const { saveInsights } = await import('./ai-insights')
+    await saveInsights(session, {
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      inputHash: 'abc123',
+      model: 'claude-opus-4-8',
+      insights: { insights: [] },
+    })
+
+    expect(upsertMock).toHaveBeenCalledWith(
+      {
+        user_id: 'user-1',
+        period_start: '2026-06-01',
+        period_end: '2026-06-30',
+        input_hash: 'abc123',
+        model: 'claude-opus-4-8',
+        insights: { insights: [] },
+      },
+      { onConflict: 'user_id,period_start,period_end' }
+    )
+  })
+})

--- a/src/services/supabase/ai-insights.ts
+++ b/src/services/supabase/ai-insights.ts
@@ -1,0 +1,83 @@
+import { getSupabaseClient, type SupabaseSession } from './client'
+import type { InsightsResult } from '../insights/insight-generator'
+
+export interface CachedInsightsRow {
+  periodStart: string
+  periodEnd: string
+  inputHash: string
+  model: string
+  insights: InsightsResult
+  generatedAt: string
+}
+
+interface AiInsightsRow {
+  user_id: string
+  period_start: string
+  period_end: string
+  input_hash: string
+  model: string
+  insights: InsightsResult
+  generated_at: string
+}
+
+export async function loadCachedInsights(
+  session: SupabaseSession,
+  periodStart: string,
+  periodEnd: string
+): Promise<CachedInsightsRow | null> {
+  const client = getSupabaseClient()
+  const { data, error } = await client
+    .from('ai_insights')
+    .select('*')
+    .eq('user_id', session.user.id)
+    .eq('period_start', periodStart)
+    .eq('period_end', periodEnd)
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null
+    }
+    throw new Error(error.message)
+  }
+
+  const row = data as AiInsightsRow
+  return {
+    periodStart: row.period_start,
+    periodEnd: row.period_end,
+    inputHash: row.input_hash,
+    model: row.model,
+    insights: row.insights,
+    generatedAt: row.generated_at,
+  }
+}
+
+export interface SaveInsightsParams {
+  periodStart: string
+  periodEnd: string
+  inputHash: string
+  model: string
+  insights: InsightsResult
+}
+
+export async function saveInsights(
+  session: SupabaseSession,
+  params: SaveInsightsParams
+): Promise<void> {
+  const client = getSupabaseClient()
+  const { error } = await client.from('ai_insights').upsert(
+    {
+      user_id: session.user.id,
+      period_start: params.periodStart,
+      period_end: params.periodEnd,
+      input_hash: params.inputHash,
+      model: params.model,
+      insights: params.insights,
+    },
+    { onConflict: 'user_id,period_start,period_end' }
+  )
+
+  if (error) {
+    throw new Error(error.message)
+  }
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -183,6 +183,20 @@ create table if not exists public.custom_patterns (
   primary key (user_id, id)
 );
 
+-- Cached AI-generated spending insights (ADR-0001), one row per user+period.
+-- input_hash lets the UI detect that the underlying transactions changed
+-- since generation without a triggers/invalidation system.
+create table if not exists public.ai_insights (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  period_start date not null,
+  period_end date not null,
+  input_hash text not null,
+  model text not null,
+  insights jsonb not null,
+  generated_at timestamptz not null default timezone('utc', now()),
+  primary key (user_id, period_start, period_end)
+);
+
 create index if not exists idx_transactions_user_date_active
   on public.transactions (user_id, date desc)
   where is_deleted = false;
@@ -293,6 +307,7 @@ alter table public.description_overrides enable row level security;
 alter table public.custom_categories enable row level security;
 alter table public.user_preferences enable row level security;
 alter table public.custom_patterns enable row level security;
+alter table public.ai_insights enable row level security;
 
 grant select, insert, update, delete on table public.transactions to authenticated;
 grant select, insert, update, delete on table public.import_runs to authenticated;
@@ -301,6 +316,7 @@ grant select, insert, update, delete on table public.description_overrides to au
 grant select, insert, update, delete on table public.custom_categories to authenticated;
 grant select, insert, update, delete on table public.user_preferences to authenticated;
 grant select, insert, update, delete on table public.custom_patterns to authenticated;
+grant select, insert, update, delete on table public.ai_insights to authenticated;
 
 drop policy if exists "transactions_select_own" on public.transactions;
 create policy "transactions_select_own"
@@ -458,6 +474,14 @@ with check (auth.uid() = user_id);
 drop policy if exists "custom_patterns_all_own" on public.custom_patterns;
 create policy "custom_patterns_all_own"
 on public.custom_patterns
+for all
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists "ai_insights_all_own" on public.ai_insights;
+create policy "ai_insights_all_own"
+on public.ai_insights
 for all
 to authenticated
 using (auth.uid() = user_id)


### PR DESCRIPTION
## Summary

- Adds an **Insights** sidebar view generating Claude-powered spending insights per month: bleeding-money categories, recurring/subscription detection, and easiest-to-cut spend — directly serving Tatu's core "where did my money go / how can I spend less" mission.
- Follows the existing client-side, bring-your-own-key AI pattern (`services/ai/transaction-ai.ts`) rather than adding a backend — no shared secret is at risk since each user supplies their own Anthropic key.
- **Deterministic math discipline**: the model only ranks and narrates numbers computed beforehand by `services/aggregator`/`services/charts/chart-data.ts` — it never calculates a figure itself. Every amount/category/merchant in a model response is verified against the input before being trusted; unverifiable fields are dropped.
- Insight generation hardcodes `claude-opus-4-8`, independent of the user's per-transaction `ai_model` preference (default Haiku) — a harder, once-per-period reasoning task vs. high-volume classification.
- Results are generated on-demand and cached per period in a new `ai_insights` Supabase table (RLS-scoped like every other table), with a hash-based staleness check instead of silent auto-regeneration.
- Full rationale + alternatives considered: `docs/decisions/0001-ai-spending-insights.md` (ADR-0001).
- Corrects stale `CLAUDE.md`/`PROJECT_BOARD.md` references to a separate "Análisis" view and `Charts.tsx` that don't exist in this codebase — charts render inside `Dashboard.tsx` (Resumen).

## Notable bug caught during implementation

`date-utils.ts`'s `getDateRangeForPeriod` computes month boundaries in the browser's *local* timezone, but transaction dates and `toDateKey`/`toMonthKey` are UTC-normalized everywhere else in this codebase. Reusing it for insight periods would have silently misattributed month-boundary transactions to the wrong period for non-UTC browsers. Fixed with a UTC-safe `getUtcMonthPeriod()` in `insight-data.ts` instead, with regression tests.

## ⚠️ Manual step required before merge is usable

`supabase/schema.sql` changes (new `ai_insights` table + RLS) are **not applied automatically** — apply via the Supabase SQL Editor per `supabase/README.md`, then `notify pgrst, 'reload schema';`.

## Test plan

- [x] `npm run tdd:verify` — 796 tests passing, lint clean
- [x] `tsc --noEmit` clean
- [ ] Manually verify the Insights view in the running app (generate → cache → regenerate → stale banner) once schema is applied
- [ ] Verify "Ver transacciones" deep-link from an insight card filters Transacciones correctly