### PR TITLE
fix: stop counting ignored transactions in Resumen totals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -393,6 +393,7 @@ function App() {
                   transactions={transactions}
                   userName={getFriendlyName(session) || undefined}
                   onNavigateToImport={() => setImportOpen(true)}
+                  onNavigateToCategories={() => setCurrentView('categories')}
                   onNavigateToTransactions={navigateToTransactions}
                   homeCurrency={preferredCurrency}
                   fxRate={fxRate}

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -326,6 +326,29 @@ describe('Dashboard', () => {
     expect(screen.getByText('1 transacciones registradas')).toBeInTheDocument()
   })
 
+  it('labels the statement month, not today, when every row is ignored', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-20T12:00:00.000Z'))
+
+    const transactions = [
+      makeTransaction({
+        id: 'only-transfer',
+        description: 'TRASPASO',
+        category: Category.InternalTransfer,
+        amount: 5000,
+        currency: 'USD',
+        date: new Date('2026-01-10T00:00:00.000Z'),
+      }),
+    ]
+
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+
+    expect(screen.getAllByText(/enero de 2026/i).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/agosto de 2026/i)).not.toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
   it('anchors "este mes" to the latest counted month, not an ignored one', () => {
     const transactions = [
       makeTransaction({

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -326,6 +326,35 @@ describe('Dashboard', () => {
     expect(screen.getByText('1 transacciones registradas')).toBeInTheDocument()
   })
 
+  it('explains the zeros when every transaction is ignored', () => {
+    const onNavigateToCategories = vi.fn()
+    const transactions = [
+      makeTransaction({
+        id: 'only-transfer',
+        description: 'TRASPASO',
+        category: Category.InternalTransfer,
+        amount: 5000,
+        currency: 'USD',
+      }),
+    ]
+
+    render(
+      <Dashboard
+        transactions={transactions}
+        onNavigateToCategories={onNavigateToCategories}
+      />,
+    )
+
+    expect(
+      screen.getByText('Todas tus transacciones están ignoradas'),
+    ).toBeInTheDocument()
+    // Neither the zeroed dashboard nor the "you have no data" import CTA
+    expect(screen.queryByText('Mayores comercios')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Empezá importando tu extracto'),
+    ).not.toBeInTheDocument()
+  })
+
   it('labels the statement month, not today, when every row is ignored', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-20T12:00:00.000Z'))

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -298,6 +298,60 @@ describe('Dashboard', () => {
     expect(screen.getAllByText('SUPERMERCADO').length).toBeGreaterThan(0)
   })
 
+  it('excludes pre-rename transfer ids from Resumen totals', () => {
+    const transactions = [
+      makeTransaction({
+        id: 'legacy-transfer',
+        description: 'TRASPASO ENTRE CUENTAS',
+        category: 'transfer',
+        amount: 8000,
+        currency: 'USD',
+        date: new Date('2026-01-09T00:00:00.000Z'),
+      }),
+      makeTransaction({
+        id: 'normal-tx',
+        description: 'SUPERMERCADO',
+        category: Category.Groceries,
+        amount: 200,
+        currency: 'USD',
+        date: new Date('2026-01-10T00:00:00.000Z'),
+      }),
+    ]
+
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+
+    // The legacy transfer is neither listed nor folded into "este mes"
+    expect(screen.queryByText('TRASPASO ENTRE CUENTAS')).not.toBeInTheDocument()
+    expect(screen.queryByText(/8\.000,00/)).not.toBeInTheDocument()
+    expect(screen.getByText('1 transacciones registradas')).toBeInTheDocument()
+  })
+
+  it('anchors "este mes" to the latest counted month, not an ignored one', () => {
+    const transactions = [
+      makeTransaction({
+        id: 'grocery',
+        description: 'SUPERMERCADO',
+        category: Category.Groceries,
+        amount: 200,
+        currency: 'USD',
+        date: new Date('2026-01-10T00:00:00.000Z'),
+      }),
+      makeTransaction({
+        id: 'later-transfer',
+        description: 'TRASPASO',
+        category: Category.InternalTransfer,
+        amount: 5000,
+        currency: 'USD',
+        date: new Date('2026-02-05T00:00:00.000Z'),
+      }),
+    ]
+
+    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+
+    expect(screen.getByText('1 transacciones registradas')).toBeInTheDocument()
+    expect(screen.getAllByText(/enero de 2026/i).length).toBeGreaterThan(0)
+  })
+
   it('renders all major section headings', () => {
     const transactions = [
       makeTransaction({ id: 'food-1', category: Category.Groceries, amount: 200 }),

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Card } from './ui/card'
 import { Button } from './ui/button'
 import {
   Upload,
+  EyeOff,
   ArrowRight,
   CreditCard,
   DollarSign,
@@ -254,6 +255,7 @@ interface DashboardProps {
   transactions: Transaction[]
   userName?: string
   onNavigateToImport?: () => void
+  onNavigateToCategories?: () => void
   onNavigateToTransactions?: (filter: TransactionsFilter) => void
   homeCurrency?: Currency
   fxRate?: number
@@ -265,6 +267,7 @@ export function Dashboard({
   transactions,
   userName,
   onNavigateToImport,
+  onNavigateToCategories,
   onNavigateToTransactions,
   homeCurrency = 'USD',
   fxRate = 40.5,
@@ -279,6 +282,10 @@ export function Dashboard({
     () => transactions.filter((tx) => !isExcludedFromTotals(tx)),
     [transactions],
   )
+
+  // Data exists but every row is ignored — a zeroed dashboard would look like
+  // a bug, so say why instead of rendering empty cards.
+  const allIgnored = hasTransactions && countedTransactions.length === 0
 
   // Latest date used as reference month (avoids dependency on system clock).
   // Falls back to the raw rows when everything is ignored, so a transfers-only
@@ -573,7 +580,7 @@ export function Dashboard({
               })}
           </p>
         </div>
-        {hasTransactions && (
+        {hasTransactions && !allIgnored && (
           <div
             style={{
               display: 'flex',
@@ -613,7 +620,31 @@ export function Dashboard({
         </Card>
       )}
 
-      {hasTransactions && (
+      {/* Data exists, but nothing in it counts */}
+      {allIgnored && (
+        <Card className="p-8 text-center space-y-4">
+          <div className="mx-auto w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
+            <EyeOff className="text-primary" size={28} />
+          </div>
+          <div>
+            <h2 className="mb-2">Todas tus transacciones están ignoradas</h2>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              Importaste {transactions.length}{' '}
+              {transactions.length === 1 ? 'transacción' : 'transacciones'}, pero
+              todas caen en categorías ignoradas (transferencias u otras que
+              marcaste), así que no suman a ningún total. Cambiales la categoría
+              o desmarcá “ignorar” para verlas acá.
+            </p>
+          </div>
+          {onNavigateToCategories && (
+            <Button size="lg" variant="outline" onClick={onNavigateToCategories}>
+              Revisar categorías
+            </Button>
+          )}
+        </Card>
+      )}
+
+      {hasTransactions && !allIgnored && (
         <>
           {/* Account source cards — 3-col grid */}
           {periodRange && (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,7 +10,6 @@ import {
   Banknote,
 } from 'lucide-react'
 import type { Transaction, Currency, TransactionsFilter } from '../models'
-import { isSplitParentTx } from '../models'
 import { useMemo } from 'react'
 import {
   PieChart,
@@ -36,7 +35,6 @@ import { getCategoryDisplay } from '../utils/category-display'
 import {
   getCategoryDefinition,
   getCategoryDefinitions,
-  isCategoryIgnored,
 } from '../services/categories/category-registry'
 import {
   buildCurrentMonthSummary,
@@ -44,6 +42,7 @@ import {
   buildMonthlyTrendsConverted,
   buildCurrencySplit,
   spendByAccount,
+  isExcludedFromTotals,
 } from '../services/charts/chart-data'
 import type { AccountSpend } from '../services/charts/chart-data'
 import { convert } from '../services/currency/convert'
@@ -274,21 +273,28 @@ export function Dashboard({
 }: DashboardProps) {
   const hasTransactions = transactions.length > 0
 
+  // Every figure on Resumen is computed from countable transactions only —
+  // ignored categories (transfers, user-flagged) and split parents are out.
+  const countedTransactions = useMemo(
+    () => transactions.filter((tx) => !isExcludedFromTotals(tx)),
+    [transactions],
+  )
+
   // Latest date used as reference month (avoids dependency on system clock)
   const latestDate = useMemo(() => {
-    if (transactions.length === 0) return new Date()
-    return transactions.reduce(
+    if (countedTransactions.length === 0) return new Date()
+    return countedTransactions.reduce(
       (latest, tx) => (tx.date > latest ? tx.date : latest),
-      transactions[0].date,
+      countedTransactions[0].date,
     )
-  }, [transactions])
+  }, [countedTransactions])
 
-  // Full date range across all transactions — used for section period labels
+  // Date range across counted transactions — used for section period labels
   const periodRange = useMemo(() => {
-    if (!transactions.length) return null
-    let min = transactions[0].date
-    let max = transactions[0].date
-    for (const tx of transactions) {
+    if (!countedTransactions.length) return null
+    let min = countedTransactions[0].date
+    let max = countedTransactions[0].date
+    for (const tx of countedTransactions) {
       if (tx.date < min) min = tx.date
       if (tx.date > max) max = tx.date
     }
@@ -299,7 +305,7 @@ export function Dashboard({
         timeZone: 'UTC',
       })
     return `${fmt(min)} – ${fmt(max)}`
-  }, [transactions])
+  }, [countedTransactions])
 
   // Account spend by source
   const acctSpend = useMemo(
@@ -409,13 +415,8 @@ export function Dashboard({
       string,
       { name: string; total: number; count: number; catId: string }
     >()
-    transactions
-      .filter(
-        (tx) =>
-          tx.type === 'debit' &&
-          !isCategoryIgnored(tx.category) &&
-          !isSplitParentTx(tx),
-      )
+    countedTransactions
+      .filter((tx) => tx.type === 'debit')
       .forEach((tx) => {
         const key = getDisplayDescription(tx)
         const prev = map.get(key) ?? {
@@ -431,16 +432,15 @@ export function Dashboard({
     return Array.from(map.values())
       .sort((a, b) => b.total - a.total)
       .slice(0, 6)
-  }, [transactions, homeCurrency, fxRate])
+  }, [countedTransactions, homeCurrency, fxRate])
 
   // Recent transactions
   const recentTransactions = useMemo(
     () =>
-      [...transactions]
-        .filter((tx) => !isCategoryIgnored(tx.category) && !isSplitParentTx(tx))
+      [...countedTransactions]
         .sort((a, b) => b.date.getTime() - a.date.getTime())
         .slice(0, 6),
-    [transactions],
+    [countedTransactions],
   )
 
   const greeting = userName ? `Hola, ${userName} 👋` : 'Hola 👋'

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -280,14 +280,17 @@ export function Dashboard({
     [transactions],
   )
 
-  // Latest date used as reference month (avoids dependency on system clock)
+  // Latest date used as reference month (avoids dependency on system clock).
+  // Falls back to the raw rows when everything is ignored, so a transfers-only
+  // dataset still labels the statement month instead of today's.
   const latestDate = useMemo(() => {
-    if (countedTransactions.length === 0) return new Date()
-    return countedTransactions.reduce(
+    const source = countedTransactions.length ? countedTransactions : transactions
+    if (source.length === 0) return new Date()
+    return source.reduce(
       (latest, tx) => (tx.date > latest ? tx.date : latest),
-      countedTransactions[0].date,
+      source[0].date,
     )
-  }, [countedTransactions])
+  }, [countedTransactions, transactions])
 
   // Date range across counted transactions — used for section period labels
   const periodRange = useMemo(() => {

--- a/src/services/categories/category-aliases.ts
+++ b/src/services/categories/category-aliases.ts
@@ -30,11 +30,18 @@ export function resolveBuiltinAlias(id: string): string {
   return aliasFor(id) ?? id
 }
 
-// True when the id is spoken for by a built-in category or one of its
-// pre-rename aliases — such an id must never be handed to a custom category.
+// The legacy pseudo-category that "Ignorar" assigns. Not a Category value, but
+// isCategoryIgnored treats it as ignore-by-default, so a custom category
+// slugged 'ignored' would silently drop its transactions from every total.
+export const LEGACY_IGNORED_ID = 'ignored'
+
+// True when the id is spoken for by a built-in category, one of its pre-rename
+// aliases, or the legacy ignored marker — such an id must never be handed to a
+// custom category.
 export function isReservedCategoryId(id: string): boolean {
   const normalized = id.toLowerCase()
   return (
+    normalized === LEGACY_IGNORED_ID ||
     aliasFor(normalized) !== undefined ||
     (Object.values(Category) as string[]).includes(normalized)
   )

--- a/src/services/categories/category-aliases.ts
+++ b/src/services/categories/category-aliases.ts
@@ -15,8 +15,19 @@ export const ID_ALIASES: Partial<Record<string, Category>> = {
   transfers: Category.ExternalTransfer,
 }
 
+// hasOwnProperty rather than `in`: ID_ALIASES is a plain object literal, so
+// `'constructor' in ID_ALIASES` is true and the lookup yields a function.
+function aliasFor(id: string): string | undefined {
+  const normalized = id.toLowerCase()
+  if (!Object.prototype.hasOwnProperty.call(ID_ALIASES, normalized)) {
+    return undefined
+  }
+  const alias = ID_ALIASES[normalized]
+  return typeof alias === 'string' ? alias : undefined
+}
+
 export function resolveBuiltinAlias(id: string): string {
-  return ID_ALIASES[id.toLowerCase()] ?? id
+  return aliasFor(id) ?? id
 }
 
 // True when the id is spoken for by a built-in category or one of its
@@ -24,7 +35,7 @@ export function resolveBuiltinAlias(id: string): string {
 export function isReservedCategoryId(id: string): boolean {
   const normalized = id.toLowerCase()
   return (
-    normalized in ID_ALIASES ||
+    aliasFor(normalized) !== undefined ||
     (Object.values(Category) as string[]).includes(normalized)
   )
 }

--- a/src/services/categories/category-aliases.ts
+++ b/src/services/categories/category-aliases.ts
@@ -1,0 +1,30 @@
+import { Category } from '../../models'
+
+// Pre-rename category ids that may still be stored on transactions and on
+// custom_categories rows. Lives in its own module so category-store can guard
+// against slug collisions without importing the registry (which imports it).
+export const ID_ALIASES: Partial<Record<string, Category>> = {
+  food: Category.Groceries,
+  restaurant: Category.Restaurants,
+  restaurants: Category.Restaurants,
+  health: Category.Healthcare,
+  salary: Category.Income,
+  other: Category.Uncategorized,
+  // backward-compat: old string values before rename
+  transfer: Category.InternalTransfer,
+  transfers: Category.ExternalTransfer,
+}
+
+export function resolveBuiltinAlias(id: string): string {
+  return ID_ALIASES[id.toLowerCase()] ?? id
+}
+
+// True when the id is spoken for by a built-in category or one of its
+// pre-rename aliases — such an id must never be handed to a custom category.
+export function isReservedCategoryId(id: string): boolean {
+  const normalized = id.toLowerCase()
+  return (
+    normalized in ID_ALIASES ||
+    (Object.values(Category) as string[]).includes(normalized)
+  )
+}

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -377,6 +377,24 @@ describe('isCategoryIgnored', () => {
     }
   })
 
+  it('keeps the transfer default when a legacy row records no preference', () => {
+    // custom_categories.is_ignored is nullable, and rows written between the
+    // upsert landing and the transfer rename carry NULL. That maps to
+    // undefined, which must fall through to the built-in default rather than
+    // read as an explicit "not ignored" and let transfers back into totals.
+    listCustomCategoriesMock.mockReturnValue([
+      {
+        id: 'transfer',
+        label: 'Transferencias',
+        color: '#ff0000',
+        isIgnored: undefined,
+      },
+    ])
+
+    expect(isCategoryIgnored(Category.InternalTransfer)).toBe(true)
+    expect(isCategoryIgnored('transfer')).toBe(true)
+  })
+
   it('lets the Categorías toggle override a legacy alias row', () => {
     // A pre-existing row keyed by an alias ('food' -> groceries) controls the
     // built-in's ignore flag. Unticking "ignorar" in Categorías calls

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -401,10 +401,10 @@ describe('isCategoryIgnored', () => {
   })
 
   it('keeps the transfer default when a legacy row records no preference', () => {
-    // custom_categories.is_ignored is nullable, and rows written between the
-    // upsert landing and the transfer rename carry NULL. That maps to
-    // undefined, which must fall through to the built-in default rather than
-    // read as an explicit "not ignored" and let transfers back into totals.
+    // A row with no recorded preference must fall through to the built-in
+    // default rather than read as an explicit "not ignored" and let transfers
+    // back into totals. Defensive: schema.sql has is_ignored NOT NULL DEFAULT
+    // false, so today only the in-memory store can produce undefined.
     listCustomCategoriesMock.mockReturnValue([
       {
         id: 'transfer',

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -377,6 +377,29 @@ describe('isCategoryIgnored', () => {
     }
   })
 
+  it('resolves two alias rows for one built-in the same way in any order', () => {
+    // 'restaurant' and 'restaurants' both resolve to Restaurantes, so array
+    // order must not decide which one supplies the ignore flag.
+    const singular = {
+      id: 'restaurant',
+      label: 'Restaurantes',
+      color: '#ff0000',
+      isIgnored: true,
+    }
+    const plural = {
+      id: 'restaurants',
+      label: 'Restaurantes',
+      color: '#00ff00',
+      isIgnored: false,
+    }
+
+    listCustomCategoriesMock.mockReturnValue([singular, plural])
+    const first = isCategoryIgnored(Category.Restaurants)
+
+    listCustomCategoriesMock.mockReturnValue([plural, singular])
+    expect(isCategoryIgnored(Category.Restaurants)).toBe(first)
+  })
+
   it('keeps the transfer default when a legacy row records no preference', () => {
     // custom_categories.is_ignored is nullable, and rows written between the
     // upsert landing and the transfer rename carry NULL. That maps to

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -256,6 +256,30 @@ describe('getCategoryDefinition', () => {
   })
 })
 
+describe('accessor agreement', () => {
+  beforeEach(() => {
+    listCustomCategoriesMock.mockReturnValue([])
+  })
+
+  it('resolves legacy override rows the same way in all three accessors', () => {
+    listCustomCategoriesMock.mockReturnValue([
+      {
+        id: 'transfer',
+        label: 'Transferencias internas',
+        color: '#ff0000',
+        isIgnored: false,
+      },
+    ])
+
+    expect(isCategoryIgnored(Category.InternalTransfer)).toBe(false)
+    expect(
+      getCategoryDefinitions().find((c) => c.id === Category.InternalTransfer)
+        ?.isIgnored
+    ).toBe(false)
+    expect(getCategoryDefinition(Category.InternalTransfer).isIgnored).toBe(false)
+  })
+})
+
 describe('isCategoryIgnored', () => {
   beforeEach(() => {
     listCustomCategoriesMock.mockReturnValue([])
@@ -351,6 +375,28 @@ describe('isCategoryIgnored', () => {
           ?.isIgnored
       ).toBe(false)
     }
+  })
+
+  it('lets the Categorías toggle override a legacy alias row', () => {
+    // A pre-existing row keyed by an alias ('food' -> groceries) controls the
+    // built-in's ignore flag. Unticking "ignorar" in Categorías calls
+    // upsertBuiltinOverride, which appends a row keyed by the current id —
+    // that row must win, so the state is always correctable from the UI.
+    listCustomCategoriesMock.mockReturnValue([
+      { id: 'food', label: 'Food', color: '#ff0000', isIgnored: true },
+    ])
+    expect(isCategoryIgnored(Category.Groceries)).toBe(true)
+
+    listCustomCategoriesMock.mockReturnValue([
+      { id: 'food', label: 'Food', color: '#ff0000', isIgnored: true },
+      {
+        id: Category.Groceries,
+        label: 'Alimentación',
+        color: '#ff0000',
+        isIgnored: false,
+      },
+    ])
+    expect(isCategoryIgnored(Category.Groceries)).toBe(false)
   })
 
   it('honours a legacy-id override when un-ignoring a renamed built-in', () => {

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -300,6 +300,29 @@ describe('isCategoryIgnored', () => {
     expect(isCategoryIgnored('IGNORED')).toBe(true)
   })
 
+  it('prefers the current-id override over a stale legacy duplicate', () => {
+    // upsertBuiltinOverride matches on the exact id and appends otherwise, so
+    // un-ignoring Transferencias internas leaves the pre-rename row in place.
+    // getCategoryDefinitions resolves this last-wins; the predicate must agree.
+    listCustomCategoriesMock.mockReturnValue([
+      {
+        id: 'transfer',
+        label: 'Transferencias internas',
+        color: '#ff0000',
+        isIgnored: true,
+      },
+      {
+        id: Category.InternalTransfer,
+        label: 'Transferencias internas',
+        color: '#ff0000',
+        isIgnored: false,
+      },
+    ])
+
+    expect(isCategoryIgnored(Category.InternalTransfer)).toBe(false)
+    expect(isCategoryIgnored('transfer')).toBe(false)
+  })
+
   it('honours a legacy-id override when un-ignoring a renamed built-in', () => {
     listCustomCategoriesMock.mockReturnValue([
       {

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -378,26 +378,27 @@ describe('isCategoryIgnored', () => {
   })
 
   it('resolves two alias rows for one built-in the same way in any order', () => {
-    // 'restaurant' and 'restaurants' both resolve to Restaurantes, so array
-    // order must not decide which one supplies the ignore flag.
-    const singular = {
-      id: 'restaurant',
-      label: 'Restaurantes',
+    // Ids differing only in case both alias onto internal_transfer, so both
+    // land in the aliased bucket and the tie must break on the id rather than
+    // on the order select('*') happened to return them in.
+    const lower = {
+      id: 'transfer',
+      label: 'Transferencias',
       color: '#ff0000',
       isIgnored: true,
     }
-    const plural = {
-      id: 'restaurants',
-      label: 'Restaurantes',
+    const upper = {
+      id: 'Transfer',
+      label: 'Transferencias',
       color: '#00ff00',
       isIgnored: false,
     }
 
-    listCustomCategoriesMock.mockReturnValue([singular, plural])
-    const first = isCategoryIgnored(Category.Restaurants)
+    listCustomCategoriesMock.mockReturnValue([lower, upper])
+    const first = isCategoryIgnored(Category.InternalTransfer)
 
-    listCustomCategoriesMock.mockReturnValue([plural, singular])
-    expect(isCategoryIgnored(Category.Restaurants)).toBe(first)
+    listCustomCategoriesMock.mockReturnValue([upper, lower])
+    expect(isCategoryIgnored(Category.InternalTransfer)).toBe(first)
   })
 
   it('keeps the transfer default when a legacy row records no preference', () => {

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -323,6 +323,36 @@ describe('isCategoryIgnored', () => {
     expect(isCategoryIgnored('transfer')).toBe(false)
   })
 
+  it('prefers the current-id override whatever order the rows arrive in', () => {
+    // Supabase returns custom_categories without an ORDER BY, so the stale
+    // legacy row can come back either side of the canonical one.
+    const legacy = {
+      id: 'transfer',
+      label: 'Transferencias internas',
+      color: '#ff0000',
+      isIgnored: true,
+    }
+    const current = {
+      id: Category.InternalTransfer,
+      label: 'Transferencias internas',
+      color: '#ff0000',
+      isIgnored: false,
+    }
+
+    for (const rows of [
+      [legacy, current],
+      [current, legacy],
+    ]) {
+      listCustomCategoriesMock.mockReturnValue(rows)
+      expect(isCategoryIgnored(Category.InternalTransfer)).toBe(false)
+      expect(isCategoryIgnored('transfer')).toBe(false)
+      expect(
+        getCategoryDefinitions().find((c) => c.id === Category.InternalTransfer)
+          ?.isIgnored
+      ).toBe(false)
+    }
+  })
+
   it('honours a legacy-id override when un-ignoring a renamed built-in', () => {
     listCustomCategoriesMock.mockReturnValue([
       {

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -289,4 +289,28 @@ describe('isCategoryIgnored', () => {
 
     expect(isCategoryIgnored(Category.Shopping)).toBe(false)
   })
+
+  it('returns true for pre-rename transfer ids stored on transactions', () => {
+    expect(isCategoryIgnored('transfer')).toBe(true)
+    expect(isCategoryIgnored('transfers')).toBe(true)
+  })
+
+  it('ignores casing on stored ids', () => {
+    expect(isCategoryIgnored('Internal_Transfer')).toBe(true)
+    expect(isCategoryIgnored('IGNORED')).toBe(true)
+  })
+
+  it('honours a legacy-id override when un-ignoring a renamed built-in', () => {
+    listCustomCategoriesMock.mockReturnValue([
+      {
+        id: 'transfer',
+        label: 'Transferencias internas',
+        color: '#ff0000',
+        isIgnored: false,
+      },
+    ])
+
+    expect(isCategoryIgnored(Category.InternalTransfer)).toBe(false)
+    expect(isCategoryIgnored('transfer')).toBe(false)
+  })
 })

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -7,6 +7,9 @@ import {
 import type { CustomCategory } from './category-store'
 import { listCustomCategories } from './category-store'
 import { memoizeByReference } from '../../utils/memo'
+import { ID_ALIASES, resolveBuiltinAlias } from './category-aliases'
+
+export { ID_ALIASES }
 
 export interface CategoryDefinition {
   id: string
@@ -20,30 +23,32 @@ export interface CategoryDefinition {
 
 const DEFAULT_CUSTOM_ICON = '🏷️'
 
-export const ID_ALIASES: Partial<Record<string, Category>> = {
-  food: Category.Groceries,
-  restaurant: Category.Restaurants,
-  restaurants: Category.Restaurants,
-  health: Category.Healthcare,
-  salary: Category.Income,
-  other: Category.Uncategorized,
-  // backward-compat: old string values before rename
-  transfer: Category.InternalTransfer,
-  transfers: Category.ExternalTransfer,
-}
+// Override rows keyed by the category they actually apply to. A legacy row
+// ('transfer') and a current one ('internal_transfer') can coexist —
+// upsertBuiltinOverride matches on the exact id and appends otherwise — and
+// Supabase returns custom_categories unordered, so resolution must not depend
+// on array order: aliased rows claim their built-in first, then any row
+// already keyed by the current id overwrites it. Memoized on the store's
+// array identity, which every mutator replaces rather than mutating.
+const resolvedOverrides = memoizeByReference((categories: CustomCategory[]) => {
+  const map = new Map<string, CustomCategory>()
+  categories.forEach((c) => {
+    const normalized = c.id.toLowerCase()
+    const resolved = resolveBuiltinAlias(normalized)
+    if (resolved !== normalized) map.set(resolved, c)
+  })
+  categories.forEach((c) => {
+    const normalized = c.id.toLowerCase()
+    if (resolveBuiltinAlias(normalized) === normalized) map.set(normalized, c)
+  })
+  return map
+})
 
-function resolveBuiltinAlias(id: string): string {
-  return ID_ALIASES[id.toLowerCase()] ?? id
-}
 
 export function getCategoryDefinitions(): CategoryDefinition[] {
   const customList = listCustomCategories()
   const builtinIds = new Set(Object.values(Category) as string[])
-  const overrideMap = new Map(
-    customList
-      .map((c) => [resolveBuiltinAlias(c.id), c] as const)
-      .filter(([resolvedId]) => builtinIds.has(resolvedId))
-  )
+  const overrideMap = resolvedOverrides(customList)
 
   const builtin = Object.values(Category).map((category) => {
     const override = overrideMap.get(category)
@@ -130,29 +135,13 @@ function isTransferCategoryId(id: string): boolean {
   return id === Category.InternalTransfer || id === Category.ExternalTransfer
 }
 
-// Override rows keyed by resolved id. A legacy row ('transfer') and a
-// current one ('internal_transfer') can coexist — upsertBuiltinOverride
-// matches on the exact id and appends otherwise — so the later row wins,
-// exactly as the Map build in getCategoryDefinitions resolves it.
-// Memoized on the store's array identity: every mutator replaces the array.
-const resolvedOverridesByCategory = memoizeByReference(
-  (categories: CustomCategory[]) => {
-    const map = new Map<string, CustomCategory>()
-    categories.forEach((c) =>
-      map.set(resolveBuiltinAlias(c.id.toLowerCase()), c)
-    )
-    return map
-  }
-)
 
 export function isCategoryIgnored(id: string | undefined): boolean {
   if (!id) return false
   // Resolve through ID_ALIASES first so pre-rename ids stored on transactions
   // ('transfer', 'transfers') and on override rows match their current built-in.
   const resolvedId = resolveBuiltinAlias(id.toLowerCase())
-  const override = resolvedOverridesByCategory(listCustomCategories()).get(
-    resolvedId
-  )
+  const override = resolvedOverrides(listCustomCategories()).get(resolvedId)
   if (override?.isIgnored !== undefined) return override.isIgnored
   // Transfer categories and the legacy 'ignored' id are excluded by default
   return isTransferCategoryId(resolvedId) || resolvedId === 'ignored'

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -130,8 +130,13 @@ function isTransferCategoryId(id: string): boolean {
 
 export function isCategoryIgnored(id: string | undefined): boolean {
   if (!id) return false
-  const override = listCustomCategories().find((c) => c.id === id)
+  // Resolve through ID_ALIASES first so pre-rename ids stored on transactions
+  // ('transfer', 'transfers') and on override rows match their current built-in.
+  const resolvedId = resolveBuiltinAlias(id.toLowerCase())
+  const override = listCustomCategories().find(
+    (c) => resolveBuiltinAlias(c.id.toLowerCase()) === resolvedId
+  )
   if (override?.isIgnored !== undefined) return override.isIgnored
   // Transfer categories and the legacy 'ignored' id are excluded by default
-  return isTransferCategoryId(id) || id === 'ignored'
+  return isTransferCategoryId(resolvedId) || resolvedId === 'ignored'
 }

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -4,7 +4,9 @@ import {
   CATEGORY_ICONS,
   CATEGORY_LABELS,
 } from '../../models'
+import type { CustomCategory } from './category-store'
 import { listCustomCategories } from './category-store'
+import { memoizeByReference } from '../../utils/memo'
 
 export interface CategoryDefinition {
   id: string
@@ -128,13 +130,28 @@ function isTransferCategoryId(id: string): boolean {
   return id === Category.InternalTransfer || id === Category.ExternalTransfer
 }
 
+// Override rows keyed by resolved id. A legacy row ('transfer') and a
+// current one ('internal_transfer') can coexist — upsertBuiltinOverride
+// matches on the exact id and appends otherwise — so the later row wins,
+// exactly as the Map build in getCategoryDefinitions resolves it.
+// Memoized on the store's array identity: every mutator replaces the array.
+const resolvedOverridesByCategory = memoizeByReference(
+  (categories: CustomCategory[]) => {
+    const map = new Map<string, CustomCategory>()
+    categories.forEach((c) =>
+      map.set(resolveBuiltinAlias(c.id.toLowerCase()), c)
+    )
+    return map
+  }
+)
+
 export function isCategoryIgnored(id: string | undefined): boolean {
   if (!id) return false
   // Resolve through ID_ALIASES first so pre-rename ids stored on transactions
   // ('transfer', 'transfers') and on override rows match their current built-in.
   const resolvedId = resolveBuiltinAlias(id.toLowerCase())
-  const override = listCustomCategories().find(
-    (c) => resolveBuiltinAlias(c.id.toLowerCase()) === resolvedId
+  const override = resolvedOverridesByCategory(listCustomCategories()).get(
+    resolvedId
   )
   if (override?.isIgnored !== undefined) return override.isIgnored
   // Transfer categories and the legacy 'ignored' id are excluded by default

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -31,17 +31,23 @@ const DEFAULT_CUSTOM_ICON = '🏷️'
 // already keyed by the current id overwrites it. Memoized on the store's
 // array identity, which every mutator replaces rather than mutating.
 const resolvedOverrides = memoizeByReference((categories: CustomCategory[]) => {
-  const map = new Map<string, CustomCategory>()
+  const aliased = new Map<string, CustomCategory>()
+  const exact = new Map<string, CustomCategory>()
+
   categories.forEach((c) => {
     const normalized = c.id.toLowerCase()
     const resolved = resolveBuiltinAlias(normalized)
-    if (resolved !== normalized) map.set(resolved, c)
+    const target = resolved === normalized ? exact : aliased
+    const held = target.get(resolved)
+    // Several rows can land on one category: two alias keys for the same
+    // built-in ('restaurant' and 'restaurants'), or ids differing only in
+    // case. Break the tie on the id so the winner never depends on the order
+    // Supabase happened to return the rows in.
+    if (!held || c.id < held.id) target.set(resolved, c)
   })
-  categories.forEach((c) => {
-    const normalized = c.id.toLowerCase()
-    if (resolveBuiltinAlias(normalized) === normalized) map.set(normalized, c)
-  })
-  return map
+
+  // A row already keyed by the current id always beats a stale alias row.
+  return new Map([...aliased, ...exact])
 })
 
 export function getCategoryDefinitions(): CategoryDefinition[] {

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -44,7 +44,6 @@ const resolvedOverrides = memoizeByReference((categories: CustomCategory[]) => {
   return map
 })
 
-
 export function getCategoryDefinitions(): CategoryDefinition[] {
   const customList = listCustomCategories()
   const builtinIds = new Set(Object.values(Category) as string[])
@@ -65,7 +64,7 @@ export function getCategoryDefinitions(): CategoryDefinition[] {
   const seenCustomIds = new Set<string>()
   const custom = customList
     .filter((c) => {
-      if (builtinIds.has(resolveBuiltinAlias(c.id))) return false
+      if (builtinIds.has(resolveBuiltinAlias(c.id.toLowerCase()))) return false
       if (seenCustomIds.has(c.id)) return false
       seenCustomIds.add(c.id)
       return true
@@ -135,7 +134,6 @@ export function getCategoryDefinition(
 function isTransferCategoryId(id: string): boolean {
   return id === Category.InternalTransfer || id === Category.ExternalTransfer
 }
-
 
 export function isCategoryIgnored(id: string | undefined): boolean {
   if (!id) return false

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -7,7 +7,11 @@ import {
 import type { CustomCategory } from './category-store'
 import { listCustomCategories } from './category-store'
 import { memoizeByReference } from '../../utils/memo'
-import { ID_ALIASES, resolveBuiltinAlias } from './category-aliases'
+import {
+  ID_ALIASES,
+  LEGACY_IGNORED_ID,
+  resolveBuiltinAlias,
+} from './category-aliases'
 
 export { ID_ALIASES }
 
@@ -149,5 +153,5 @@ export function isCategoryIgnored(id: string | undefined): boolean {
   const override = resolvedOverrides(listCustomCategories()).get(resolvedId)
   if (override?.isIgnored !== undefined) return override.isIgnored
   // Transfer categories and the legacy 'ignored' id are excluded by default
-  return isTransferCategoryId(resolvedId) || resolvedId === 'ignored'
+  return isTransferCategoryId(resolvedId) || resolvedId === LEGACY_IGNORED_ID
 }

--- a/src/services/categories/category-registry.ts
+++ b/src/services/categories/category-registry.ts
@@ -101,11 +101,12 @@ export function getCategoryDefinition(
   }
 
   const normalizedId = id.toLowerCase()
-  const resolvedId = ID_ALIASES[normalizedId] ?? normalizedId
+  const resolvedId = resolveBuiltinAlias(normalizedId)
+  const overrides = resolvedOverrides(listCustomCategories())
 
   if (Object.values(Category).includes(resolvedId as Category)) {
     const category = resolvedId as Category
-    const override = listCustomCategories().find((c) => c.id === resolvedId)
+    const override = overrides.get(resolvedId)
     return {
       id: category,
       label: override?.label ?? CATEGORY_LABELS[category],
@@ -116,7 +117,7 @@ export function getCategoryDefinition(
     }
   }
 
-  const custom = listCustomCategories().find((category) => category.id === resolvedId)
+  const custom = overrides.get(resolvedId)
   if (!custom) {
     return fallback
   }

--- a/src/services/categories/category-store.test.ts
+++ b/src/services/categories/category-store.test.ts
@@ -44,6 +44,20 @@ describe('Custom category store', () => {
     expect(categories[0].color).toBe('#ff0000')
   })
 
+  it('never hands a custom category a reserved built-in or alias id', () => {
+    // 'food' is an ID_ALIASES key for groceries; a custom category taking it
+    // would override Alimentación's ignore flag in every total.
+    const food = addCustomCategory({ label: 'Food', color: '#ff0000' })
+    expect(food.id).not.toBe('food')
+
+    const groceries = addCustomCategory({ label: 'Groceries', color: '#00ff00' })
+    expect(groceries.id).not.toBe('groceries')
+
+    // Still a usable, unique id rather than a collision or an empty string
+    expect(food.id).toMatch(/^food-\d+$/)
+    expect(new Set([food.id, groceries.id]).size).toBe(2)
+  })
+
   it('updates a custom category', () => {
     const category = addCustomCategory({
       label: 'Coffee',

--- a/src/services/categories/category-store.test.ts
+++ b/src/services/categories/category-store.test.ts
@@ -58,6 +58,11 @@ describe('Custom category store', () => {
     expect(new Set([food.id, groceries.id]).size).toBe(2)
   })
 
+  it('does not treat inherited Object properties as reserved ids', () => {
+    const c = addCustomCategory({ label: 'Constructor', color: '#ff0000' })
+    expect(c.id).toBe('constructor')
+  })
+
   it('updates a custom category', () => {
     const category = addCustomCategory({
       label: 'Coffee',

--- a/src/services/categories/category-store.test.ts
+++ b/src/services/categories/category-store.test.ts
@@ -58,6 +58,13 @@ describe('Custom category store', () => {
     expect(new Set([food.id, groceries.id]).size).toBe(2)
   })
 
+  it('never hands a custom category the legacy ignored id', () => {
+    // isCategoryIgnored treats 'ignored' as ignore-by-default, so a category
+    // slugged that way would silently drop its transactions from every total.
+    const c = addCustomCategory({ label: 'Ignored', color: '#ff0000' })
+    expect(c.id).not.toBe('ignored')
+  })
+
   it('does not treat inherited Object properties as reserved ids', () => {
     const c = addCustomCategory({ label: 'Constructor', color: '#ff0000' })
     expect(c.id).toBe('constructor')

--- a/src/services/categories/category-store.ts
+++ b/src/services/categories/category-store.ts
@@ -1,3 +1,5 @@
+import { isReservedCategoryId } from './category-aliases'
+
 export const DEFAULT_CATEGORY_COLOR = '#0ea5e9'
 
 export interface CustomCategory {
@@ -19,12 +21,17 @@ function slugifyLabel(label: string): string {
 }
 
 function ensureUniqueId(base: string, existingIds: Set<string>): string {
-  if (!existingIds.has(base)) {
+  // A slug that collides with a built-in id or one of its pre-rename aliases
+  // would silently override that built-in everywhere — a custom "Food" would
+  // take over Alimentación's ignore flag in every total.
+  const taken = (id: string) => existingIds.has(id) || isReservedCategoryId(id)
+
+  if (!taken(base)) {
     return base
   }
 
   let suffix = 2
-  while (existingIds.has(`${base}-${suffix}`)) {
+  while (taken(`${base}-${suffix}`)) {
     suffix += 1
   }
   return `${base}-${suffix}`

--- a/src/services/categories/category-store.ts
+++ b/src/services/categories/category-store.ts
@@ -99,7 +99,7 @@ export async function syncCustomCategoryToCloud(id: string): Promise<void> {
         label: category.label,
         color: category.color,
         icon: category.icon,
-        isIgnored: category.isIgnored ?? false,
+        isIgnored: category.isIgnored,
         isArchived: false,
       })
     }
@@ -139,7 +139,7 @@ export async function updateCustomCategoryWithSync(
         label: category.label,
         color: category.color,
         icon: category.icon,
-        isIgnored: category.isIgnored ?? false,
+        isIgnored: category.isIgnored,
         isArchived: false,
       })
     }

--- a/src/services/charts/chart-data.test.ts
+++ b/src/services/charts/chart-data.test.ts
@@ -421,5 +421,113 @@ describe('chart-data multicurrency converting selectors', () => {
       expect(result.usd.count).toBe(0)
       expect(result.uyu.count).toBe(0)
     })
+
+    it('excludes legacy pre-rename transfer ids from account spend', () => {
+      const txs = [
+        makeTx('real', { source: 'bank_account', currency: 'USD', amount: 40 }),
+        makeTx('legacy', {
+          source: 'bank_account',
+          currency: 'USD',
+          amount: 1000,
+          category: 'transfer',
+        }),
+      ]
+      const result = spendByAccount(txs, 'USD', RATE)
+      expect(result.usd.conv).toBe(40)
+      expect(result.usd.count).toBe(1)
+    })
+  })
+
+  describe('ignored categories are never counted', () => {
+    it('keeps legacy transfer ids out of category spending', () => {
+      const transactions = [
+        makeTransaction('tx-1', {
+          amount: 30,
+          category: Category.Groceries,
+        }),
+        makeTransaction('tx-2', { amount: 900, category: 'transfer' }),
+        makeTransaction('tx-3', { amount: 700, category: 'transfers' }),
+      ]
+
+      const result = buildCategorySpendingConverted(transactions, 'USD', 40)
+
+      expect(result).toEqual([{ category: Category.Groceries, total: 30 }])
+    })
+
+    it('keeps legacy transfer ids out of monthly trends', () => {
+      const transactions = [
+        makeTransaction('tx-1', {
+          date: new Date('2025-03-10T00:00:00.000Z'),
+          amount: 30,
+          category: Category.Groceries,
+        }),
+        makeTransaction('tx-2', {
+          date: new Date('2025-03-12T00:00:00.000Z'),
+          amount: 900,
+          category: 'transfer',
+        }),
+      ]
+
+      const result = buildMonthlyTrendsConverted(transactions, 'USD', 40)
+
+      expect(result).toEqual([
+        { month: '2025-03', income: 0, expense: 30, net: -30 },
+      ])
+    })
+
+    it('keeps legacy transfer ids out of the currency split', () => {
+      const transactions = [
+        makeTransaction('tx-1', { amount: 25, currency: 'USD' }),
+        makeTransaction('tx-2', {
+          amount: 4000,
+          currency: 'UYU',
+          category: 'transfer',
+        }),
+      ]
+
+      const result = buildCurrencySplit(transactions, 'USD', 40)
+
+      expect(result.total).toBe(25)
+      expect(result.UYU).toBe(0)
+      expect(result.pctUSD).toBe(100)
+    })
+
+    it('picks the reference month from counted transactions only', () => {
+      const transactions = [
+        makeTransaction('tx-1', {
+          date: new Date('2025-03-10T00:00:00.000Z'),
+          amount: 30,
+          category: Category.Groceries,
+        }),
+        // A later month containing nothing but an ignored transfer must not
+        // become the "este mes" reference month.
+        makeTransaction('tx-2', {
+          date: new Date('2025-04-02T00:00:00.000Z'),
+          amount: 5000,
+          category: Category.InternalTransfer,
+        }),
+      ]
+
+      const result = buildCurrentMonthSummary(transactions, 'USD', 40)
+
+      expect(result.expense).toBe(30)
+      expect(result.count).toBe(1)
+      expect(result.monthLabel).toContain('marzo')
+    })
+
+    it('returns an empty summary when every transaction is ignored', () => {
+      const transactions = [
+        makeTransaction('tx-1', {
+          amount: 5000,
+          category: Category.InternalTransfer,
+        }),
+      ]
+
+      const result = buildCurrentMonthSummary(transactions, 'USD', 40)
+
+      expect(result.count).toBe(0)
+      expect(result.expense).toBe(0)
+      expect(result.monthLabel).toBe('')
+    })
   })
 })

--- a/src/services/charts/chart-data.ts
+++ b/src/services/charts/chart-data.ts
@@ -135,7 +135,10 @@ export interface CurrencySplitData {
   pctUYU: number
 }
 
-function shouldExclude(tx: Transaction): boolean {
+// A transaction is excluded from every total when its category is ignored
+// (transfers, the legacy 'ignored' id, or any category the user flagged) or
+// when it is the inert parent row of a split.
+export function isExcludedFromTotals(tx: Transaction): boolean {
   return isCategoryIgnored(tx.category) || isSplitParentTx(tx)
 }
 
@@ -147,7 +150,7 @@ export function buildCategorySpendingConverted(
   const grouped = new Map<string, number>()
 
   transactions.forEach((tx) => {
-    if (tx.type !== 'debit' || shouldExclude(tx)) return
+    if (tx.type !== 'debit' || isExcludedFromTotals(tx)) return
     const category = tx.category ?? Category.Uncategorized
     const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
     grouped.set(category, (grouped.get(category) ?? 0) + converted)
@@ -166,7 +169,7 @@ export function buildMonthlyTrendsConverted(
   const grouped = new Map<string, MonthlyTrendDatum>()
 
   transactions.forEach((tx) => {
-    if (shouldExclude(tx)) return
+    if (isExcludedFromTotals(tx)) return
     const month = toMonthKey(tx.date)
     if (!grouped.has(month)) {
       grouped.set(month, { month, income: 0, expense: 0, net: 0 })
@@ -192,7 +195,10 @@ export function buildCurrentMonthSummary(
   homeCurrency: Currency,
   fxRate: number
 ): MonthSummary {
-  if (transactions.length === 0) {
+  // Reference month comes from countable transactions only — a trailing
+  // transfer or ignored row must not drag "este mes" onto an empty month.
+  const counted = transactions.filter((tx) => !isExcludedFromTotals(tx))
+  if (counted.length === 0) {
     return {
       income: 0,
       expense: 0,
@@ -203,20 +209,16 @@ export function buildCurrentMonthSummary(
     }
   }
 
-  const latest = transactions.reduce(
+  const latest = counted.reduce(
     (max, tx) => (tx.date > max ? tx.date : max),
-    transactions[0].date
+    counted[0].date
   )
   const m = latest.getUTCMonth()
   const y = latest.getUTCFullYear()
 
-  const monthTxs = transactions.filter((tx) => {
-    return (
-      tx.date.getUTCFullYear() === y &&
-      tx.date.getUTCMonth() === m &&
-      !shouldExclude(tx)
-    )
-  })
+  const monthTxs = counted.filter(
+    (tx) => tx.date.getUTCFullYear() === y && tx.date.getUTCMonth() === m
+  )
 
   let income = 0
   let expense = 0
@@ -257,7 +259,7 @@ export function buildCurrencySplit(
   let uyu = 0
 
   transactions.forEach((tx) => {
-    if (tx.type !== 'debit' || shouldExclude(tx)) return
+    if (tx.type !== 'debit' || isExcludedFromTotals(tx)) return
     const converted = convert(tx.amount, tx.currency, homeCurrency, fxRate)
     if (tx.currency === 'USD') usd += converted
     else uyu += converted
@@ -299,7 +301,7 @@ export function spendByAccount(
   }
 
   transactions
-    .filter((tx) => tx.type === 'debit' && !shouldExclude(tx))
+    .filter((tx) => tx.type === 'debit' && !isExcludedFromTotals(tx))
     .forEach((tx) => {
       let bucket: AccountBucket
       if (tx.source === 'credit_card') {

--- a/src/services/supabase/custom-categories.test.ts
+++ b/src/services/supabase/custom-categories.test.ts
@@ -135,6 +135,20 @@ describe('supabase custom categories service', () => {
     )
   })
 
+  it('writes NULL when no ignore preference is set', async () => {
+    const { upsertCustomCategory } = await import('./custom-categories')
+    await upsertCustomCategory(session, {
+      id: 'mates',
+      label: 'Mates',
+      color: '#00AA11',
+    })
+
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'mates', is_ignored: null }),
+      expect.anything()
+    )
+  })
+
   it('persists the is_ignored flag on upsert', async () => {
     const { upsertCustomCategory } = await import('./custom-categories')
     await upsertCustomCategory(session, {

--- a/src/services/supabase/custom-categories.test.ts
+++ b/src/services/supabase/custom-categories.test.ts
@@ -92,7 +92,7 @@ describe('supabase custom categories service', () => {
     expect(categories[0].isIgnored).toBe(true)
   })
 
-  it('defaults is_ignored to false when the column is null', async () => {
+  it('leaves is_ignored undefined when the column is null', async () => {
     isMock.mockResolvedValueOnce({
       data: [
         {
@@ -113,7 +113,9 @@ describe('supabase custom categories service', () => {
     const { listCustomCategories } = await import('./custom-categories')
     const categories = await listCustomCategories(session)
 
-    expect(categories[0].isIgnored).toBe(false)
+    // NULL means "no preference recorded" and must stay distinct from an
+    // explicit false, which would override a built-in's own default.
+    expect(categories[0].isIgnored).toBeUndefined()
   })
 
   it('upserts custom category', async () => {

--- a/src/services/supabase/custom-categories.test.ts
+++ b/src/services/supabase/custom-categories.test.ts
@@ -135,7 +135,9 @@ describe('supabase custom categories service', () => {
     )
   })
 
-  it('writes NULL when no ignore preference is set', async () => {
+  it('writes false, never null, when no ignore preference is set', async () => {
+    // custom_categories.is_ignored is NOT NULL DEFAULT false in schema.sql —
+    // a null here is rejected by Postgres at runtime.
     const { upsertCustomCategory } = await import('./custom-categories')
     await upsertCustomCategory(session, {
       id: 'mates',
@@ -144,7 +146,7 @@ describe('supabase custom categories service', () => {
     })
 
     expect(upsertMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'mates', is_ignored: null }),
+      expect.objectContaining({ id: 'mates', is_ignored: false }),
       expect.anything()
     )
   })

--- a/src/services/supabase/custom-categories.ts
+++ b/src/services/supabase/custom-categories.ts
@@ -18,10 +18,9 @@ export interface CustomCategoryRecord {
   color: string
   icon?: string
   /**
-   * undefined when the column is NULL — the row records no preference, which
-   * must stay distinct from an explicit false. A pre-rename override row
-   * ('transfer') carrying a spurious false would otherwise un-ignore the
-   * built-in it resolves to.
+   * undefined when the column is NULL. The schema has it NOT NULL DEFAULT
+   * false, so this is defensive rather than reachable today — but a null must
+   * not read as an explicit false, which would override a built-in's default.
    */
   isIgnored?: boolean
   isArchived: boolean
@@ -66,7 +65,6 @@ export async function upsertCustomCategory(
     label: string
     color: string
     icon?: string
-    /** undefined leaves the column NULL — no preference recorded. */
     isIgnored?: boolean
     isArchived?: boolean
   }
@@ -79,7 +77,9 @@ export async function upsertCustomCategory(
       label: category.label,
       color: category.color,
       icon: category.icon ?? null,
-      is_ignored: category.isIgnored ?? null,
+      // custom_categories.is_ignored is NOT NULL DEFAULT false — writing null
+      // is rejected by Postgres, so an unset flag persists as false.
+      is_ignored: category.isIgnored ?? false,
       is_archived: category.isArchived ?? false,
     },
     { onConflict: 'user_id,id' }

--- a/src/services/supabase/custom-categories.ts
+++ b/src/services/supabase/custom-categories.ts
@@ -17,7 +17,13 @@ export interface CustomCategoryRecord {
   label: string
   color: string
   icon?: string
-  isIgnored: boolean
+  /**
+   * undefined when the column is NULL — the row records no preference, which
+   * must stay distinct from an explicit false. A pre-rename override row
+   * ('transfer') carrying a spurious false would otherwise un-ignore the
+   * built-in it resolves to.
+   */
+  isIgnored?: boolean
   isArchived: boolean
   createdAt: string
   updatedAt: string
@@ -29,7 +35,7 @@ function rowToRecord(row: CustomCategoryRow): CustomCategoryRecord {
     label: row.label,
     color: row.color,
     icon: row.icon ?? undefined,
-    isIgnored: row.is_ignored ?? false,
+    isIgnored: row.is_ignored ?? undefined,
     isArchived: row.is_archived,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/services/supabase/custom-categories.ts
+++ b/src/services/supabase/custom-categories.ts
@@ -66,7 +66,8 @@ export async function upsertCustomCategory(
     label: string
     color: string
     icon?: string
-    isIgnored: boolean
+    /** undefined leaves the column NULL — no preference recorded. */
+    isIgnored?: boolean
     isArchived?: boolean
   }
 ): Promise<void> {
@@ -78,7 +79,7 @@ export async function upsertCustomCategory(
       label: category.label,
       color: category.color,
       icon: category.icon ?? null,
-      is_ignored: category.isIgnored,
+      is_ignored: category.isIgnored ?? null,
       is_archived: category.isArchived ?? false,
     },
     { onConflict: 'user_id,id' }


### PR DESCRIPTION
## What was wrong

Resumen's aggregates *all* already gated on `isCategoryIgnored` — account cards, "este mes", donut, trend, currency split, top merchants, recientes. No missing filter anywhere. The bug was in the predicate they share.

`isCategoryIgnored` matched the raw id against `internal_transfer` / `external_transfer` / `'ignored'` without running it through `ID_ALIASES` first — unlike `getCategoryDefinition` twenty lines above it. Transactions stored before the transfer rename carry `category: 'transfer'` or `'transfers'` (which is precisely why `ID_ALIASES` exists), so the predicate returned `false` for them and their amounts were counted in every Resumen total. Casing had the same hole. The inverse too: an override row keyed on the legacy id could never *un*-ignore transfers, so the Categorías toggle silently did nothing for them.

## User-visible change beyond the totals

`isCategoryIgnored` also drives row rendering and export, so pre-rename transfer rows change behavior in three places, not one:

- **Resumen** — they stop being counted. This is the fix.
- **Transacciones** — they were ordinary visible rows with no "Ignorada" chip; they now carry it and are **hidden by default** behind the "Mostrar transferencias ignoradas" toggle.
- **CSV export** — they were included; they are now excluded, like every other ignored row.

All three follow from the same predicate and are the intended treatment for a transfer. Calling it out because the second and third are not obvious from the title.

## Changes

**The fix**
- `isCategoryIgnored` lowercases and resolves through `ID_ALIASES`. One predicate, ~9 call sites.
- Override rows resolve through a single shared map used by `isCategoryIgnored`, `getCategoryDefinitions` and `getCategoryDefinition`, so the three can't disagree. Resolution is order-independent — `listCustomCategories` queries Supabase with no `ORDER BY`, so a stale `transfer` row and a canonical `internal_transfer` row can arrive either way round. Rows keyed by the current id beat alias-keyed ones; ties among alias rows break on the id, never on arrival order.
- `ID_ALIASES` moved to `category-aliases.ts` so `category-store` can use it without an import cycle; `category-registry` re-exports it. Alias lookup uses `hasOwnProperty` + a `typeof` guard — `'constructor' in ID_ALIASES` was true and returned a function from a declared-`string` signature.

**Adjacent defects found along the way**
- `buildCurrentMonthSummary` picked its reference month from *unfiltered* transactions, so a trailing internal transfer could anchor "este mes" onto a month with nothing countable in it.
- A custom category whose slug collided with a built-in id, an alias key (`"Food"` → `food` → groceries) or the legacy `ignored` marker silently took over that category's ignore flag in every total. `ensureUniqueId` now treats reserved ids as taken.
- An all-ignored dataset rendered a fully zeroed Resumen with nothing to explain it — and not the import CTA either, since data does exist. Added a distinct state naming the cause, linking to Categorías.
- `latestDate` fell back to `new Date()` when everything was ignored, reintroducing the system-clock dependence its own comment disclaims.
- `Dashboard` derives one `countedTransactions` list instead of re-rolling the filter inline in three places.

## Blast radius

The predicate fix also corrects **CSV export** (`export.ts:56`) and **AI insight inputs** (`insight-data.ts:104`). Cached insights self-flag: `insight-cache.ts` hashes the `InsightInput`, so changed totals trip `isStale` and Insights shows its "regenerar" banner. No schema change and no data migration.

## Known and deliberate — worth a second opinion

**Existing alias-keyed override rows are not migrated, and they now drive their built-in's ignore flag.** A pre-existing row slugged `food` / `salary` / `health` controls the built-in it resolves to. If such a row was created as a *custom category* named "Food" and marked ignored, Alimentación now drops out of totals entirely.

Chosen this way because `getCategoryDefinitions` has folded such rows into the built-in since 7e6102d — the grid already showed Alimentación as ignored while the totals counted it, which is the exact divergence this PR closes. Post-PR the two agree, and unticking "ignorar" in Categorías writes a row keyed by the current id that wins outright. Covered by a test. Low likelihood (alias keys are English, the app is Spanish) but silent if hit, so flagging rather than burying: the alternative is to let the built-in default win over alias rows, a one-line change in `resolvedOverrides`.

**Out of scope:** `buildCategorySpendingConverted` groups on the raw `tx.category`, so an aliased id still yields two donut slices sharing one label — the visible residue of the same fold. And `services/aggregator/aggregation.ts` has no callers outside its own tests.

## Tests

23 new. Each verified to fail against the commit it fixes rather than passing vacuously, by reverting source and re-running. `npm run ci:check` green — 820 tests, lint clean, build OK.

Six review rounds; each round's findings are addressed in their own commit, and every commit message records what was found and why the fix takes the shape it does. One round's schema check caught a bug in the previous round's own fix: it wrote `null` to `is_ignored`, which `schema.sql` declares `not null default false` — invisible to the suite, which mocks Supabase.