### PR TITLE
docs: correct CLAUDE.md and ADR-0001 to match the actual code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The app is fully online — authentication and data persistence require Supabase
 - **Charts**: Recharts
 - **Backend**: Supabase (auth + PostgreSQL, required — app won't function without it)
 - **Hosting**: Firebase Hosting
-- **Testing**: Vitest + React Testing Library (796 tests, 76 test files)
+- **Testing**: Vitest + React Testing Library (tests colocated with source)
 
 ## Commands
 
@@ -46,29 +46,37 @@ src/
     Categories.tsx         # Categorías view — category grid + auto-categorization rules
     Settings.tsx           # Configuración view — theme, currency, account, data management
     ImportCSV.tsx          # CSV import flow (wrapped in Radix Dialog, not a view)
-    AccountCard.tsx        # Account summary card with balance + footer
     CategoryBreakdownList.tsx  # Ranked category list with progress bars
     FxChip.tsx             # Editable FX rate chip (click to edit inline)
+    CurrencyToggle.tsx     # Home-currency switch
     TransactionFilters.tsx # Unified filter bar (search, category, account, type, currency, date, amount)
     TransactionTable.tsx   # Transaction rows, selection, confidence meter, row actions
     EditTransactionDialog.tsx  # Edit modal: description, category, apply-scope
     BulkEditDialog.tsx     # Bulk categorization modal
+    SplitTransactionDialog.tsx # Split one transaction into parts (see is_split_parent / split_parent_id)
+    ConfirmDialog.tsx      # Shared confirmation modal
     CategoryBadge.tsx      # Category badge with color dot
     ConfidenceBadge.tsx    # 3-bar confidence meter
-    DateRangePicker.tsx    # Date range input pair
+    Onboarding.tsx         # First-run empty state (no transactions yet)
+    EmptyState.tsx         # Generic empty state
+    StateSkeletons.tsx     # Loading skeletons for dashboard + transaction table
+    ConnectionLostState.tsx    # Supabase unreachable — retry affordance
     AuthCard.tsx           # Login / signup / password-reset form
     TatuLogo.tsx           # Armadillo-shell SVG brand mark
+    dev/                   # Developer tooling rendered inside Settings:
+                           #   CoverageAnalysis, AiCategorizationPreview, AiPatternAnalysis
   hooks/                   # Custom React hooks (extracted from App.tsx)
     useAuthSession.ts      # Supabase auth session management
     useUserPreferences.ts  # Theme, homeCurrency, fxRate — synced to Supabase
     useTransactionHandlers.ts  # All transaction mutation handlers
     useTransactionSync.ts  # Loads transactions from Supabase on login
     useTransactionFiltering.ts # Filter + sort + paginate transactions
+    useClickOutside.ts     # Dismiss popovers/menus on outside click
   services/
     parsers/               # CSV parsing (credit-card, bank-account, auto-detection)
     categorizer/           # Merchant pattern matching + auto-categorization
-    aggregator/            # Data grouping + summaries
-    filters/               # Transaction filtering + search
+    categories/            # Category registry + user custom categories (source of isCategoryIgnored)
+    filters/               # Transaction filtering used by export (the views filter via useTransactionFiltering)
     export/                # CSV/PDF export
     charts/                # Chart data transformations
     currency/              # convert(amount, from, to, rate) + Currency type
@@ -170,7 +178,11 @@ Requires `.env` with Supabase vars (see `.env.example`):
 
 ## Current status
 
-Redesign complete: sidebar navigation, 5 views, multicurrency with FxChip. Architectural refactor complete: hooks extracted from App.tsx, store simplified, large components split. Deployed to Firebase Hosting. 796 tests passing.
+Redesign complete: sidebar navigation, 5 views, multicurrency with FxChip. Hooks extracted from App.tsx and the store simplified. Deployed to Firebase Hosting.
+
+**Known shape of the code, so nobody is surprised:** `Transactions.tsx` (~1.6k lines) and `Dashboard.tsx` (~1.5k lines) are still large — the earlier refactor extracted hooks, not view components. Both define their sub-components inline at the top of the file.
+
+Test counts are deliberately not recorded here; they go stale within a PR. Run `npm run test:run` for the current number.
 
 AI Insights Phase 1 shipped (ADR-0001, `docs/decisions/0001-ai-spending-insights.md`): new Insights view generates Claude-powered spending insights per month, cached in Supabase (`ai_insights` table — requires a manual `schema.sql` apply, see `supabase/README.md`). Client-side, BYO API key, same pattern as `services/ai/`.
 

--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -9,7 +9,7 @@
 - **Transactions**: Unified filter bar (search, category, account, type, currency, date range, amount range), paginated table, bulk actions, edit modal with apply-scope
 - **Multicurrency**: `homeCurrency` + editable `fxRate`, combined totals in Resumen (charts live in `Dashboard.tsx`, not a separate Análisis view) + Insights, native amounts in transaction rows
 - **Redesign**: Sidebar navigation (overview / transactions / insights / categories / settings), warm token palette, Spectral + Hanken Grotesk + JetBrains Mono typography
-- **Refactor**: Hooks extracted from App.tsx (`useAuthSession`, `useUserPreferences`, `useTransactionHandlers`, `useTransactionSync`, `useTransactionFiltering`), Transactions.tsx split into sub-components
+- **Refactor**: Hooks extracted from App.tsx (`useAuthSession`, `useUserPreferences`, `useTransactionHandlers`, `useTransactionSync`, `useTransactionFiltering`). Note `Transactions.tsx` and `Dashboard.tsx` are still ~1.6k / ~1.5k lines — the refactor extracted hooks, not view components
 - **Export**: CSV + PDF from filtered transaction view
 - **AI Insights (Phase 1)**: new Insights sidebar view — Claude-generated (Opus 4.8) spending insights per month, cached in Supabase (`ai_insights` table), deterministic math only (category totals, deltas, recurring-charge detection all computed client-side, model only ranks/narrates). See ADR-0001 (`docs/decisions/0001-ai-spending-insights.md`).
 

--- a/docs/decisions/0001-ai-spending-insights.md
+++ b/docs/decisions/0001-ai-spending-insights.md
@@ -1,7 +1,22 @@
 # ADR-0001: AI-Powered Spending Insights
 
 ## Status
-Proposed
+Accepted — Phase 1 shipped in #42.
+
+Corrections applied after implementation (the decision stands; these are
+places where this document described code that does not exist):
+
+- Insights builds on `src/services/charts/chart-data.ts` only.
+  `src/services/aggregator/aggregation.ts`, named below, was never wired up
+  and has been deleted — extending it would have been wasted work.
+- The Insights UI does **not** reuse `DateRangePicker`; that component had no
+  importer at all and has been deleted. The view uses its own month
+  navigation.
+- The `ai_insights` DDL below does not match `supabase/schema.sql`, which is
+  the source of truth. See the Data Model note.
+- Prompt-caching and batch-truncation handling were added to
+  `transaction-ai.ts` after this ADR (#49, #52); the "no `output_config.format`,
+  parse defensively" decision is unchanged.
 
 ## Date
 2026-07-22
@@ -40,6 +55,16 @@ Tatu already has a working, shipped AI integration
 Because each user supplies their own key, there is no shared secret at risk
 of leaking — the exposure is a user to their own credential, in their own
 session. This is a deliberate, already-shipped decision, not an oversight.
+
+**Accepted risk — the key is stored in plaintext at rest.**
+`user_preferences.claude_api_key` is a plain `text` column. RLS scopes it so
+no other user can read it, but it is readable by anyone with database or
+Supabase dashboard access, and it appears in backups. There is no
+server-side component in this architecture to hold a decryption secret, so
+encrypting it would only move the problem: the key material would have to
+live in the client bundle. This is recorded as an accepted risk rather than
+an oversight. Revisit it if Tatu ever gains a backend, or moves off
+bring-your-own-key — either would need its own ADR.
 
 There is no serverless layer in this repo (no `supabase/functions`) — all
 backend logic is client + Supabase Postgres/RLS.
@@ -132,6 +157,13 @@ shippable slice stays small.
 
 New table `ai_insights`, RLS-scoped per user like every other table in
 `schema.sql`:
+
+> **As built, `supabase/schema.sql` is the source of truth.** The shipped
+> table uses a composite `primary key (user_id, period_start, period_end)`
+> and has no `id` column — equivalent uniqueness, one less index. The DDL
+> sketched below is the original proposal, kept for context. Do not
+> provision a database from it; `schema.sql` is applied manually (see
+> `supabase/README.md`).
 
 ```sql
 create table ai_insights (


### PR DESCRIPTION
> Stacked on #69 → #68 so it documents the post-cleanup tree instead of needing a second pass.

## Summary

`CLAUDE.md` and `ADR-0001` both describe code that does not exist. That is worse than an omission — both are read as the authoritative map of this codebase.

Closes #67

## The concrete failure this prevents

ADR-0001 states Insights builds on `src/services/aggregator/aggregation.ts`. That module has **no importer** — Insights uses `chart-data.ts`. Someone picking up "AI Insights Phase 2" from `PROJECT_BOARD.md`, reading the ADR as CLAUDE.md instructs, would open `aggregation.ts`, extend the trend math, add tests, and ship. Nothing calls it. Tests pass, CI is green, the feature does nothing.

That is the shortest path from the current docs to a wasted PR, and it is why this is filed as a bug rather than tidying.

## CLAUDE.md

**Removed** — documented but dead (deleted in #69): `AccountCard.tsx`, `DateRangePicker.tsx`, `services/aggregator/`.

**Corrected** — `services/filters/` is described by what it actually serves (export), not as the views' filtering, which goes through `useTransactionFiltering`.

**Added** — live and previously unlisted: `SplitTransactionDialog` (split is a core domain concept with schema support and handling in every `chart-data` selector), `Onboarding`, `EmptyState`, `StateSkeletons`, `ConnectionLostState`, `ConfirmDialog`, `CurrencyToggle`, `services/categories/` (the source of `isCategoryIgnored`, which every total depends on), `useClickOutside`, and `components/dev/` — noted as rendering inside production Settings, cross-referencing #65.

**Claims corrected:**
- *"796 tests, 76 test files"* — already wrong before this branch (main is 820) and stale within a PR. Dropped in favour of "run `npm run test:run`".
- *"large components split"* — the refactor extracted **hooks**, not view components. `Transactions.tsx` is ~1.6k lines and `Dashboard.tsx` ~1.5k. Now stated plainly under Current status so the next reader is not surprised.

## ADR-0001

- **Status `Proposed` → `Accepted`** (Phase 1 shipped in #42), with a short corrections block at the top rather than silently rewriting the decision record.
- Corrected the `aggregation.ts` and `DateRangePicker` references.
- **Flagged the DDL divergence.** The ADR sketches `id uuid primary key` + `unique(...)`; `schema.sql` ships a composite `primary key (user_id, period_start, period_end)`. Since `schema.sql` is applied **by hand** (`supabase/README.md`), someone provisioning from the ADR would get a different table. The original DDL is kept for context with a pointer to the source of truth.
- **Recorded the plaintext API key as an accepted risk.** `user_preferences.claude_api_key` is a plain `text` column. The ADR reasoned carefully about `dangerouslyAllowBrowser` but never about storage at rest — it is RLS-scoped, but readable by anyone with database or dashboard access, and present in backups. With no server-side component there is nowhere to hold a decryption secret, so encrypting it would only move the key material into the client bundle. Filed as a decision rather than a security fix, per the reasoning in #67.

## PROJECT_BOARD.md
Same correction to the "Transactions.tsx split into sub-components" claim.

## Verification
`npm run ci:check` passes (74 test files, 802 tests on this branch — the reduced count is #69's dead-test removal, not a regression). Documentation-only change.

## Tests
- [x] Added or updated tests for behavior changes — n/a, docs only
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation