### PR TITLE
fix: surface AI enrichment failures instead of swallowing them

### DIFF
--- a/src/components/ImportCSV.test.tsx
+++ b/src/components/ImportCSV.test.tsx
@@ -3,10 +3,13 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { ImportCSV } from './ImportCSV'
 import type { ParsedData, Transaction } from '../models'
 
-const { parseCSVMock, addTransactionsMock } = vi.hoisted(() => ({
+const { parseCSVMock, addTransactionsMock, toastMock } = vi.hoisted(() => ({
   parseCSVMock: vi.fn(),
   addTransactionsMock: vi.fn(),
+  toastMock: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
 }))
+
+vi.mock('sonner', () => ({ toast: toastMock }))
 
 vi.mock('../services/parsers/csv-parser', () => ({
   parseCSV: parseCSVMock,
@@ -241,5 +244,51 @@ describe('ImportCSV', () => {
       })
     )
     expect(addTransactionsMock).not.toHaveBeenCalled()
+  })
+
+  it('warns that AI categorization failed while still reporting a successful import', async () => {
+    parseCSVMock.mockReturnValue(makeParsedData())
+    const onTransactionsImported = vi.fn().mockResolvedValue({
+      added: [makeTx('tx-1'), makeTx('tx-2')],
+      duplicates: [makeTx('tx-3')],
+      aiError: '401 invalid x-api-key',
+    })
+
+    render(<ImportCSV onTransactionsImported={onTransactionsImported} />)
+
+    fireEvent.change(screen.getByLabelText('Seleccionar archivo'), {
+      target: {
+        files: [new File(['a,b'], 'movements.csv', { type: 'text/csv' })],
+      },
+    })
+
+    // The import still succeeded ...
+    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      screen.getByText('2 de 3 transacciones guardadas (1 duplicadas omitidas)')
+    ).toBeInTheDocument()
+
+    // ... but the user is told the AI step did not run, and why.
+    await waitFor(() => expect(toastMock.warning).toHaveBeenCalledTimes(1))
+    expect(toastMock.warning.mock.calls[0][0]).toContain('401 invalid x-api-key')
+  })
+
+  it('does not warn about AI when the import reports no AI failure', async () => {
+    parseCSVMock.mockReturnValue(makeParsedData())
+    const onTransactionsImported = vi.fn().mockResolvedValue({
+      added: [makeTx('tx-1')],
+      duplicates: [],
+    })
+
+    render(<ImportCSV onTransactionsImported={onTransactionsImported} />)
+
+    fireEvent.change(screen.getByLabelText('Seleccionar archivo'), {
+      target: {
+        files: [new File(['a,b'], 'movements.csv', { type: 'text/csv' })],
+      },
+    })
+
+    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(toastMock.warning).not.toHaveBeenCalled()
   })
 })

--- a/src/components/ImportCSV.tsx
+++ b/src/components/ImportCSV.tsx
@@ -24,6 +24,11 @@ interface ImportCSVProps {
   ) => Promise<{
     added: Transaction[];
     duplicates: Transaction[];
+    /**
+     * Set when the import succeeded but AI enrichment did not, so the user can
+     * tell a dead API key apart from the model categorizing badly.
+     */
+    aiError?: string;
   }>;
 }
 
@@ -99,13 +104,17 @@ export function ImportCSV({
         setFileType('uyu_account');
       }
 
-      const { added, duplicates } = onTransactionsImported
+      const { added, duplicates, aiError } = onTransactionsImported
         ? await onTransactionsImported(result.transactions, {
             parsedData: result,
             csvContent,
             fileName: file.name,
           })
-        : transactionStore.getState().addTransactions(result.transactions);
+        : {
+            ...transactionStore.getState().addTransactions(result.transactions),
+            // Local-only path never runs AI enrichment.
+            aiError: undefined as string | undefined,
+          };
 
       setImportSummary({
         total: result.transactions.length,
@@ -117,6 +126,14 @@ export function ImportCSV({
       toast.success(
         `${added.length} nueva${added.length === 1 ? '' : 's'} · ${duplicates.length} duplicada${duplicates.length === 1 ? '' : 's'} omitida${duplicates.length === 1 ? '' : 's'}`
       );
+
+      // The import succeeded, but the AI step did not — say so, otherwise a
+      // dead API key looks identical to poor categorization.
+      if (aiError) {
+        toast.warning(
+          `Categorización con IA no disponible: ${aiError}. Se usaron las reglas de categorización.`
+        );
+      }
 
       if (onImportComplete) {
         onImportComplete();

--- a/src/hooks/useTransactionHandlers.test.ts
+++ b/src/hooks/useTransactionHandlers.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Transaction } from '../models'
+import type { SupabaseSession } from '../services/supabase/client'
+
+// Mocks are declared via vi.hoisted so the vi.mock factories (which are
+// hoisted above the imports) can reference them without a TDZ error.
+const mocks = vi.hoisted(() => ({
+  persistTransactions: vi.fn<[unknown, unknown, unknown?], Promise<void>>(
+    async () => undefined
+  ),
+  createImportRun: vi.fn(async () => 'import-1'),
+  completeImportRun: vi.fn(async () => undefined),
+  failImportRun: vi.fn(async () => undefined),
+  getAiConfig: vi.fn(() => ({
+    apiKey: 'sk-test',
+    enabled: true,
+    model: 'claude-haiku-4-5',
+  })),
+  enrichTransactionsWithAi: vi.fn(async () => new Map()),
+}))
+
+vi.mock('../services/supabase/transactions', () => ({
+  persistTransactions: mocks.persistTransactions,
+  softDeleteTransaction: vi.fn(async () => undefined),
+  updateTransaction: vi.fn(async () => undefined),
+  splitTransaction: vi.fn(async () => undefined),
+  unsplitTransaction: vi.fn(async () => undefined),
+  hardDeleteTransactions: vi.fn(async () => undefined),
+}))
+
+vi.mock('../services/supabase/import-runs', () => ({
+  createImportRun: mocks.createImportRun,
+  completeImportRun: mocks.completeImportRun,
+  failImportRun: mocks.failImportRun,
+  sha256Hex: async () => 'checksum',
+}))
+
+// Override stores are empty, so nothing is filtered out of AI enrichment.
+vi.mock('../services/categorizer/category-overrides', () => ({
+  listMerchantCategoryOverrides: () => ({}),
+  clearMerchantCategoryOverrideWithSync: vi.fn(async () => undefined),
+  setMerchantCategoryOverrideWithSync: vi.fn(async () => undefined),
+  getMerchantCategoryOverride: () => undefined,
+}))
+vi.mock('../services/descriptions/description-overrides', () => ({
+  clearDescriptionOverrideWithSync: vi.fn(async () => undefined),
+  setDescriptionOverrideWithSync: vi.fn(async () => undefined),
+  getDescriptionOverride: () => undefined,
+}))
+
+vi.mock('../services/ai', () => ({
+  getAiConfig: mocks.getAiConfig,
+  enrichTransactionsWithAi: mocks.enrichTransactionsWithAi,
+  applyAiEnrichment: (txs: Transaction[]) => txs,
+}))
+vi.mock('../services/ai/correction-context', () => ({
+  buildCorrectionContext: () => ({
+    descriptionExamples: [],
+    categoryExamples: [],
+    customCategories: [],
+    customPatterns: [],
+  }),
+}))
+
+import { useTransactionHandlers } from './useTransactionHandlers'
+import { transactionStore } from '../stores/transaction-store'
+
+const session = { user: { id: 'user-1' } } as SupabaseSession
+
+function makeTransaction(id: string, overrides: Partial<Transaction> = {}) {
+  return {
+    id,
+    date: new Date('2026-03-15T00:00:00Z'),
+    description: 'SUPERMERCADO DISCO',
+    amount: 1200,
+    currency: 'UYU',
+    type: 'debit',
+    source: 'bank_account',
+    category: 'groceries',
+    categoryConfidence: 0.8,
+    rawData: {},
+    ...overrides,
+  } as Transaction
+}
+
+function makeImportContext() {
+  return {
+    parsedData: { fileType: 'bank_account_uyu' as const },
+    csvContent: 'raw,csv',
+    fileName: 'movements.csv',
+  }
+}
+
+function setup() {
+  const setError = vi.fn()
+  const setNotice = vi.fn()
+  const { result } = renderHook(() =>
+    useTransactionHandlers({ session, setError, setNotice })
+  )
+  return { handlers: result.current, setError, setNotice }
+}
+
+describe('useTransactionHandlers — import with AI enrichment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transactionStore.getState().clearTransactions()
+    mocks.getAiConfig.mockReturnValue({
+      apiKey: 'sk-test',
+      enabled: true,
+      model: 'claude-haiku-4-5',
+    })
+    mocks.enrichTransactionsWithAi.mockResolvedValue(new Map())
+  })
+
+  it('imports transactions and reports no AI failure on the happy path', async () => {
+    const { handlers } = setup()
+
+    const outcome = await handlers.handleTransactionsImported(
+      [makeTransaction('tx-1')],
+      makeImportContext()
+    )
+
+    expect(outcome.added).toHaveLength(1)
+    expect(outcome.aiError).toBeUndefined()
+    expect(transactionStore.getState().transactions).toHaveLength(1)
+  })
+
+  it('still stores rule-based results when AI enrichment fails', async () => {
+    mocks.enrichTransactionsWithAi.mockRejectedValue(new Error('401 invalid x-api-key'))
+    const { handlers } = setup()
+
+    const outcome = await handlers.handleTransactionsImported(
+      [makeTransaction('tx-1')],
+      makeImportContext()
+    )
+
+    // The import itself must still succeed with the rule-based categories.
+    expect(outcome.added).toHaveLength(1)
+    expect(transactionStore.getState().transactions).toHaveLength(1)
+    expect(transactionStore.getState().transactions[0].category).toBe('groceries')
+    expect(mocks.persistTransactions).toHaveBeenCalledTimes(1)
+    expect(mocks.completeImportRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports the AI failure reason to the caller instead of swallowing it', async () => {
+    mocks.enrichTransactionsWithAi.mockRejectedValue(new Error('401 invalid x-api-key'))
+    const { handlers } = setup()
+
+    const outcome = await handlers.handleTransactionsImported(
+      [makeTransaction('tx-1')],
+      makeImportContext()
+    )
+
+    expect(outcome.aiError).toContain('401 invalid x-api-key')
+  })
+
+  it('does not report an AI failure when AI is disabled', async () => {
+    mocks.getAiConfig.mockReturnValue({
+      apiKey: '',
+      enabled: false,
+      model: 'claude-haiku-4-5',
+    })
+    const { handlers } = setup()
+
+    const outcome = await handlers.handleTransactionsImported(
+      [makeTransaction('tx-1')],
+      makeImportContext()
+    )
+
+    expect(outcome.aiError).toBeUndefined()
+    expect(mocks.enrichTransactionsWithAi).not.toHaveBeenCalled()
+  })
+
+  it('still fails the import when persistence fails, regardless of AI', async () => {
+    mocks.persistTransactions.mockRejectedValueOnce(new Error('network down'))
+    const { handlers } = setup()
+
+    await expect(
+      handlers.handleTransactionsImported(
+        [makeTransaction('tx-1')],
+        makeImportContext()
+      )
+    ).rejects.toThrow('network down')
+
+    expect(mocks.failImportRun).toHaveBeenCalledTimes(1)
+    expect(mocks.completeImportRun).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useTransactionHandlers.ts
+++ b/src/hooks/useTransactionHandlers.ts
@@ -51,6 +51,13 @@ export function useTransactionHandlers({
   setError: (msg: string) => void
   setNotice: (msg: string) => void
 }) {
+  /**
+   * Imports a parsed statement. AI enrichment is best-effort: if it fails the
+   * import still completes with the rule-based categories, but the reason is
+   * returned as `aiError` so the caller can tell the user the AI step did not
+   * run. Swallowing it silently makes an expired API key indistinguishable
+   * from the model simply categorizing badly.
+   */
   async function handleTransactionsImported(
     transactionsToImport: Transaction[],
     context?: {
@@ -60,7 +67,11 @@ export function useTransactionHandlers({
       csvContent: string
       fileName: string
     }
-  ) {
+  ): Promise<{
+    added: Transaction[]
+    duplicates: Transaction[]
+    aiError?: string
+  }> {
     if (!session) {
       return transactionStore.getState().addTransactions(transactionsToImport)
     }
@@ -84,6 +95,7 @@ export function useTransactionHandlers({
 
     const aiConfig = getAiConfig()
     let toStore = added
+    let aiError: string | undefined
 
     if (aiConfig?.enabled && aiConfig.apiKey && added.length > 0) {
       const toEnrich = added.filter((tx) => {
@@ -110,8 +122,12 @@ export function useTransactionHandlers({
             correctionContext
           )
           toStore = applyAiEnrichment(added, results)
-        } catch {
-          // AI failed — fall through with rule-based results already on transactions
+        } catch (error) {
+          // Fall through with the rule-based results already on the
+          // transactions, but keep the reason so it can be surfaced.
+          aiError =
+            error instanceof Error ? error.message : 'Error desconocido de IA'
+          console.error('AI enrichment failed during import:', error)
         }
       }
     }
@@ -140,7 +156,7 @@ export function useTransactionHandlers({
       throw error
     }
 
-    return { added, duplicates }
+    return { added, duplicates, aiError }
   }
 
   async function handleUpdateTransaction(


### PR DESCRIPTION
## Summary

`handleTransactionsImported` caught AI enrichment errors with an empty `catch {}` and a comment. The fallback to rule-based categories was correct; the silence was not — an expired API key looked exactly like the model categorizing badly, and the import was still recorded as `completed`.

Closes #48
Refs #54 (this adds the first test file for `useTransactionHandlers`)

## Design decision

The reason is **returned** as `aiError` rather than pushed through `setNotice`.

`setNotice` is wired to `setAuthNotice` (`App.tsx:188`) — an auth-screen surface, not the import dialog, so it would have shown the message in the wrong place, if at all. Returning it also keeps the hook free of UI imports and leaves presentation with `ImportCSV`, which already owns the import toasts.

The logging half uses `console.error`, matching the existing convention in `services/categorizer/custom-patterns.ts:50,75` and `hooks/useUserPreferences.ts:64`.

## TDD Evidence

### RED
Added `src/hooks/useTransactionHandlers.test.ts` first. Four cases characterized existing correct behavior and passed immediately; one failed:

```
FAIL > reports the AI failure reason to the caller instead of swallowing it
AssertionError: the given combination of arguments (undefined and string) is invalid
 ❯ expect(outcome.aiError).toContain('401 invalid x-api-key')
```

`outcome.aiError` was `undefined` — the failure was swallowed, exactly as reported.

### GREEN
- `useTransactionHandlers.ts` — bind the error, record `aiError`, `console.error` it, return it. Explicit `Promise<{added, duplicates, aiError?}>` return type.
- `ImportCSV.tsx` — destructure `aiError`, emit `toast.warning` after the existing `toast.success`.

### REFACTOR
Two problems surfaced during verification, both fixed:

1. **Mock hoisting.** `vi.mock` factories are hoisted above the imports, so referencing `const` mocks directly threw `ReferenceError: Cannot access 'persistTransactions' before initialization`. Moved them into `vi.hoisted()` — the idiomatic fix, and it keeps the mocks typed (the `(...args: unknown[])` wrapper form I tried first fails `tsc` with TS2556).
2. **Union type.** The `!onTransactionsImported` fallback returns the store's `{added, duplicates}`, so destructuring `aiError` off the ternary failed `tsc`. That branch now spreads an explicit `aiError: undefined`.

Then added two `ImportCSV.test.tsx` cases, because the hook test alone does not prove the *user* learns anything — which is the entire point of the issue.

## Tests

`useTransactionHandlers.test.ts` (new, 5 cases):
- happy path — imports and reports no AI failure
- **AI failure still stores rule-based results** and completes the import run (regression for the fallback behavior that must not break)
- **AI failure reason reaches the caller** (the RED case)
- AI disabled → no failure reported, enricher never called
- persistence failure still throws and calls `failImportRun` (proves this change did not soften real import failures)

`ImportCSV.test.tsx` (2 added):
- import succeeds **and** the user gets a warning naming the reason
- no AI failure → no warning

Mock isolation is real, not incidental — the file's `beforeEach` already calls `vi.clearAllMocks()` (`ImportCSV.test.tsx:93`).

## Verification
`npm run ci:check` passes — **77 test files, 827 tests**, lint clean, build succeeds.

## Deliberately out of scope
- The toast shows the raw SDK message (e.g. `401 invalid x-api-key`) inside Spanish copy. Mapping common failures to Spanish text would read better but needs its own mapping + tests; diagnosability is the goal here and the raw reason delivers it.
- `import_runs` still records `completed` for an AI-failed import. Recording partial AI failure would need a schema change (there is no `partial` status), so it belongs with the write-semantics work in #60/#61.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation