### PR TITLE
fix: correct Insights prior-period baseline and round amounts at source

### DIFF
--- a/src/services/insights/insight-data.test.ts
+++ b/src/services/insights/insight-data.test.ts
@@ -171,3 +171,147 @@ describe('buildInsightInput', () => {
     expect(result.homeCurrency).toBe('UYU')
   })
 })
+
+describe('buildInsightInput — prior period is the previous calendar month', () => {
+  const MARCH = {
+    start: new Date('2026-03-01T00:00:00.000Z'),
+    end: new Date('2026-03-31T23:59:59.999Z'),
+  }
+
+  it('compares March against February, not against a rolling 31-day window', () => {
+    // A 31-day rolling window ending Feb 28 starts on Jan 28, so the Jan 31
+    // charge would leak into March's baseline and understate the delta.
+    const transactions = [
+      makeTransaction('mar', {
+        date: new Date('2026-03-10T00:00:00.000Z'),
+        amount: 100,
+        category: Category.Groceries,
+      }),
+      makeTransaction('feb', {
+        date: new Date('2026-02-15T00:00:00.000Z'),
+        amount: 40,
+        category: Category.Groceries,
+      }),
+      makeTransaction('jan', {
+        date: new Date('2026-01-31T00:00:00.000Z'),
+        amount: 1000,
+        category: Category.Groceries,
+      }),
+    ]
+
+    const input = buildInsightInput(transactions, MARCH, 'USD', 40)
+    const groceries = input.categoryTotals.find(
+      (c) => c.category === Category.Groceries
+    )
+
+    // 100 (March) - 40 (February only) = 60
+    expect(groceries?.deltaVsPriorPeriod).toBe(60)
+  })
+
+  it('uses December of the previous year as January prior period', () => {
+    const january = {
+      start: new Date('2026-01-01T00:00:00.000Z'),
+      end: new Date('2026-01-31T23:59:59.999Z'),
+    }
+    const transactions = [
+      makeTransaction('jan', {
+        date: new Date('2026-01-10T00:00:00.000Z'),
+        amount: 50,
+        category: Category.Groceries,
+      }),
+      makeTransaction('dec', {
+        date: new Date('2025-12-20T00:00:00.000Z'),
+        amount: 30,
+        category: Category.Groceries,
+      }),
+    ]
+
+    const input = buildInsightInput(transactions, january, 'USD', 40)
+    const groceries = input.categoryTotals.find(
+      (c) => c.category === Category.Groceries
+    )
+
+    expect(groceries?.deltaVsPriorPeriod).toBe(20)
+  })
+})
+
+describe('buildInsightInput — amounts are rounded for the model', () => {
+  // The model is asked to echo amounts back EXACTLY, and the generator
+  // validates them with ===. Float residue from convert() makes that a
+  // lottery, so every monetary field is rounded at source.
+  function isRounded(value: number): boolean {
+    return Number.isFinite(value) && Math.abs(value * 100 - Math.round(value * 100)) < 1e-9
+  }
+
+  it('rounds converted category totals, deltas and percentages to 2 decimals', () => {
+    // 50000 UYU / 40.5 = 1234.5679012345679 in USD
+    const transactions = [
+      makeTransaction('a', {
+        date: new Date('2026-06-10T00:00:00.000Z'),
+        amount: 50000,
+        currency: 'UYU',
+        category: Category.Restaurants,
+      }),
+      makeTransaction('b', {
+        date: new Date('2026-06-11T00:00:00.000Z'),
+        amount: 33333,
+        currency: 'UYU',
+        category: Category.Groceries,
+      }),
+    ]
+
+    const input = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(input.categoryTotals.length).toBeGreaterThan(0)
+    for (const c of input.categoryTotals) {
+      expect(isRounded(c.amount)).toBe(true)
+      expect(isRounded(c.pctOfTotal)).toBe(true)
+      expect(isRounded(c.deltaVsPriorPeriod)).toBe(true)
+    }
+  })
+
+  it('rounds merchant totals to 2 decimals', () => {
+    const transactions = [
+      makeTransaction('a', {
+        date: new Date('2026-06-10T00:00:00.000Z'),
+        amount: 50000,
+        currency: 'UYU',
+        description: 'RESTAURANTE X',
+        category: Category.Restaurants,
+      }),
+    ]
+
+    const input = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(input.topMerchants.length).toBeGreaterThan(0)
+    for (const m of input.topMerchants) {
+      expect(isRounded(m.amount)).toBe(true)
+    }
+  })
+
+  it('rounds monthly trend income and expense to 2 decimals', () => {
+    const transactions = [
+      makeTransaction('a', {
+        date: new Date('2026-06-10T00:00:00.000Z'),
+        amount: 50000,
+        currency: 'UYU',
+        category: Category.Restaurants,
+      }),
+      makeTransaction('b', {
+        date: new Date('2026-06-12T00:00:00.000Z'),
+        amount: 77777,
+        currency: 'UYU',
+        type: 'credit',
+        category: Category.Income,
+      }),
+    ]
+
+    const input = buildInsightInput(transactions, JUNE, 'USD', 40.5)
+
+    expect(input.monthlyTrend.length).toBeGreaterThan(0)
+    for (const m of input.monthlyTrend) {
+      expect(isRounded(m.income)).toBe(true)
+      expect(isRounded(m.expense)).toBe(true)
+    }
+  })
+})

--- a/src/services/insights/insight-data.ts
+++ b/src/services/insights/insight-data.ts
@@ -118,11 +118,26 @@ function filterInRange(
   return transactions.filter((tx) => tx.date >= start && tx.date <= end)
 }
 
+/**
+ * The previous calendar month, not a rolling window of the same length.
+ * Subtracting the period's span in milliseconds looks equivalent but is not:
+ * for a 31-day March it yields Jan 28 - Feb 28, so a charge on Jan 31 lands
+ * in March's baseline and the delta comes out with the wrong sign. ADR-0001
+ * specifies month-over-month, and every caller builds periods with
+ * getUtcMonthPeriod, so the prior period is that month minus one.
+ */
 function priorPeriodOf(period: InsightPeriod): InsightPeriod {
-  const spanMs = period.end.getTime() - period.start.getTime()
-  const priorEnd = new Date(period.start.getTime() - 1)
-  const priorStart = new Date(priorEnd.getTime() - spanMs)
-  return { start: priorStart, end: priorEnd }
+  return getUtcMonthPeriod(period.start, -1)
+}
+
+/**
+ * Rounds to cents. Every number handed to the model goes through this: the
+ * prompt asks it to echo amounts back exactly and the generator validates
+ * them with ===, so unrounded FX residue (50000 / 40.5 = 1234.5679012345679)
+ * would make a legitimate echo of 1234.57 fail validation and get dropped.
+ */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
 }
 
 function buildCategoryTotals(
@@ -145,9 +160,9 @@ function buildCategoryTotals(
 
   return current.map((d) => ({
     category: d.category,
-    amount: d.total,
-    pctOfTotal: (d.total / grandTotal) * 100,
-    deltaVsPriorPeriod: d.total - (priorByCategory.get(d.category) ?? 0),
+    amount: round2(d.total),
+    pctOfTotal: round2((d.total / grandTotal) * 100),
+    deltaVsPriorPeriod: round2(d.total - (priorByCategory.get(d.category) ?? 0)),
   }))
 }
 
@@ -171,6 +186,7 @@ function buildTopMerchants(
   return Array.from(byMerchant.values())
     .sort((a, b) => b.amount - a.amount)
     .slice(0, TOP_MERCHANTS_LIMIT)
+    .map((m) => ({ ...m, amount: round2(m.amount) }))
 }
 
 function median(values: number[]): number {
@@ -239,7 +255,7 @@ function detectRecurringCharges(
 
     charges.push({
       merchant,
-      approxAmount,
+      approxAmount: round2(approxAmount),
       cadence: cadenceFromGap(averageGapDays(sortedDates)),
       monthsSeen,
     })
@@ -259,7 +275,11 @@ function buildMonthlyTrend(
     (tx) => tx.date >= windowStart && tx.date <= asOf
   )
   return buildMonthlyTrendsConverted(relevant, homeCurrency, fxRate).map(
-    (d) => ({ month: d.month, income: d.income, expense: d.expense })
+    (d) => ({
+      month: d.month,
+      income: round2(d.income),
+      expense: round2(d.expense),
+    })
   )
 }
 

--- a/src/services/insights/insight-generator.test.ts
+++ b/src/services/insights/insight-generator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { InsightInput } from './insight-data'
+import { buildInsightInput } from './insight-data'
+import type { Transaction } from '../../models'
+import { Category } from '../../models'
 
 const { messagesCreateMock } = vi.hoisted(() => ({
   messagesCreateMock: vi.fn(),
@@ -173,5 +176,82 @@ describe('generateInsights', () => {
     await expect(generateInsights(baseInput, 'sk-test-key')).rejects.toThrow(
       /Respuesta inesperada/
     )
+  })
+})
+
+describe('insight amounts survive the round trip from a real InsightInput', () => {
+  it('keeps an amount the model echoed back from FX-converted spend', async () => {
+    // Reproduces the real failure path: UYU spend converted to USD produces
+    // 1234.5679012345679 unrounded. The model is asked to copy the number
+    // exactly, but reproducing float residue verbatim is not something to
+    // rely on — so the input is rounded at source and both sides agree.
+    const transactions: Transaction[] = [
+      {
+        id: 'tx-1',
+        date: new Date('2026-06-10T00:00:00.000Z'),
+        description: 'RESTAURANTE X',
+        amount: 50000,
+        currency: 'UYU',
+        type: 'debit',
+        source: 'bank_account',
+        category: Category.Restaurants,
+        rawData: {},
+      },
+    ]
+
+    const input = buildInsightInput(
+      transactions,
+      {
+        start: new Date('2026-06-01T00:00:00.000Z'),
+        end: new Date('2026-06-30T23:59:59.999Z'),
+      },
+      'USD',
+      40.5
+    )
+
+    const amount = input.categoryTotals[0].amount
+    expect(amount).toBe(1234.57)
+
+    const result = parseInsightsResponse(
+      JSON.stringify({
+        insights: [
+          {
+            type: 'bleeding_money',
+            title: 'Restaurantes domina tu gasto',
+            narrative: 'Es tu categoría más grande del mes.',
+            amount,
+            currency: 'USD',
+            category: Category.Restaurants,
+            severity: 'high',
+          },
+        ],
+      }),
+      input
+    )
+
+    expect(result.insights).toHaveLength(1)
+    expect(result.insights[0].amount).toBe(1234.57)
+  })
+
+  it('still drops an amount that is not present in the input', async () => {
+    // The anti-hallucination guarantee from ADR-0001 must not regress.
+    const result = parseInsightsResponse(
+      JSON.stringify({
+        insights: [
+          {
+            type: 'bleeding_money',
+            title: 'Inventado',
+            narrative: 'Número que el modelo se inventó.',
+            amount: 99999.99,
+            currency: 'USD',
+            severity: 'high',
+          },
+        ],
+      }),
+      baseInput
+    )
+
+    expect(result.insights).toHaveLength(1)
+    expect(result.insights[0].amount).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Two defects that both made the Insights view report wrong or missing numbers — for the feature whose entire value proposition is trustworthy forensic analysis.

Closes #50
Closes #51

## 1. The prior-period baseline was a rolling window (#50)

`priorPeriodOf` subtracted the period's span in milliseconds instead of taking the previous calendar month. For a 31-day March that gives **Jan 28 – Feb 28**.

The RED test made the damage concrete — 100 spent in March, 40 in February, 1000 on Jan 31:

```
→ expected -940 to be 60
```

The Jan 31 charge leaked into March's baseline, so the delta came out as **−940** when the truth is **+60**. The model then does exactly what it is told and narrates a large drop in grocery spending that never happened. Every 31→28 and 30↔31 month boundary is affected.

Fix: `priorPeriodOf` delegates to `getUtcMonthPeriod(period.start, -1)` — already in the same file, already UTC-anchored. Verified safe: `Insights.tsx:118` is the only caller and always builds periods with `getUtcMonthPeriod`, so periods are always calendar months.

## 2. Insight amounts were dropped by float equality (#51)

`isKnownAmount` compares with `===` against numbers that reach the model **unrounded** — `insight-prompt.ts:35` is `JSON.stringify(input)`, and the values come from `convert()`. 50000 UYU at 40.5 serializes as `1234.5679012345679`. The model echoes `1234.57`. The comparison fails, the amount is stripped, and the card renders **with no number on it** — no error, no log, indistinguishable from the model choosing not to include one.

Fix: round every monetary field in `InsightInput` to cents at source (`buildCategoryTotals`, `buildTopMerchants`, `detectRecurringCharges`, `buildMonthlyTrend`), so the input, the prompt and the validator all agree on one value.

**Rounding at the boundary rather than loosening the validator** is deliberate: an epsilon comparison would also widen the window for a hallucinated amount to slip through. This keeps ADR-0001's guarantee exact, and the displayed number is now identical to the one the model reasoned over.

## TDD Evidence

### RED
```
→ expected -940 to be 60                    (prior period)
→ expected false to be true   × 3           (category totals / merchants / trend not rounded)
```

### GREEN
`priorPeriodOf` → `getUtcMonthPeriod(period.start, -1)`; a `round2` helper applied to every monetary field leaving `insight-data.ts`.

### REFACTOR
Both fixes carry a comment explaining *why*, since both look like harmless arithmetic and the next reader will otherwise "simplify" them back.

## Tests
- March's prior period is February only — a Jan 31 charge does not contribute
- January's prior period is December of the previous year
- category totals, deltas, percentages, merchant totals, and trend income/expense are all rounded to 2dp
- **round trip:** a real `buildInsightInput` over 50000 UYU at 40.5 yields exactly `1234.57`, and an insight echoing `1234.57` is **retained** — this is the actual user-visible fix, not just the internal rounding
- **anti-hallucination unchanged:** an amount not present in the input is still dropped

## Verification
`npm run ci:check` passes — 76 test files, **827 tests**, lint clean, build succeeds.

## Related, deliberately not touched
#59 (recurring-charge detection groups by raw bank description and disqualifies a subscription on one outlier) is in the same file but is tagged `needs-human-review` — the fix changes *which* charges the user is told are subscriptions, which is a product judgment, not a refactor.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation