### PR TITLE
perf: short-circuit transaction search and stabilise derived arrays

### DIFF
--- a/src/hooks/useTransactionFiltering.test.ts
+++ b/src/hooks/useTransactionFiltering.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import type { Transaction } from '../models'
+import { useTransactionFiltering } from './useTransactionFiltering'
+
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
+  return {
+    id,
+    date: new Date('2026-03-15T00:00:00.000Z'),
+    description: `TX ${id}`,
+    amount: 100,
+    currency: 'USD',
+    type: 'debit',
+    source: 'bank_account',
+    category: 'groceries',
+    rawData: {},
+    ...overrides,
+  }
+}
+
+function setup(transactions: Transaction[]) {
+  return renderHook(() => useTransactionFiltering({ transactions }))
+}
+
+describe('useTransactionFiltering — search', () => {
+  const transactions = [
+    makeTransaction('a', { description: 'FARMACIA SAN ROQUE' }),
+    makeTransaction('b', { description: 'SUPERMERCADO DISCO' }),
+    makeTransaction('c', {
+      description: 'PAGO VARIOS',
+      displayDescription: 'Farmashop',
+    }),
+    makeTransaction('d', { description: 'OTRA COSA', tags: ['farmacia-mes'] }),
+  ]
+
+  it('returns everything when the search box is empty', () => {
+    const { result } = setup(transactions)
+    expect(result.current.filteredTransactions).toHaveLength(4)
+  })
+
+  it('matches the raw description, case-insensitively', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setSearchTerm('farmacia san'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual(['a'])
+  })
+
+  it('matches the friendly display description', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setSearchTerm('farmashop'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual(['c'])
+  })
+
+  it('matches tags', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setSearchTerm('farmacia-mes'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual(['d'])
+  })
+
+  it('returns nothing when nothing matches', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setSearchTerm('zzzz'))
+    expect(result.current.filteredTransactions).toHaveLength(0)
+  })
+})
+
+describe('useTransactionFiltering — filters', () => {
+  const transactions = [
+    makeTransaction('usd-debit', { currency: 'USD', type: 'debit' }),
+    makeTransaction('uyu-debit', { currency: 'UYU', type: 'debit' }),
+    makeTransaction('usd-credit', { currency: 'USD', type: 'credit' }),
+    makeTransaction('card', { source: 'credit_card' }),
+    makeTransaction('restaurant', { category: 'restaurants' }),
+  ]
+
+  it('filters by currency', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setCurrencyFilter('UYU'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'uyu-debit',
+    ])
+  })
+
+  it('filters by type', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setTypeFilter('credit'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'usd-credit',
+    ])
+  })
+
+  it('filters by account source', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setAccountFilters(['credit_card']))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'card',
+    ])
+  })
+
+  it('filters by category', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setCategoryFilters(['restaurants']))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'restaurant',
+    ])
+  })
+
+  it('clears every filter at once', () => {
+    const { result } = setup(transactions)
+    act(() => {
+      result.current.setCurrencyFilter('UYU')
+      result.current.setSearchTerm('nope')
+    })
+    expect(result.current.hasActiveFilters).toBe(true)
+
+    act(() => result.current.clearAllFilters())
+    expect(result.current.hasActiveFilters).toBe(false)
+    expect(result.current.filteredTransactions).toHaveLength(
+      transactions.length
+    )
+  })
+})
+
+describe('useTransactionFiltering — amount and date ranges', () => {
+  const transactions = [
+    makeTransaction('cheap', { amount: 10 }),
+    makeTransaction('mid', { amount: 100 }),
+    makeTransaction('pricey', { amount: 1000 }),
+    makeTransaction('old', { date: new Date('2026-01-05T00:00:00.000Z') }),
+  ]
+
+  it('applies an inclusive minimum amount', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setMinAmount('100'))
+    expect(result.current.filteredTransactions.map((t) => t.id).sort()).toEqual(
+      ['mid', 'old', 'pricey']
+    )
+  })
+
+  it('applies an inclusive maximum amount', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setMaxAmount('100'))
+    expect(result.current.filteredTransactions.map((t) => t.id).sort()).toEqual(
+      ['cheap', 'mid', 'old']
+    )
+  })
+
+  it('filters by a date range', () => {
+    const { result } = setup(transactions)
+    act(() => {
+      result.current.setDateFromFilter('2026-03-01')
+      result.current.setDateToFilter('2026-03-31')
+    })
+    expect(result.current.filteredTransactions.map((t) => t.id)).not.toContain(
+      'old'
+    )
+  })
+
+  it('ignores an inverted date range rather than returning nothing', () => {
+    const { result } = setup(transactions)
+    act(() => {
+      result.current.setDateFromFilter('2026-12-31')
+      result.current.setDateToFilter('2026-01-01')
+    })
+    expect(result.current.filteredTransactions).toHaveLength(
+      transactions.length
+    )
+  })
+})
+
+describe('useTransactionFiltering — sorting', () => {
+  const transactions = [
+    makeTransaction('b', {
+      amount: 200,
+      date: new Date('2026-03-02T00:00:00.000Z'),
+    }),
+    makeTransaction('a', {
+      amount: 100,
+      date: new Date('2026-03-01T00:00:00.000Z'),
+    }),
+    makeTransaction('c', {
+      amount: 300,
+      date: new Date('2026-03-03T00:00:00.000Z'),
+    }),
+  ]
+
+  it('sorts by date descending by default', () => {
+    const { result } = setup(transactions)
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'c',
+      'b',
+      'a',
+    ])
+  })
+
+  it('toggles direction when the same field is sorted twice', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.handleSort('amount'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'c',
+      'b',
+      'a',
+    ])
+
+    act(() => result.current.handleSort('amount'))
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+})
+
+describe('useTransactionFiltering — pagination', () => {
+  const transactions = Array.from({ length: 30 }, (_, i) =>
+    makeTransaction(`tx-${String(i).padStart(2, '0')}`, {
+      date: new Date(Date.UTC(2026, 2, i + 1)),
+    })
+  )
+
+  it('paginates into pages of 12', () => {
+    const { result } = setup(transactions)
+    expect(result.current.paginatedTransactions).toHaveLength(12)
+    expect(result.current.totalPages).toBe(3)
+  })
+
+  it('returns the remainder on the last page', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setCurrentPage(3))
+    expect(result.current.paginatedTransactions).toHaveLength(6)
+  })
+
+  it('exposes ids for the current page and for the whole filtered set', () => {
+    const { result } = setup(transactions)
+    expect(result.current.paginatedTransactionIds).toHaveLength(12)
+    expect(result.current.filteredTransactionIds).toHaveLength(30)
+  })
+
+  it('clamps the current page when filtering shrinks the result set', () => {
+    const { result } = setup(transactions)
+    act(() => result.current.setCurrentPage(3))
+    expect(result.current.currentPage).toBe(3)
+
+    act(() => result.current.setSearchTerm('tx-00'))
+    expect(result.current.currentPage).toBe(1)
+    expect(result.current.paginatedTransactions).toHaveLength(1)
+  })
+})
+
+describe('useTransactionFiltering — derived array identity', () => {
+  // These arrays are handed to memoized children. Recreating them on every
+  // render defeats that memoization entirely, so identity is behavior here.
+  const transactions = Array.from({ length: 20 }, (_, i) =>
+    makeTransaction(`tx-${i}`)
+  )
+
+  it('keeps paginated results stable across a re-render with no input change', () => {
+    const { result, rerender } = setup(transactions)
+
+    const before = result.current.paginatedTransactions
+    const beforeIds = result.current.paginatedTransactionIds
+    const beforeFilteredIds = result.current.filteredTransactionIds
+
+    rerender()
+
+    expect(result.current.paginatedTransactions).toBe(before)
+    expect(result.current.paginatedTransactionIds).toBe(beforeIds)
+    expect(result.current.filteredTransactionIds).toBe(beforeFilteredIds)
+  })
+
+  it('produces new results when the filter actually changes', () => {
+    const { result } = setup(transactions)
+    const before = result.current.paginatedTransactions
+
+    act(() => result.current.setSearchTerm('tx-1'))
+
+    expect(result.current.paginatedTransactions).not.toBe(before)
+  })
+})
+
+describe('useTransactionFiltering — initialFilter', () => {
+  const transactions = [
+    makeTransaction('a', { category: 'groceries', currency: 'USD' }),
+    makeTransaction('b', { category: 'restaurants', currency: 'UYU' }),
+  ]
+
+  it('applies an initial category and currency', () => {
+    const { result } = renderHook(() =>
+      useTransactionFiltering({
+        transactions,
+        initialFilter: { category: 'restaurants', currency: 'UYU' },
+      })
+    )
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual(['b'])
+  })
+
+  it('does not reset a user filter change when the parent re-renders', () => {
+    // A parent passing an inline object literal gives a new identity on every
+    // render; keying the effect on identity would silently undo the user's
+    // own filter edits mid-session.
+    const { result, rerender } = renderHook(
+      ({ category }: { category: string }) =>
+        useTransactionFiltering({
+          transactions,
+          initialFilter: { category, currency: 'UYU' },
+        }),
+      { initialProps: { category: 'restaurants' } }
+    )
+
+    act(() => result.current.setCategoryFilters(['groceries']))
+    expect(result.current.categoryFilters).toEqual(['groceries'])
+
+    rerender({ category: 'restaurants' })
+
+    expect(result.current.categoryFilters).toEqual(['groceries'])
+  })
+})
+
+describe('useTransactionFiltering — split grouping through the hook', () => {
+  // The existing grouping test asserts against a copy of this logic rather
+  // than the hook, so it cannot catch a regression in the hook itself.
+  const transactions = [
+    makeTransaction('parent', { isSplitParent: true }),
+    makeTransaction('other'),
+    makeTransaction('child-1', { splitParentId: 'parent' }),
+    makeTransaction('child-2', { splitParentId: 'parent' }),
+  ]
+
+  it('emits split children directly after their parent', () => {
+    const { result } = setup(transactions)
+    const ids = result.current.paginatedTransactions.map((t) => t.id)
+
+    expect(ids.indexOf('child-1')).toBe(ids.indexOf('parent') + 1)
+    expect(ids.indexOf('child-2')).toBe(ids.indexOf('parent') + 2)
+  })
+
+  it('emits every transaction exactly once', () => {
+    const { result } = setup(transactions)
+    const ids = result.current.paginatedTransactions.map((t) => t.id)
+
+    expect(ids).toHaveLength(4)
+    expect(new Set(ids).size).toBe(4)
+  })
+})

--- a/src/hooks/useTransactionFiltering.ts
+++ b/src/hooks/useTransactionFiltering.ts
@@ -37,15 +37,23 @@ export function useTransactionFiltering({
     return new Date(Math.max(...transactions.map((tx) => tx.date.getTime())))
   }, [transactions])
 
+  // Keyed on the filter's primitive fields, not the object identity. A caller
+  // passing an inline object literal gives a new identity on every render,
+  // which would re-run this effect every render and re-set state with fresh
+  // array literals — an unbounded render loop, and a silent undo of any
+  // filter the user changed in the meantime.
+  const initialCategory = initialFilter?.category
+  const initialAccountType = initialFilter?.accountType
+  const initialCurrency = initialFilter?.currency
+
   useEffect(() => {
-    if (initialFilter) {
-      if (initialFilter.category) setCategoryFilters([initialFilter.category])
-      if (initialFilter.accountType && initialFilter.accountType !== 'all') {
-        setAccountFilters([initialFilter.accountType])
-      }
-      setCurrencyFilter(initialFilter.currency ?? 'all')
+    if (!initialCategory && !initialAccountType && !initialCurrency) return
+    if (initialCategory) setCategoryFilters([initialCategory])
+    if (initialAccountType && initialAccountType !== 'all') {
+      setAccountFilters([initialAccountType])
     }
-  }, [initialFilter])
+    setCurrencyFilter(initialCurrency ?? 'all')
+  }, [initialCategory, initialAccountType, initialCurrency])
 
   const [sortField, setSortField] = useState<SortField>('date')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
@@ -64,10 +72,12 @@ export function useTransactionFiltering({
         ? new Date(`${dateToFilter}T23:59:59.999`)
         : null
 
+    // Cheap field comparisons run before the search-string build, and the
+    // build is skipped entirely when there is no query. Previously every
+    // transaction paid for a template literal + toLowerCase on every
+    // keystroke — and on every render with an empty search box, where the
+    // resulting `includes('')` was always true anyway.
     const filtered = transactions.filter((transaction) => {
-      const searchable =
-        `${getDisplayDescription(transaction)} ${transaction.description} ${(transaction.tags ?? []).join(' ')}`.toLowerCase()
-      if (!searchable.includes(query)) return false
       if (dateFrom && transaction.date < dateFrom) return false
       if (dateTo && transaction.date > dateTo) return false
       if (
@@ -87,7 +97,12 @@ export function useTransactionFiltering({
         return false
       if (maxAmount && Math.abs(transaction.amount) > parseFloat(maxAmount))
         return false
-      return true
+
+      if (!query) return true
+
+      const searchable =
+        `${getDisplayDescription(transaction)} ${transaction.description} ${(transaction.tags ?? []).join(' ')}`.toLowerCase()
+      return searchable.includes(query)
     })
 
     filtered.sort((a, b) => {
@@ -232,12 +247,23 @@ export function useTransactionFiltering({
   }, [safeTotalPages])
 
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE
-  const paginatedTransactions = groupedTransactions.slice(
-    startIndex,
-    startIndex + ITEMS_PER_PAGE
+
+  // These three are handed to memoized children, so a fresh array identity on
+  // every render defeats that memoization entirely — identity is behavior
+  // here, not a micro-optimization. filteredTransactionIds in particular
+  // re-mapped the whole filtered set, not just the visible page.
+  const paginatedTransactions = useMemo(
+    () => groupedTransactions.slice(startIndex, startIndex + ITEMS_PER_PAGE),
+    [groupedTransactions, startIndex]
   )
-  const paginatedTransactionIds = paginatedTransactions.map((tx) => tx.id)
-  const filteredTransactionIds = groupedTransactions.map((tx) => tx.id)
+  const paginatedTransactionIds = useMemo(
+    () => paginatedTransactions.map((tx) => tx.id),
+    [paginatedTransactions]
+  )
+  const filteredTransactionIds = useMemo(
+    () => groupedTransactions.map((tx) => tx.id),
+    [groupedTransactions]
+  )
 
   return {
     searchTerm,


### PR DESCRIPTION
## Summary

Three changes to `useTransactionFiltering`, plus the behavior coverage the hook was missing.

Closes #56

## 1. The search string was built even with an empty search box

The predicate built a template literal and lowercased it **for every transaction on every evaluation** — including when there is no query, where the resulting `includes('')` is always `true` and the work is entirely wasted. Cheap field comparisons now run first, and the string build is skipped when there is no query.

Measured over 5,000 transactions:

| Case | Before | After |
|---|---|---|
| **Empty search box** (every render, every non-search interaction) | 0.60 ms | **0.05 ms** (~12×) |
| Active search term (per keystroke) | 0.65 ms | 0.65 ms (unchanged) |

## 2. Derived arrays had a fresh identity on every render

`paginatedTransactions`, `paginatedTransactionIds` and `filteredTransactionIds` sat outside `useMemo`, so every render produced new arrays and defeated memoization in every child they are passed to. `filteredTransactionIds` re-mapped the **entire** filtered set, not just the visible page. All three are memoized, with a test asserting identity is stable across a no-op re-render and *does* change when the filter changes.

## 3. The `initialFilter` effect was worse than I filed it

The issue described this as "resets the user's filters". It is actually an **unbounded synchronous render loop**: a new object identity re-runs the effect, which calls `setCategoryFilters([...])` with a fresh array literal, which re-renders, which re-runs the effect.

I found this the hard way — writing the test hung the test runner outright rather than failing, twice, until I killed it. That is the RED for this one; there is no clean assertion failure to show.

**Production is safe today**: `App.tsx:420` passes `pendingTxFilter`, which is React state, so its identity is stable. The loop is latent and fires only if a caller passes an inline object literal — a completely ordinary thing to do. The effect is now keyed on the filter's primitive fields, which removes the hazard and makes the hook safe either way.

## Correcting my own issue

#56 claimed typing would be "visibly laggy and characters drop". The measurement does not support that — 0.65 ms per pass over 5,000 transactions is fine, and it is unchanged by this PR. **Debouncing (item 3 of the issue's fix list) is deliberately not implemented**: it changes observable timing, and the numbers do not justify the cost. The real wins here are the empty-search short-circuit and the memoization.

## Test coverage

The hook had only `useTransactionFiltering.grouping.test.ts`, which asserts against a **local copy** of the grouping logic rather than the hook — it cannot catch a regression in the hook itself. Added `useTransactionFiltering.test.ts` with 26 cases exercising the real hook: search (raw description, friendly description, tags, no-match), each filter dimension, clear-all, amount and date ranges including an inverted range, sort default and toggle, pagination including page clamping when filtering shrinks the set, derived-array identity, `initialFilter` application and non-clobbering, and split grouping **through the hook**.

Left the old grouping file in place — deleting it belongs with the broader test cleanup, not a perf PR.

## Verification
`npm run ci:check` passes — 77 test files, **846 tests**, lint clean, build succeeds.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation