### PR TITLE
fix: clear displayDescription remotely on a matching-scope edit, and cover the mutation paths

### DIFF
--- a/src/components/ImportCSV.test.tsx
+++ b/src/components/ImportCSV.test.tsx
@@ -291,4 +291,28 @@ describe('ImportCSV', () => {
     expect(await screen.findByText('Importación completada')).toBeInTheDocument()
     expect(toastMock.warning).not.toHaveBeenCalled()
   })
+
+  it('says the AI run was incomplete, not unavailable, on a partial failure', async () => {
+    // "no disponible" would be plainly wrong when 10 of 12 batches enriched.
+    parseCSVMock.mockReturnValue(makeParsedData())
+    const onTransactionsImported = vi.fn().mockResolvedValue({
+      added: [makeTx('tx-1')],
+      duplicates: [],
+      aiPartial: '2 de 12 lotes fallaron: 529 overloaded',
+    })
+
+    render(<ImportCSV onTransactionsImported={onTransactionsImported} />)
+
+    fireEvent.change(screen.getByLabelText('Seleccionar archivo'), {
+      target: {
+        files: [new File(['a,b'], 'movements.csv', { type: 'text/csv' })],
+      },
+    })
+
+    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    await waitFor(() => expect(toastMock.warning).toHaveBeenCalledTimes(1))
+    const message = toastMock.warning.mock.calls[0][0] as string
+    expect(message).toContain('incompleta')
+    expect(message).not.toContain('no disponible')
+  })
 })

--- a/src/components/ImportCSV.tsx
+++ b/src/components/ImportCSV.tsx
@@ -28,7 +28,10 @@ interface ImportCSVProps {
      * Set when the import succeeded but AI enrichment did not, so the user can
      * tell a dead API key apart from the model categorizing badly.
      */
+    /** Enrichment did not run at all. */
     aiError?: string;
+    /** Enrichment ran but some batches failed; the rest were applied. */
+    aiPartial?: string;
   }>;
 }
 
@@ -104,7 +107,7 @@ export function ImportCSV({
         setFileType('uyu_account');
       }
 
-      const { added, duplicates, aiError } = onTransactionsImported
+      const { added, duplicates, aiError, aiPartial } = onTransactionsImported
         ? await onTransactionsImported(result.transactions, {
             parsedData: result,
             csvContent,
@@ -114,6 +117,7 @@ export function ImportCSV({
             ...transactionStore.getState().addTransactions(result.transactions),
             // Local-only path never runs AI enrichment.
             aiError: undefined as string | undefined,
+            aiPartial: undefined as string | undefined,
           };
 
       setImportSummary({
@@ -128,10 +132,16 @@ export function ImportCSV({
       );
 
       // The import succeeded, but the AI step did not — say so, otherwise a
-      // dead API key looks identical to poor categorization.
+      // dead API key looks identical to poor categorization. Total failure
+      // and partial failure need different wording: telling the user "no
+      // disponible" when 10 of 12 batches did enrich is simply wrong.
       if (aiError) {
         toast.warning(
           `Categorización con IA no disponible: ${aiError}. Se usaron las reglas de categorización.`
+        );
+      } else if (aiPartial) {
+        toast.warning(
+          `Categorización con IA incompleta: ${aiPartial}. El resto se categorizó con reglas.`
         );
       }
 

--- a/src/hooks/useTransactionHandlers.test.ts
+++ b/src/hooks/useTransactionHandlers.test.ts
@@ -220,7 +220,10 @@ describe('useTransactionHandlers — import with AI enrichment', () => {
     )
 
     expect(outcome.added).toHaveLength(1)
-    expect(outcome.aiError).toContain('529 overloaded')
+    // Partial failure is distinct from total failure: the caller must be able
+    // to tell the user that most rows *were* enriched.
+    expect(outcome.aiPartial).toContain('529 overloaded')
+    expect(outcome.aiError).toBeUndefined()
   })
 })
 
@@ -312,7 +315,7 @@ describe('useTransactionHandlers — apply scope', () => {
       )
     })
 
-    it('asks the remote layer to clear displayDescription, matching the local store', async () => {
+    it('clears displayDescription on both sides when the user renames', async () => {
       // The local store sets displayDescription to undefined on every matching
       // row. Passing `undefined` to the remote layer means the column is
       // omitted from the payload entirely and the old value survives, so the
@@ -320,6 +323,7 @@ describe('useTransactionHandlers — apply scope', () => {
       const { handlers } = setup()
 
       await handlers.handleUpdateTransaction('same-1', {
+        displayDescription: 'Disco',
         category: 'restaurants',
         applyScope: 'matching_past_and_future',
       })
@@ -332,6 +336,34 @@ describe('useTransactionHandlers — apply scope', () => {
       for (const update of displayUpdates) {
         expect(update.displayDescription).toBeNull()
       }
+    })
+
+    it('does not touch displayDescription when only the category changed', async () => {
+      // Regression guard. Clearing unconditionally destroys per-row friendly
+      // names (an AI-enriched "Tienda Inglesa", say) on every sibling row
+      // when the user only meant to fix a category — and, because the remote
+      // write makes it permanent, the next sync cannot bring them back.
+      transactionStore.getState().setTransactions([
+        makeTransaction('enriched', {
+          description: MERCHANT,
+          displayDescription: 'Tienda Inglesa',
+        }),
+        makeTransaction('plain', { description: MERCHANT }),
+      ])
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('plain', {
+        category: 'restaurants',
+        applyScope: 'matching_past_and_future',
+      })
+
+      const touched = mocks.updateRemoteTransaction.mock.calls
+        .map((call) => call[2])
+        .filter((u) => u && 'displayDescription' in u)
+      expect(touched).toHaveLength(0)
+
+      expect(stored('enriched')?.displayDescription).toBe('Tienda Inglesa')
+      expect(stored('enriched')?.category).toBe('restaurants')
     })
   })
 
@@ -528,5 +560,61 @@ describe('useTransactionHandlers — split and unsplit', () => {
       expect.arrayContaining(['parent_split_0', 'parent_split_1'])
     )
     expect(transactionStore.getState().transactions).toHaveLength(0)
+  })
+})
+
+describe('useTransactionHandlers — resetting a friendly name', () => {
+  const MERCHANT = 'SUPERMERCADO DISCO'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transactionStore.getState().clearTransactions()
+    transactionStore.getState().setTransactions([
+      makeTransaction('tx', {
+        description: MERCHANT,
+        displayDescription: 'Disco',
+      }),
+    ])
+  })
+
+  function remoteDisplayUpdate() {
+    return mocks.updateRemoteTransaction.mock.calls
+      .map((call) => call[2])
+      .find((u) => u && 'displayDescription' in u)
+  }
+
+  it("scope 'single': clearing the name reaches the server, not just the store", async () => {
+    // Passing undefined omits the column, so the server keeps the old name
+    // and it reappears on the next sync while the store shows it cleared.
+    const { handlers } = setup()
+
+    await handlers.handleUpdateTransaction('tx', {
+      displayDescription: MERCHANT,
+      applyScope: 'single',
+    })
+
+    expect(remoteDisplayUpdate()?.displayDescription).toBeNull()
+  })
+
+  it("scope 'future_matching_only': clearing the name reaches the server too", async () => {
+    const { handlers } = setup()
+
+    await handlers.handleUpdateTransaction('tx', {
+      displayDescription: MERCHANT,
+      applyScope: 'future_matching_only',
+    })
+
+    expect(remoteDisplayUpdate()?.displayDescription).toBeNull()
+  })
+
+  it("scope 'single': a real rename is still persisted as the new name", async () => {
+    const { handlers } = setup()
+
+    await handlers.handleUpdateTransaction('tx', {
+      displayDescription: 'Tienda Inglesa',
+      applyScope: 'single',
+    })
+
+    expect(remoteDisplayUpdate()?.displayDescription).toBe('Tienda Inglesa')
   })
 })

--- a/src/hooks/useTransactionHandlers.test.ts
+++ b/src/hooks/useTransactionHandlers.test.ts
@@ -17,6 +17,14 @@ const mocks = vi.hoisted(() => ({
     enabled: true,
     model: 'claude-haiku-4-5',
   })),
+  updateRemoteTransaction: vi.fn<
+    [unknown, string, { displayDescription?: string | null }],
+    Promise<void>
+  >(async () => undefined),
+  setDescriptionOverrideWithSync: vi.fn(async () => undefined),
+  clearDescriptionOverrideWithSync: vi.fn(async () => undefined),
+  setMerchantCategoryOverrideWithSync: vi.fn(async () => undefined),
+  clearMerchantCategoryOverrideWithSync: vi.fn(async () => undefined),
   enrichTransactionsWithAi: vi.fn(
     async (): Promise<{
       results: Map<string, unknown>
@@ -28,7 +36,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../services/supabase/transactions', () => ({
   persistTransactions: mocks.persistTransactions,
   softDeleteTransaction: vi.fn(async () => undefined),
-  updateTransaction: vi.fn(async () => undefined),
+  updateTransaction: mocks.updateRemoteTransaction,
   splitTransaction: vi.fn(async () => undefined),
   unsplitTransaction: vi.fn(async () => undefined),
   hardDeleteTransactions: vi.fn(async () => undefined),
@@ -44,13 +52,13 @@ vi.mock('../services/supabase/import-runs', () => ({
 // Override stores are empty, so nothing is filtered out of AI enrichment.
 vi.mock('../services/categorizer/category-overrides', () => ({
   listMerchantCategoryOverrides: () => ({}),
-  clearMerchantCategoryOverrideWithSync: vi.fn(async () => undefined),
-  setMerchantCategoryOverrideWithSync: vi.fn(async () => undefined),
+  clearMerchantCategoryOverrideWithSync: mocks.clearMerchantCategoryOverrideWithSync,
+  setMerchantCategoryOverrideWithSync: mocks.setMerchantCategoryOverrideWithSync,
   getMerchantCategoryOverride: () => undefined,
 }))
 vi.mock('../services/descriptions/description-overrides', () => ({
-  clearDescriptionOverrideWithSync: vi.fn(async () => undefined),
-  setDescriptionOverrideWithSync: vi.fn(async () => undefined),
+  clearDescriptionOverrideWithSync: mocks.clearDescriptionOverrideWithSync,
+  setDescriptionOverrideWithSync: mocks.setDescriptionOverrideWithSync,
   getDescriptionOverride: () => undefined,
 }))
 
@@ -208,5 +216,191 @@ describe('useTransactionHandlers — import with AI enrichment', () => {
 
     expect(outcome.added).toHaveLength(1)
     expect(outcome.aiError).toContain('529 overloaded')
+  })
+})
+
+describe('useTransactionHandlers — apply scope', () => {
+  const MERCHANT = 'SUPERMERCADO DISCO'
+
+  function seedStore() {
+    transactionStore.getState().setTransactions([
+      makeTransaction('same-1', { description: MERCHANT }),
+      makeTransaction('same-2', { description: MERCHANT }),
+      makeTransaction('other', {
+        description: 'FARMACIA SAN ROQUE',
+        category: 'healthcare',
+      }),
+    ])
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transactionStore.getState().clearTransactions()
+    seedStore()
+  })
+
+  function stored(id: string) {
+    return transactionStore.getState().transactions.find((t) => t.id === id)
+  }
+
+  describe("scope 'single'", () => {
+    it('changes only the target transaction', async () => {
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'single',
+      })
+
+      expect(stored('same-1')?.category).toBe('restaurants')
+      expect(stored('same-2')?.category).toBe('groceries')
+      expect(stored('other')?.category).toBe('healthcare')
+    })
+
+    it('does not write a merchant override', async () => {
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'single',
+      })
+
+      expect(mocks.setMerchantCategoryOverrideWithSync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("scope 'matching_past_and_future'", () => {
+    it('changes every transaction sharing the description', async () => {
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'matching_past_and_future',
+      })
+
+      expect(stored('same-1')?.category).toBe('restaurants')
+      expect(stored('same-2')?.category).toBe('restaurants')
+    })
+
+    it('leaves non-matching transactions alone', async () => {
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'matching_past_and_future',
+      })
+
+      expect(stored('other')?.category).toBe('healthcare')
+    })
+
+    it('records a merchant override so future imports match too', async () => {
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'matching_past_and_future',
+      })
+
+      expect(mocks.setMerchantCategoryOverrideWithSync).toHaveBeenCalledWith(
+        MERCHANT,
+        'restaurants'
+      )
+    })
+
+    it('asks the remote layer to clear displayDescription, matching the local store', async () => {
+      // The local store sets displayDescription to undefined on every matching
+      // row. Passing `undefined` to the remote layer means the column is
+      // omitted from the payload entirely and the old value survives, so the
+      // cleared name reappears on the next sync.
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'matching_past_and_future',
+      })
+
+      const displayUpdates = mocks.updateRemoteTransaction.mock.calls
+        .map((call) => call[2])
+        .filter((u) => u && 'displayDescription' in u)
+
+      expect(displayUpdates.length).toBeGreaterThan(0)
+      for (const update of displayUpdates) {
+        expect(update.displayDescription).toBeNull()
+      }
+    })
+  })
+
+  describe("scope 'future_matching_only'", () => {
+    it('records the override but leaves other existing rows untouched', async () => {
+      const { handlers } = setup()
+
+      await handlers.handleUpdateTransaction('same-1', {
+        category: 'restaurants',
+        applyScope: 'future_matching_only',
+      })
+
+      expect(mocks.setMerchantCategoryOverrideWithSync).toHaveBeenCalledWith(
+        MERCHANT,
+        'restaurants'
+      )
+      expect(stored('same-1')?.category).toBe('restaurants')
+      expect(stored('same-2')?.category).toBe('groceries')
+    })
+  })
+})
+
+describe('useTransactionHandlers — bulk operations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transactionStore.getState().clearTransactions()
+    transactionStore
+      .getState()
+      .setTransactions([
+        makeTransaction('a'),
+        makeTransaction('b'),
+        makeTransaction('c'),
+      ])
+  })
+
+  function stored(id: string) {
+    return transactionStore.getState().transactions.find((t) => t.id === id)
+  }
+
+  it('categorizes only the selected transactions', async () => {
+    const { handlers, setNotice } = setup()
+
+    await handlers.handleBulkCategorizeTransactions(['a', 'b'], 'restaurants')
+
+    expect(stored('a')?.category).toBe('restaurants')
+    expect(stored('b')?.category).toBe('restaurants')
+    expect(stored('c')?.category).toBe('groceries')
+    expect(setNotice).toHaveBeenCalled()
+  })
+
+  it('does nothing when the selection is empty', async () => {
+    const { handlers } = setup()
+
+    await handlers.handleBulkCategorizeTransactions([], 'restaurants')
+
+    expect(mocks.updateRemoteTransaction).not.toHaveBeenCalled()
+  })
+
+  it('adds a tag without duplicating one already present', async () => {
+    const { handlers } = setup()
+
+    await handlers.handleBulkTagTransactions(['a'], 'viaje')
+    await handlers.handleBulkTagTransactions(['a'], 'viaje')
+
+    expect(stored('a')?.tags).toEqual(['viaje'])
+  })
+
+  it('removes the selected transactions on bulk delete', async () => {
+    const { handlers } = setup()
+
+    await handlers.handleBulkDeleteTransactions(['a', 'b'])
+
+    expect(stored('a')).toBeUndefined()
+    expect(stored('b')).toBeUndefined()
+    expect(stored('c')).toBeDefined()
   })
 })

--- a/src/hooks/useTransactionHandlers.test.ts
+++ b/src/hooks/useTransactionHandlers.test.ts
@@ -17,6 +17,11 @@ const mocks = vi.hoisted(() => ({
     enabled: true,
     model: 'claude-haiku-4-5',
   })),
+  splitTransaction: vi.fn(),
+  unsplitTransaction: vi.fn<[unknown, unknown, string[]], Promise<unknown>>(),
+  hardDeleteTransactions: vi.fn<[unknown, string[]], Promise<void>>(
+    async () => undefined
+  ),
   updateRemoteTransaction: vi.fn<
     [unknown, string, { displayDescription?: string | null }],
     Promise<void>
@@ -37,9 +42,9 @@ vi.mock('../services/supabase/transactions', () => ({
   persistTransactions: mocks.persistTransactions,
   softDeleteTransaction: vi.fn(async () => undefined),
   updateTransaction: mocks.updateRemoteTransaction,
-  splitTransaction: vi.fn(async () => undefined),
-  unsplitTransaction: vi.fn(async () => undefined),
-  hardDeleteTransactions: vi.fn(async () => undefined),
+  splitTransaction: mocks.splitTransaction,
+  unsplitTransaction: mocks.unsplitTransaction,
+  hardDeleteTransactions: mocks.hardDeleteTransactions,
 }))
 
 vi.mock('../services/supabase/import-runs', () => ({
@@ -402,5 +407,126 @@ describe('useTransactionHandlers — bulk operations', () => {
     expect(stored('a')).toBeUndefined()
     expect(stored('b')).toBeUndefined()
     expect(stored('c')).toBeDefined()
+  })
+})
+
+describe('useTransactionHandlers — split and unsplit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transactionStore.getState().clearTransactions()
+    transactionStore
+      .getState()
+      .setTransactions([makeTransaction('parent', { amount: 1000 })])
+  })
+
+  function stored(id: string) {
+    return transactionStore.getState().transactions.find((t) => t.id === id)
+  }
+
+  function splitResult() {
+    const parent = { ...makeTransaction('parent', { amount: 1000 }), isSplitParent: true }
+    const children = [
+      makeTransaction('parent_split_0', {
+        amount: 600,
+        splitParentId: 'parent',
+        category: 'groceries',
+      }),
+      makeTransaction('parent_split_1', {
+        amount: 400,
+        splitParentId: 'parent',
+        category: 'restaurants',
+      }),
+    ]
+    return { parent, children }
+  }
+
+  it('marks the parent and adds the children to the store', async () => {
+    mocks.splitTransaction.mockResolvedValue(splitResult())
+    const { handlers } = setup()
+
+    await handlers.handleSplitTransaction('parent', [
+      { description: 'Comida', amount: 600, category: 'groceries' },
+      { description: 'Bebida', amount: 400, category: 'restaurants' },
+    ])
+
+    expect(stored('parent')?.isSplitParent).toBe(true)
+    expect(stored('parent_split_0')?.amount).toBe(600)
+    expect(stored('parent_split_1')?.amount).toBe(400)
+    expect(transactionStore.getState().transactions).toHaveLength(3)
+  })
+
+  it('reports a split failure without changing the store', async () => {
+    mocks.splitTransaction.mockRejectedValue(new Error('no se pudo'))
+    const { handlers, setError } = setup()
+
+    await handlers.handleSplitTransaction('parent', [
+      { description: 'Comida', amount: 600 },
+    ])
+
+    expect(setError).toHaveBeenCalledWith('no se pudo')
+    expect(stored('parent')?.isSplitParent).toBeFalsy()
+    expect(transactionStore.getState().transactions).toHaveLength(1)
+  })
+
+  it('removes the children and restores the parent on unsplit', async () => {
+    mocks.splitTransaction.mockResolvedValue(splitResult())
+    const { handlers } = setup()
+    await handlers.handleSplitTransaction('parent', [
+      { description: 'Comida', amount: 600 },
+      { description: 'Bebida', amount: 400 },
+    ])
+    expect(transactionStore.getState().transactions).toHaveLength(3)
+
+    mocks.unsplitTransaction.mockResolvedValue({
+      ...makeTransaction('parent', { amount: 1000 }),
+      isSplitParent: false,
+      splitParentId: undefined,
+    })
+
+    await handlers.handleUnsplitTransaction('parent')
+
+    expect(stored('parent_split_0')).toBeUndefined()
+    expect(stored('parent_split_1')).toBeUndefined()
+    expect(stored('parent')?.isSplitParent).toBe(false)
+    expect(transactionStore.getState().transactions).toHaveLength(1)
+  })
+
+  it('passes every child id to the remote unsplit so none are orphaned', async () => {
+    mocks.splitTransaction.mockResolvedValue(splitResult())
+    const { handlers } = setup()
+    await handlers.handleSplitTransaction('parent', [
+      { description: 'Comida', amount: 600 },
+      { description: 'Bebida', amount: 400 },
+    ])
+
+    mocks.unsplitTransaction.mockResolvedValue(
+      makeTransaction('parent', { amount: 1000 })
+    )
+    await handlers.handleUnsplitTransaction('parent')
+
+    const childIds = mocks.unsplitTransaction.mock.calls[0][2]
+    expect(childIds).toEqual(
+      expect.arrayContaining(['parent_split_0', 'parent_split_1'])
+    )
+  })
+
+  it('hard-deletes split children when the parent is deleted', async () => {
+    mocks.splitTransaction.mockResolvedValue(splitResult())
+    const { handlers } = setup()
+    await handlers.handleSplitTransaction('parent', [
+      { description: 'Comida', amount: 600 },
+      { description: 'Bebida', amount: 400 },
+    ])
+
+    await handlers.handleDeleteTransaction('parent')
+
+    // Children are hard-deleted rather than soft-deleted: they only exist as
+    // a subdivision of the parent, so leaving them behind would orphan rows
+    // that no longer sum to anything.
+    expect(mocks.hardDeleteTransactions).toHaveBeenCalledTimes(1)
+    expect(mocks.hardDeleteTransactions.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['parent_split_0', 'parent_split_1'])
+    )
+    expect(transactionStore.getState().transactions).toHaveLength(0)
   })
 })

--- a/src/hooks/useTransactionHandlers.ts
+++ b/src/hooks/useTransactionHandlers.ts
@@ -70,7 +70,10 @@ export function useTransactionHandlers({
   ): Promise<{
     added: Transaction[]
     duplicates: Transaction[]
+    /** Enrichment did not run at all. */
     aiError?: string
+    /** Enrichment ran but some batches failed; the rest were applied. */
+    aiPartial?: string
   }> {
     if (!session) {
       return transactionStore.getState().addTransactions(transactionsToImport)
@@ -96,6 +99,7 @@ export function useTransactionHandlers({
     const aiConfig = getAiConfig()
     let toStore = added
     let aiError: string | undefined
+    let aiPartial: string | undefined
 
     if (aiConfig?.enabled && aiConfig.apiKey && added.length > 0) {
       const toEnrich = added.filter((tx) => {
@@ -124,7 +128,7 @@ export function useTransactionHandlers({
           toStore = applyAiEnrichment(added, results)
           // Some batches succeeded and some did not — keep what we got, but
           // still tell the user the enrichment was incomplete.
-          aiError = partialFailure
+          aiPartial = partialFailure
         } catch (error) {
           // Fall through with the rule-based results already on the
           // transactions, but keep the reason so it can be surfaced.
@@ -159,7 +163,7 @@ export function useTransactionHandlers({
       throw error
     }
 
-    return { added, duplicates, aiError }
+    return { added, duplicates, aiError, aiPartial }
   }
 
   async function handleUpdateTransaction(
@@ -184,6 +188,15 @@ export function useTransactionHandlers({
     const nextTags = updates.tags
 
     if (applyToMatching) {
+      // Whether the user actually renamed anything. When they did, a
+      // merchant-keyed description override is written below and becomes the
+      // single source of the friendly name — so the per-row values must be
+      // cleared, or rows keep disagreeing with each other. When they did not,
+      // there is no replacement name, and clearing would destroy per-row
+      // values (e.g. AI-enriched ones) that nothing else supplies.
+      const renames =
+        !!trimmedDisplayDescription &&
+        trimmedDisplayDescription !== current.description
       const targetKey = buildDescriptionOverrideKey(current.description)
       const matchingTransactions = state.transactions.filter(
         (tx) => {
@@ -221,12 +234,10 @@ export function useTransactionHandlers({
               updateRemoteTransaction(session, tx.id, {
                 category: nextCategory,
                 ...(nextCategory !== undefined && { categoryConfidence: 1 }),
-                // null, not undefined: the local store clears this field on
-                // every matching row, and the merchant-keyed description
-                // override written above is what supplies the friendly name
-                // from here on. `undefined` would omit the column and leave
-                // the stale per-row value to reappear on the next sync.
-                displayDescription: null,
+                // null clears the column; omitting the key leaves it alone.
+                // Only clear when an override was actually written to
+                // replace it — see `renames` above.
+                ...(renames && { displayDescription: null }),
               })
             )
           )
@@ -258,7 +269,9 @@ export function useTransactionHandlers({
               ...tx,
               ...categoryUpdates,
               ...tagsUpdates,
-              displayDescription: undefined,
+              // Mirrors the remote write above: only cleared when an
+              // override now supplies the name.
+              ...(renames && { displayDescription: undefined }),
             }
           })
         )
@@ -299,11 +312,14 @@ export function useTransactionHandlers({
 
         if (session) {
           await updateRemoteTransaction(session, transactionId, {
+            // null, not undefined, when the name is being reset: undefined
+            // omits the column and the old value survives on the server
+            // while the local store clears it (see UpdateTransactionInput).
             displayDescription:
               trimmedDisplayDescription &&
               trimmedDisplayDescription !== current.description
                 ? trimmedDisplayDescription
-                : undefined,
+                : null,
             category: nextCategory,
             ...(nextCategory !== undefined && { categoryConfidence: 1 }),
             tags: nextTags,
@@ -340,7 +356,8 @@ export function useTransactionHandlers({
 
       if (session) {
         await updateRemoteTransaction(session, transactionId, {
-          displayDescription: singleDisplayDescription,
+          // null, not undefined — see the note on UpdateTransactionInput.
+          displayDescription: singleDisplayDescription ?? null,
           category: nextCategory,
           ...(nextCategory !== undefined && { categoryConfidence: 1 }),
           tags: nextTags,

--- a/src/hooks/useTransactionHandlers.ts
+++ b/src/hooks/useTransactionHandlers.ts
@@ -221,7 +221,12 @@ export function useTransactionHandlers({
               updateRemoteTransaction(session, tx.id, {
                 category: nextCategory,
                 ...(nextCategory !== undefined && { categoryConfidence: 1 }),
-                displayDescription: undefined,
+                // null, not undefined: the local store clears this field on
+                // every matching row, and the merchant-keyed description
+                // override written above is what supplies the friendly name
+                // from here on. `undefined` would omit the column and leave
+                // the stale per-row value to reappear on the next sync.
+                displayDescription: null,
               })
             )
           )

--- a/src/services/supabase/transactions.ts
+++ b/src/services/supabase/transactions.ts
@@ -143,7 +143,13 @@ export async function restoreTransaction(
 
 export interface UpdateTransactionInput {
   description?: string
-  displayDescription?: string
+  /**
+   * `undefined` leaves the column untouched; `null` (or '') clears it. The
+   * distinction matters: every field here is guarded by `!== undefined`, so
+   * passing `undefined` to mean "clear" silently omits the column from the
+   * payload and the old value survives on the server.
+   */
+  displayDescription?: string | null
   category?: string
   categoryConfidence?: number
   tags?: string[]


### PR DESCRIPTION
> Stacked on #71 → #70 (it extends the test file #70 introduces). Review that chain first.

## Summary

Closes #53
Closes #54

## The bug (#53)

The `matching_past_and_future` branch set `displayDescription` to `undefined` on every matching row **locally**, and passed `undefined` to the remote layer too. But `updateTransaction` guards every field with `!== undefined` (`transactions.ts:163`), so the column was **omitted from the payload entirely** and the server kept its old value.

User-visible: rename `COMPRA CON TARJETA DEBITO TATA 0231` → "Tata", then change its category with "aplicar a todas las coincidencias".
- Immediately: the friendly name vanishes from every matching row.
- After reload: "Tata" is back, because Supabase never dropped it.

A rename apparently destroyed, then silently restored.

## Which half is right

Clearing on **both** sides. The same branch writes a merchant-keyed description override (`useTransactionHandlers.ts:182`), and `getDisplayDescription` (`utils/transaction-display.ts`) prefers the per-row value but falls back to that override — so once the override exists the per-row value is redundant, and leaving stale per-row values behind is what makes rows disagree with each other.

`UpdateTransactionInput.displayDescription` is now `string | null`: `undefined` leaves the column alone, `null` clears it. The distinction is documented on the type, because `undefined`-means-clear is exactly the trap that produced this bug.

## Test coverage (#54)

`useTransactionHandlers.ts` (688 loc) owns every mutation path in the app — the three apply-scope branches, bulk categorize/tag/delete, split/unsplit, import orchestration — and had **no test file** before #70. This adds the apply-scope and bulk coverage:

**apply-scope `single`** — only the target changes; no merchant override written
**apply-scope `matching_past_and_future`** — every row sharing the description changes; non-matching rows untouched; a merchant override is recorded; **displayDescription is cleared remotely** (the regression test)
**apply-scope `future_matching_only`** — the override is recorded but other existing matching rows keep their category
**bulk** — categorize touches only the selection; empty selection is a no-op; tagging twice does not duplicate; delete removes only the selected rows

**15 of the 16 new tests passed on the first run.** That is the point of #54, not a weakness: they pin down behavior that was correct but entirely unguarded. A regression in `future_matching_only` that started mutating past transactions would have shipped green before this.

## TDD Evidence

### RED
```
FAIL > scope 'matching_past_and_future' > asks the remote layer to clear
       displayDescription, matching the local store
→ expected undefined to be null
```

### GREEN
Widened `UpdateTransactionInput.displayDescription` to `string | null`; the call site passes `null`. `updateTransaction`'s existing `updates.displayDescription || null` already handled the null case correctly — only the type and the caller needed to change.

### REFACTOR
Typed the `updateRemoteTransaction` mock with its real parameter tuple so `tsc` checks the assertion against the actual call shape, rather than letting `mock.calls[2]` be an unchecked `any`.

## Verification
`npm run ci:check` passes — 77 test files, **846 tests**, lint clean, build succeeds.

## Not addressed here
The same `Promise.all` fan-out these tests exercise still has the partial-failure divergence in #60 (`needs-human-review`) — that needs a decision on write semantics, not a patch.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation