### PR TITLE
perf: speed up transfer pairing without changing its output

### DIFF
--- a/src/services/transfers/internal-transfers.equivalence.test.ts
+++ b/src/services/transfers/internal-transfers.equivalence.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import type { Transaction } from '../../models'
+import { inferInternalTransfers } from './internal-transfers'
+
+/**
+ * Transfer inference decides which rows are excluded from every spending
+ * total, so a performance change here must be provably output-preserving,
+ * not just "the existing tests still pass".
+ *
+ * This builds a large deterministic corpus, runs inference over it, and
+ * fingerprints the full result. The fingerprint was captured from the
+ * implementation as it stood before the O(n^2) rework; any change to which
+ * rows get categorised — or to their confidence — changes the digest and
+ * fails this test.
+ */
+
+// Mulberry32 — small, deterministic, no dependency.
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const DESCRIPTIONS = [
+  'TRANSFERENCIA ENVIADA NRR:182500517',
+  'TRANSF INSTANTANEA RECIBIDA',
+  'DEBITO OPERACION EN SUPERNET',
+  'PAGO ELECTRONICO TARJETA CREDITO',
+  'COMPRA DOLARES',
+  'VENTA DOLARES',
+  'TRF. PLAZA- MARIA PEREZ',
+  'NRR:998877 JOSE PREX',
+  'SUPERMERCADO DISCO',
+  'FARMACIA SAN ROQUE',
+  'CARGO POR TRASPASO CTA.COMBINADA',
+  'CAMBIO MONEDA',
+  'NETFLIX.COM',
+  'PAGO SUPERNET',
+]
+
+function buildCorpus(count: number, seed = 42): Transaction[] {
+  const rng = makeRng(seed)
+  const txs: Transaction[] = []
+
+  for (let i = 0; i < count; i++) {
+    const pick = Math.floor(rng() * DESCRIPTIONS.length)
+    // Amounts are drawn from a small pool on purpose: transfer pairing keys
+    // off equal amounts, so a wide spread would produce almost no pairs and
+    // the fingerprint would not exercise the pairing path.
+    const amount = Math.round(rng() * 8) * 500 + 100
+    const day = 1 + Math.floor(rng() * 27)
+
+    txs.push({
+      id: `tx-${i}`,
+      date: new Date(Date.UTC(2026, 2, day)),
+      description: DESCRIPTIONS[pick],
+      amount,
+      currency: rng() > 0.5 ? 'USD' : 'UYU',
+      type: rng() > 0.5 ? 'debit' : 'credit',
+      source: rng() > 0.2 ? 'bank_account' : 'credit_card',
+      rawData:
+        rng() > 0.6 ? { referencia: `${100000 + Math.floor(rng() * 50)}` } : {},
+    } as Transaction)
+  }
+
+  return txs
+}
+
+function fingerprint(transactions: Transaction[]): string {
+  const serialized = transactions
+    .map((tx) => `${tx.id}|${tx.category ?? ''}|${tx.categoryConfidence ?? ''}`)
+    .sort()
+    .join('\n')
+
+  // FNV-1a, matching the style already used in insight-cache.ts.
+  let hash = 0x811c9dc5
+  for (let i = 0; i < serialized.length; i++) {
+    hash ^= serialized.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16)
+}
+
+describe('inferInternalTransfers — output is preserved', () => {
+  it('produces the same categorisation over a 600-transaction corpus', () => {
+    const result = inferInternalTransfers(buildCorpus(600))
+    expect(fingerprint(result)).toBe('141ed1cc')
+  })
+
+  it('produces the same categorisation over a differently seeded corpus', () => {
+    const result = inferInternalTransfers(buildCorpus(400, 7))
+    expect(fingerprint(result)).toBe('6b4cb7f5')
+  })
+
+  it('is idempotent — running it twice changes nothing', () => {
+    const once = inferInternalTransfers(buildCorpus(300))
+    const twice = inferInternalTransfers(once)
+    expect(fingerprint(twice)).toBe(fingerprint(once))
+  })
+
+  it('never assigns a category to a credit-card row', () => {
+    // canAutoAssignTransfer only touches bank_account rows; the pairing pass
+    // must not widen that.
+    const result = inferInternalTransfers(buildCorpus(600))
+    const cardWithTransfer = result.filter(
+      (tx) =>
+        tx.source === 'credit_card' &&
+        (tx.category === 'internal_transfer' ||
+          tx.category === 'external_transfer')
+    )
+    expect(cardWithTransfer).toHaveLength(0)
+  })
+
+  it('preserves input order and length', () => {
+    const input = buildCorpus(200)
+    const result = inferInternalTransfers(input)
+    expect(result).toHaveLength(input.length)
+    expect(result.map((t) => t.id)).toEqual(input.map((t) => t.id))
+  })
+})

--- a/src/services/transfers/internal-transfers.ts
+++ b/src/services/transfers/internal-transfers.ts
@@ -180,6 +180,11 @@ export function inferInternalTransfers(transactions: Transaction[]): Transaction
 
     const leftMeta = meta.get(left.id)!
     const windowIndexes: number[] = []
+    // ±2 is provably sufficient, not merely generous: if |a-b| <= 2*DAY_MS
+    // then |floor(a/DAY_MS) - floor(b/DAY_MS)| <= 2. (A difference of 3 would
+    // need floor(b/D) >= floor(a/D)+3, which forces b-a > 2*DAY_MS.) So no
+    // pair the exact dayDistance check would accept can fall outside this
+    // window. Narrowing it would start dropping real pairs.
     for (let offset = -2; offset <= 2; offset++) {
       const bucket = creditIndexByDay.get(leftMeta.day + offset)
       if (bucket) windowIndexes.push(...bucket)

--- a/src/services/transfers/internal-transfers.ts
+++ b/src/services/transfers/internal-transfers.ts
@@ -93,9 +93,10 @@ function markExternalTransfer(
   }
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000
+
 function dayDistance(left: Date, right: Date): number {
-  const dayMs = 24 * 60 * 60 * 1000
-  return Math.abs(left.getTime() - right.getTime()) / dayMs
+  return Math.abs(left.getTime() - right.getTime()) / DAY_MS
 }
 
 export function isTransferCategory(category: string | undefined): boolean {
@@ -137,6 +138,38 @@ export function inferInternalTransfers(transactions: Transaction[]): Transaction
           isTransferDescription(transaction.description)))
   )
 
+  // Per-candidate values that the pairing loop would otherwise recompute on
+  // every comparison — extractReferenceToken and isTransferDescription each
+  // normalise a string and scan a keyword list, and the original code called
+  // extractReferenceToken(left) twice per pair. Hoisting them turns the inner
+  // loop into numeric comparisons.
+  const meta = new Map<
+    string,
+    { refToken: string | null; isTransfer: boolean; day: number }
+  >()
+  for (const candidate of candidates) {
+    meta.set(candidate.id, {
+      refToken: extractReferenceToken(candidate),
+      isTransfer: isTransferDescription(candidate.description),
+      day: Math.floor(candidate.date.getTime() / DAY_MS),
+    })
+  }
+
+  // Credits bucketed by day, so a debit only looks at the ±2 day window
+  // instead of scanning every candidate. Buckets keep insertion order, and
+  // the merged window is re-sorted by original index below, so the loop
+  // still evaluates candidates in exactly the order it did before — which
+  // matters, because ties are resolved by `score > bestScore` (strict), i.e.
+  // first-best-wins.
+  const creditIndexByDay = new Map<number, number[]>()
+  candidates.forEach((candidate, index) => {
+    if (candidate.type !== 'credit') return
+    const { day } = meta.get(candidate.id)!
+    const bucket = creditIndexByDay.get(day)
+    if (bucket) bucket.push(index)
+    else creditIndexByDay.set(day, [index])
+  })
+
   for (const left of candidates) {
     if (left.type !== 'debit' || pairedIds.has(left.id)) {
       continue
@@ -145,23 +178,34 @@ export function inferInternalTransfers(transactions: Transaction[]): Transaction
     let bestMatch: Transaction | null = null
     let bestScore = -1
 
-    for (const right of candidates) {
-      if (left.id === right.id || pairedIds.has(right.id) || right.type !== 'credit') {
+    const leftMeta = meta.get(left.id)!
+    const windowIndexes: number[] = []
+    for (let offset = -2; offset <= 2; offset++) {
+      const bucket = creditIndexByDay.get(leftMeta.day + offset)
+      if (bucket) windowIndexes.push(...bucket)
+    }
+    windowIndexes.sort((a, b) => a - b)
+
+    for (const rightIndex of windowIndexes) {
+      const right = candidates[rightIndex]
+      if (left.id === right.id || pairedIds.has(right.id)) {
         continue
       }
 
+      // Day bucketing is a coarse filter (whole-day boundaries); the exact
+      // distance check below is still authoritative.
       const distance = dayDistance(left.date, right.date)
       if (distance > 2) {
         continue
       }
 
+      const rightMeta = meta.get(right.id)!
       const sameCurrency = left.currency === right.currency
       const sameAmount = Math.abs(left.amount - right.amount) <= 0.01
-      const leftIsTransfer = isTransferDescription(left.description)
-      const rightIsTransfer = isTransferDescription(right.description)
+      const leftIsTransfer = leftMeta.isTransfer
+      const rightIsTransfer = rightMeta.isTransfer
       const sameReference =
-        extractReferenceToken(left) !== null &&
-        extractReferenceToken(left) === extractReferenceToken(right)
+        leftMeta.refToken !== null && leftMeta.refToken === rightMeta.refToken
 
       let score = 0
       if (sameCurrency && sameAmount) {


### PR DESCRIPTION
## Summary

`inferInternalTransfers` runs on **every store mutation** — including a single-row category edit — so its cost lands on ordinary UI interactions.

Refs #55 (partial: items 2 and 3; item 1 deliberately left out, see below)

## Measured

| Corpus | Before | After | |
|---|---|---|---|
| 1,000 tx | 7.5 ms | **3.1 ms** | 2.4× |
| 3,000 tx | 63.0 ms | **16.5 ms** | 3.8× |
| 5,000 tx | **178.3 ms** | **38.5 ms** | 4.6× |

178 ms of synchronous work on one dropdown selection is a visible freeze, and it was paid again for every row in a bulk edit routed through `updateTransaction`.

## What changed

1. **Hoisted the string work out of the inner loop.** `extractReferenceToken` and `isTransferDescription` each normalise a string and scan a keyword list, and the original code called `extractReferenceToken(left)` **twice per candidate pair**. Both are now computed once per candidate.
2. **Bucketed credit candidates by day**, so a debit only examines the ±2 day window instead of scanning every candidate.

## Why correctness got more attention than speed

Transfer pairing decides which rows are excluded from **every spending total**. "The existing tests still pass" is not a strong enough claim for a rewrite of this loop.

The subtle hazard is evaluation order. Ties are resolved with `score > bestScore` — strict, so **first-best-wins**. Iterating day buckets naively would change which candidate wins a tie, silently changing categorisation. The window indexes are therefore merged and re-sorted by original index, so candidates are visited in exactly the order they were before. The whole-day bucket is only a coarse pre-filter; the exact `dayDistance` check remains authoritative for the boundary.

**Guarded by an equivalence test** (`internal-transfers.equivalence.test.ts`): it builds two seeded corpora (600 and 400 transactions, drawn from real Santander description shapes, with amounts from a small pool so the pairing path is actually exercised) and fingerprints the complete `id → category → confidence` mapping with FNV-1a.

Both digests — `141ed1cc` and `6b4cb7f5` — were captured from the **pre-change** implementation and are unchanged by this PR. Plus idempotency, credit-card rows never categorised, and input order/length preserved.

## Honest limitation

This is a constant-factor and typical-case win, **not an asymptotic one**. A corpus where every transaction shares a single day collapses back to the previous quadratic comparison count. Real statements spread across a month, which is where the 4.6× comes from.

## Deliberately not done

**Item 1 of #55** — skipping inference entirely on `updateTransaction`/`removeTransaction`. The reasoning in the issue looks right (a category edit cannot create or destroy a debit/credit pair elsewhere, and `canAutoAssignTransfer` already refuses to touch `categoryConfidence === 1` rows), but that changes *when* inference runs rather than how fast it is. On the app's trust surface that wants a human decision, so #55 stays open for it.

## Verification
`npm run ci:check` passes — 77 test files, **825 tests**, lint clean, build succeeds.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation