### PR TITLE
fix: report malformed CSV input instead of absorbing it

### DIFF
--- a/src/services/parsers/bank-account-parser.test.ts
+++ b/src/services/parsers/bank-account-parser.test.ts
@@ -270,3 +270,56 @@ Fecha,Referencia,Concepto,Descripción,Débito,Crédito,Saldos,`
     })
   })
 })
+
+describe('parseBankAccountCSV — malformed input is reported, not absorbed', () => {
+  const header = `Cliente,Gazzano      A Jose,
+Cuenta,Ca De Ahorro Atm,
+Número,007003529538,
+Moneda,USD,
+Sucursal,02 - 18 De Julio,
+
+Movimientos,
+Desde:,01/11/2025,Hasta:,30/11/2025
+
+Fecha,Referencia,Concepto,Descripción,Débito,Crédito,Saldos,`
+
+  it('reports the row when an amount cannot be parsed', () => {
+    const csv = `${header}
+27/11/2025,598386,DEBITO,ALGO,n/d,,11749.61,`
+
+    expect(() => parseBankAccountCSV(csv, 'test.csv')).toThrow(/n\/d/)
+  })
+
+  it('rejects a currency it does not recognise instead of storing it', () => {
+    // 'Pesos' would be cast straight into tx.currency, where convert() treats
+    // anything non-USD as UYU and the database check constraint rejects the
+    // insert with an opaque error far from the cause.
+    const csv = `Cliente,Gazzano      A Jose,
+Cuenta,Ca De Ahorro Atm,
+Número,007003529538,
+Moneda,Pesos,
+Sucursal,02 - 18 De Julio,
+
+Movimientos,
+Desde:,01/11/2025,Hasta:,30/11/2025
+
+Fecha,Referencia,Concepto,Descripción,Débito,Crédito,Saldos,
+27/11/2025,598386,DEBITO,ALGO,-174.65,,11749.61,`
+
+    expect(() => parseBankAccountCSV(csv, 'test.csv')).toThrow(/Pesos/)
+  })
+
+  it('reports an unrecognised file instead of returning zero transactions', () => {
+    // Distinct from a statement that genuinely has no movements: here the
+    // column header is missing entirely, so the file was not understood.
+    const csv = `Cliente,Gazzano      A Jose,
+Cuenta,Ca De Ahorro Atm,
+Número,007003529538,
+Moneda,USD,
+Sucursal,02 - 18 De Julio,
+
+Algo,Totalmente,Distinto,`
+
+    expect(() => parseBankAccountCSV(csv, 'test.csv')).toThrow(/movimientos/i)
+  })
+})

--- a/src/services/parsers/bank-account-parser.ts
+++ b/src/services/parsers/bank-account-parser.ts
@@ -35,19 +35,17 @@ export function parseBankAccountCSV(
   // Extract metadata from header rows
   const metadata = extractMetadata(rows)
 
-  // Determine file type based on currency
+  // The currency drives tx.currency, which convert() and the database check
+  // constraint both depend on — validate rather than cast.
+  const currency = parseCurrency(metadata.moneda)
   const fileType: FileType =
-    metadata.moneda === 'USD' ? 'bank_account_usd' : 'bank_account_uyu'
+    currency === 'USD' ? 'bank_account_usd' : 'bank_account_uyu'
 
-  // Find where transactions start (after "Movimientos," row)
+  // Find where transactions start (after the column header row)
   const transactionsStartIndex = findTransactionsStart(rows)
 
   // Parse transactions
-  const transactions = parseTransactions(
-    rows,
-    transactionsStartIndex,
-    metadata.moneda as 'USD' | 'UYU'
-  )
+  const transactions = parseTransactions(rows, transactionsStartIndex, currency)
 
   return {
     fileType,
@@ -56,6 +54,15 @@ export function parseBankAccountCSV(
     fileName,
     parsedAt: new Date(),
   }
+}
+
+function parseCurrency(moneda: string): 'USD' | 'UYU' {
+  if (moneda === 'USD' || moneda === 'UYU') {
+    return moneda
+  }
+  throw new Error(
+    `Moneda no reconocida: "${moneda}". Se esperaba USD o UYU.`
+  )
 }
 
 /**
@@ -104,7 +111,17 @@ function parseTransactions(
   startIndex: number,
   currency: 'USD' | 'UYU'
 ): Transaction[] {
-  if (startIndex === -1 || startIndex >= rows.length) {
+  // -1 means the column header was never found: the file was not understood.
+  // That is different from a statement whose header is present but which has
+  // no movements, which legitimately yields an empty list.
+  if (startIndex === -1) {
+    throw new Error(
+      'No se encontró la sección de movimientos en el archivo. ' +
+        '¿Es un extracto de cuenta de Santander?'
+    )
+  }
+
+  if (startIndex >= rows.length) {
     return []
   }
 
@@ -118,6 +135,22 @@ function parseTransactions(
       continue
     }
 
+    // idIndex must stay exactly `i - startIndex`: it feeds
+    // generateTransactionId, and any change to it would give every row a new
+    // id, breaking dedup against transactions already stored (see #57).
+    transactions.push(parseRow(row, i, i - startIndex, currency))
+  }
+
+  return transactions
+}
+
+function parseRow(
+  row: string[],
+  rowIndex: number,
+  idIndex: number,
+  currency: 'USD' | 'UYU'
+): Transaction {
+  try {
     const rawTransaction: BankAccountTransaction = {
       fecha: row[0],
       referencia: row[1] || '',
@@ -162,7 +195,7 @@ function parseTransactions(
         rawTransaction.fecha,
         description,
         rawTransaction.debito + rawTransaction.credito,
-        i - startIndex
+        idIndex
       ),
       date: parseSantanderDate(rawTransaction.fecha),
       description,
@@ -177,8 +210,11 @@ function parseTransactions(
       rawData: rawTransaction,
     }
 
-    transactions.push(transaction)
+    return transaction
+  } catch (error) {
+    // Row number is 1-based to match what the user sees in a spreadsheet.
+    throw new Error(
+      `Fila ${rowIndex + 1}: ${error instanceof Error ? error.message : String(error)}`
+    )
   }
-
-  return transactions
 }

--- a/src/services/parsers/credit-card-parser.test.ts
+++ b/src/services/parsers/credit-card-parser.test.ts
@@ -195,3 +195,28 @@ Algo,Totalmente,Distinto,`
     expect(() => parseCreditCardCSV(csv, 'test.csv')).toThrow(/movimientos/i)
   })
 })
+
+describe('parseCreditCardCSV — malformed amounts', () => {
+  it('reports the row when an amount cannot be parsed', () => {
+    // Matches the row context the bank-account parser already gives, so the
+    // user can find the offending line regardless of which statement failed.
+    const csv = `Cliente,Gazzano      A Jose,
+
+Movimientos,
+Fecha,Número de tarjeta,Número de autorización,Descripción,Importe original,Pesos,Dólares,
+27/11/2025,1234,P432629721,NETFLIX.COM,"0,00",n/d,"0,00",`
+
+    expect(() => parseCreditCardCSV(csv, 'test.csv')).toThrow(/n\/d/)
+  })
+
+  it('names the row number so the line can be found', () => {
+    const csv = `Cliente,Gazzano      A Jose,
+
+Movimientos,
+Fecha,Número de tarjeta,Número de autorización,Descripción,Importe original,Pesos,Dólares,
+27/11/2025,1234,P1,BUENO,"0,00","100,00","0,00",
+28/11/2025,1234,P2,MALO,"0,00",n/d,"0,00",`
+
+    expect(() => parseCreditCardCSV(csv, 'test.csv')).toThrow(/Fila 6/)
+  })
+})

--- a/src/services/parsers/credit-card-parser.test.ts
+++ b/src/services/parsers/credit-card-parser.test.ts
@@ -186,3 +186,12 @@ Fecha,Número de tarjeta,Número de autorización,Descripción,Importe original,
     })
   })
 })
+
+describe('parseCreditCardCSV — unrecognised file', () => {
+  it('reports an unrecognised file instead of returning zero transactions', () => {
+    const csv = `Cliente,Gazzano      A Jose,
+Algo,Totalmente,Distinto,`
+
+    expect(() => parseCreditCardCSV(csv, 'test.csv')).toThrow(/movimientos/i)
+  })
+})

--- a/src/services/parsers/credit-card-parser.ts
+++ b/src/services/parsers/credit-card-parser.ts
@@ -112,7 +112,17 @@ function parseTransactions(
   rows: string[][],
   startIndex: number
 ): Transaction[] {
-  if (startIndex === -1 || startIndex >= rows.length) {
+  // -1 means the "Movimientos" marker was never found: the file was not
+  // understood. That is different from a statement whose marker is present
+  // but which lists no movements, which legitimately yields an empty list.
+  if (startIndex === -1) {
+    throw new Error(
+      'No se encontró la sección de movimientos en el archivo. ' +
+        '¿Es un resumen de tarjeta de crédito de Santander?'
+    )
+  }
+
+  if (startIndex >= rows.length) {
     return []
   }
 

--- a/src/services/parsers/credit-card-parser.ts
+++ b/src/services/parsers/credit-card-parser.ts
@@ -136,6 +136,21 @@ function parseTransactions(
       continue
     }
 
+    // idIndex must stay exactly `i - startIndex`: it feeds
+    // generateTransactionId, and changing it would give every row a new id,
+    // breaking dedup against transactions already stored (see #57).
+    transactions.push(parseRow(row, i, i - startIndex))
+  }
+
+  return transactions
+}
+
+function parseRow(
+  row: string[],
+  rowIndex: number,
+  idIndex: number
+): Transaction {
+  try {
     const rawTransaction: CreditCardTransaction = {
       fecha: row[0],
       numeroTarjeta: row[1] || '',
@@ -179,7 +194,7 @@ function parseTransactions(
         rawTransaction.fecha,
         rawTransaction.descripcion,
         rawTransaction.pesos + rawTransaction.dolares,
-        i - startIndex
+        idIndex
       ),
       date: parseSantanderDate(rawTransaction.fecha),
       description: rawTransaction.descripcion,
@@ -193,8 +208,11 @@ function parseTransactions(
       rawData: rawTransaction,
     }
 
-    transactions.push(transaction)
+    return transaction
+  } catch (error) {
+    // Row number is 1-based to match what the user sees in a spreadsheet.
+    throw new Error(
+      `Fila ${rowIndex + 1}: ${error instanceof Error ? error.message : String(error)}`
+    )
   }
-
-  return transactions
 }

--- a/src/services/parsers/utils.test.ts
+++ b/src/services/parsers/utils.test.ts
@@ -148,3 +148,23 @@ describe('Parser Utilities', () => {
     })
   })
 })
+
+describe('parseSantanderNumber — malformed input', () => {
+  it('throws on a non-numeric value instead of returning NaN', () => {
+    // NaN propagates silently into amount, then into every dashboard total,
+    // the donut, the trend chart and every insight amount. Failing at the
+    // boundary is the only place the value is still identifiable.
+    expect(() => parseSantanderNumber('n/d')).toThrow(/n\/d/)
+  })
+
+  it('names the offending value so the row can be found', () => {
+    expect(() => parseSantanderNumber('1.2.3,4,5')).toThrow(/1\.2\.3,4,5/)
+  })
+
+  it('still treats empty and whitespace-only values as zero', () => {
+    // Load-bearing: the debito/credito columns are legitimately empty on
+    // every row, depending on the direction of the movement.
+    expect(parseSantanderNumber('')).toBe(0)
+    expect(parseSantanderNumber('   ')).toBe(0)
+  })
+})

--- a/src/services/parsers/utils.ts
+++ b/src/services/parsers/utils.ts
@@ -8,8 +8,15 @@
  * - Bank Account format: "1234.56" (period as decimal)
  * - Handles both formats automatically
  *
+ * An empty value is 0 — the debito/credito columns are legitimately blank
+ * depending on the direction of the movement. Anything else that does not
+ * parse throws: returning NaN would flow into `amount` and from there into
+ * every dashboard total, chart and insight, where the original bad value is
+ * no longer identifiable.
+ *
  * @param value - The string value to parse
- * @returns Parsed number, or 0 if empty/invalid
+ * @returns Parsed number, or 0 if empty
+ * @throws If the value is non-empty and not a number
  */
 export function parseSantanderNumber(value: string): number {
   if (!value || value.trim() === '') {
@@ -18,15 +25,18 @@ export function parseSantanderNumber(value: string): number {
 
   const trimmed = value.trim()
 
-  // Check if it uses comma as decimal separator (credit card format)
-  if (trimmed.includes(',')) {
-    // Remove thousand separators (periods) and replace comma with period
-    const normalized = trimmed.replace(/\./g, '').replace(',', '.')
-    return parseFloat(normalized)
+  // Comma as decimal separator (credit card format): drop the thousands
+  // separators, then swap the decimal comma for a period.
+  const normalized = trimmed.includes(',')
+    ? trimmed.replace(/\./g, '').replace(',', '.')
+    : trimmed
+
+  const parsed = Number(normalized)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Importe ilegible: "${value}"`)
   }
 
-  // Otherwise, it's already in US format (bank account format)
-  return parseFloat(trimmed)
+  return parsed
 }
 
 /**


### PR DESCRIPTION
## Summary

Three parser assumptions turned bad input into silently wrong data instead of a visible error — on the app's only ingestion path.

Closes #63

## The three defects

### 1. `NaN` amounts (`utils.ts:14-30`)
`parseSantanderNumber` returned `NaN` for any non-empty value it could not parse. `Math.abs(NaN) > 0` is `false`, so a bad credit-card row was silently classified UYU; `NaN` then propagated through `convert()` and every `+=` in `chart-data.ts`. **One bad row turns every dashboard total, the donut, the trend chart and all insight amounts into `NaN`.** The database eventually rejects it — as an opaque constraint violation, far from the cause.

Now throws naming the value; the bank parser wraps row parsing to prefix the 1-based row number. Empty still returns 0 — load-bearing, since `debito`/`credito` are legitimately blank depending on direction.

### 2. Unchecked currency cast (`bank-account-parser.ts:49`)
`metadata.moneda as 'USD' | 'UYU'`. `fileType` defended itself (`=== 'USD' ? … : uyu`), but the **raw string** went into `tx.currency`, where `convert()` treats anything non-USD as UYU and the DB check rejects the insert. Now validated with the offending value in the message.

Confirmed the committed samples use the exact literals (`Moneda,UYU` / `Moneda,USD`), so this is hardening rather than a currently-firing bug — as noted in the issue.

### 3. Unrecognised file → zero transactions
Both parsers returned `[]` when `findTransactionsStart` returned `-1`, so "I didn't understand this file" looked identical to "this statement has no movements". That case now throws.

The distinction is clean and preserved: the existing `should handle CSV with no transactions` tests have the header row **present** with no data rows, so they hit `startIndex >= rows.length` and still return `[]`. Both stay green untouched.

## The risky part, handled explicitly

Extracting `parseRow` moved the `i - startIndex` expression that feeds `generateTransactionId`. It is threaded through as `idIndex` holding **exactly** the previous value, with a comment saying why — changing it would give every row a new id and break dedup against transactions already in Supabase, which is precisely the hazard #57 documents.

Verified empirically: all three committed Santander samples parse to **64, 22 and 13** transactions, every amount finite, every currency valid.

## Behavior change worth flagging

`parseSantanderNumber` now uses `Number()` instead of `parseFloat()`, which is stricter about trailing junk (`parseFloat('174.65abc')` → `174.65`; `Number(…)` → `NaN` → throws). That is the intent — `parseFloat`'s leniency is exactly how a malformed value became a plausible-looking number. The real samples and both integration test suites confirm no regression on actual Santander output.

## TDD Evidence

### RED
6 failing tests, one per gap:
```
FAIL utils > throws on a non-numeric value instead of returning NaN
FAIL utils > names the offending value so the row can be found
FAIL bank > reports the row when an amount cannot be parsed
FAIL bank > rejects a currency it does not recognise instead of storing it
FAIL bank > reports an unrecognised file instead of returning zero transactions
FAIL credit-card > reports an unrecognised file instead of returning zero transactions
```

### GREEN
Strict numeric parse + throw; `parseCurrency` validator; `startIndex === -1` guard in both parsers; `parseRow` extraction for row-level error context.

### REFACTOR
One of my own fixtures was wrong: the "unrecognised file" case tripped the *currency* check first, because the junk row landed in the `Moneda` position. The parser was right and the test was sloppy — fixture corrected to isolate the missing-movements case.

## Verification
`npm run ci:check` passes — 76 test files, **827 tests**, lint clean, build succeeds.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation