### PR TITLE
fix: round insight amounts at source so the model's echo validates

### DIFF
--- a/src/services/insights/insight-data.test.ts
+++ b/src/services/insights/insight-data.test.ts
@@ -173,3 +173,104 @@ describe('buildInsightInput', () => {
     expect(result.homeCurrency).toBe('UYU')
   })
 })
+
+describe('buildInsightInput — amounts are rounded for the model', () => {
+  // The prompt asks the model to echo amounts back EXACTLY, and the generator
+  // validates them with ===. Float residue from convert() makes that a
+  // lottery, so every monetary field is rounded where the input is built.
+  function isRounded(value: number): boolean {
+    return (
+      Number.isFinite(value) &&
+      Math.abs(value * 100 - Math.round(value * 100)) < 1e-9
+    )
+  }
+
+  it('rounds converted category totals and percentages to 2 decimals', () => {
+    // 50000 UYU / 40.5 = 1234.5679012345679 in USD
+    const transactions = [
+      makeTransaction('a', {
+        amount: 50000,
+        currency: 'UYU',
+        category: Category.Restaurants,
+      }),
+      makeTransaction('b', {
+        amount: 33333,
+        currency: 'UYU',
+        category: Category.Groceries,
+      }),
+    ]
+
+    const input = buildInsightInput(transactions, 'USD', 40.5)
+
+    expect(input.categoryTotals.length).toBeGreaterThan(0)
+    for (const c of input.categoryTotals) {
+      expect(isRounded(c.amount)).toBe(true)
+      expect(isRounded(c.pctOfTotal)).toBe(true)
+    }
+  })
+
+  it('rounds merchant totals to 2 decimals', () => {
+    const input = buildInsightInput(
+      [
+        makeTransaction('a', {
+          amount: 50000,
+          currency: 'UYU',
+          description: 'RESTAURANTE X',
+          category: Category.Restaurants,
+        }),
+      ],
+      'USD',
+      40.5
+    )
+
+    expect(input.topMerchants.length).toBeGreaterThan(0)
+    for (const m of input.topMerchants) {
+      expect(isRounded(m.amount)).toBe(true)
+    }
+  })
+
+  it('rounds recurring-charge amounts to 2 decimals', () => {
+    const transactions = [0, 1, 2].map((i) =>
+      makeTransaction(`r${i}`, {
+        date: new Date(Date.UTC(2026, 3 + i, 10)),
+        amount: 50000,
+        currency: 'UYU',
+        description: 'SPOTIFY',
+        category: Category.Entertainment,
+      })
+    )
+
+    const input = buildInsightInput(transactions, 'USD', 40.5)
+
+    expect(input.recurringCharges.length).toBeGreaterThan(0)
+    for (const r of input.recurringCharges) {
+      expect(isRounded(r.approxAmount)).toBe(true)
+    }
+  })
+
+  it('rounds monthly trend income and expense to 2 decimals', () => {
+    const input = buildInsightInput(
+      [
+        makeTransaction('a', {
+          amount: 50000,
+          currency: 'UYU',
+          category: Category.Restaurants,
+        }),
+        makeTransaction('b', {
+          amount: 77777,
+          currency: 'UYU',
+          type: 'credit',
+          category: Category.Income,
+        }),
+      ],
+      'USD',
+      40.5
+    )
+
+    expect(input.monthlyTrend.length).toBeGreaterThan(0)
+    for (const m of input.monthlyTrend) {
+      expect(isRounded(m.income)).toBe(true)
+      expect(isRounded(m.expense)).toBe(true)
+    }
+  })
+})

--- a/src/services/insights/insight-data.ts
+++ b/src/services/insights/insight-data.ts
@@ -67,6 +67,17 @@ function isEligibleDebit(tx: Transaction): boolean {
   )
 }
 
+/**
+ * Rounds to cents. Every number handed to the model goes through this: the
+ * prompt asks it to echo amounts back exactly and insight-generator validates
+ * them with ===, so unrounded FX residue (50000 / 40.5 = 1234.5679012345679)
+ * would make a legitimate echo of 1234.57 fail validation and get dropped —
+ * the card then renders with no number on it, silently.
+ */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
 function merchantOf(tx: Transaction): string {
   return (tx.displayDescription ?? tx.description).trim()
 }
@@ -91,8 +102,8 @@ function buildCategoryTotals(
 
   return totals.map((d) => ({
     category: d.category,
-    amount: d.total,
-    pctOfTotal: (d.total / grandTotal) * 100,
+    amount: round2(d.total),
+    pctOfTotal: round2((d.total / grandTotal) * 100),
   }))
 }
 
@@ -116,6 +127,7 @@ function buildTopMerchants(
   return Array.from(byMerchant.values())
     .sort((a, b) => b.amount - a.amount)
     .slice(0, TOP_MERCHANTS_LIMIT)
+    .map((m) => ({ ...m, amount: round2(m.amount) }))
 }
 
 function median(values: number[]): number {
@@ -184,7 +196,7 @@ function detectRecurringCharges(
 
     charges.push({
       merchant,
-      approxAmount,
+      approxAmount: round2(approxAmount),
       cadence: cadenceFromGap(averageGapDays(sortedDates)),
       monthsSeen,
       lastSeenMonth,
@@ -250,6 +262,10 @@ export function buildInsightInput(
       allTransactions,
       homeCurrency,
       fxRate
-    ).map((d) => ({ month: d.month, income: d.income, expense: d.expense })),
+    ).map((d) => ({
+      month: d.month,
+      income: round2(d.income),
+      expense: round2(d.expense),
+    })),
   }
 }

--- a/src/services/insights/insight-generator.test.ts
+++ b/src/services/insights/insight-generator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { InsightInput } from './insight-data'
+import { buildInsightInput } from './insight-data'
+import type { Transaction } from '../../models'
+import { Category } from '../../models'
 
 const { messagesCreateMock } = vi.hoisted(() => ({
   messagesCreateMock: vi.fn(),
@@ -182,5 +185,75 @@ describe('generateInsights', () => {
     await expect(generateInsights(baseInput, 'sk-test-key')).rejects.toThrow(
       /Respuesta inesperada/
     )
+  })
+})
+
+describe('insight amounts survive the round trip from a real InsightInput', () => {
+  it('keeps an amount the model echoed back from FX-converted spend', () => {
+    // The real failure path: UYU spend converted to USD yields
+    // 1234.5679012345679 unrounded. The prompt tells the model to copy the
+    // number exactly, but reproducing float residue verbatim is not
+    // something to rely on — so the input is rounded at source and both
+    // sides agree on one value.
+    const transactions: Transaction[] = [
+      {
+        id: 'tx-1',
+        date: new Date('2026-06-10T00:00:00.000Z'),
+        description: 'RESTAURANTE X',
+        amount: 50000,
+        currency: 'UYU',
+        type: 'debit',
+        source: 'bank_account',
+        category: Category.Restaurants,
+        rawData: {},
+      },
+    ]
+
+    const input = buildInsightInput(transactions, 'USD', 40.5)
+    const amount = input.categoryTotals[0].amount
+    expect(amount).toBe(1234.57)
+
+    const result = parseInsightsResponse(
+      JSON.stringify({
+        insights: [
+          {
+            type: 'bleeding_money',
+            title: 'Restaurantes domina tu gasto',
+            narrative: 'Es tu categoría más grande.',
+            amount,
+            currency: 'USD',
+            category: Category.Restaurants,
+            severity: 'high',
+          },
+        ],
+      }),
+      input
+    )
+
+    expect(result.insights).toHaveLength(1)
+    expect(result.insights[0].amount).toBe(1234.57)
+  })
+
+  it('still drops an amount that is not present in the input', () => {
+    // ADR-0001's anti-hallucination guarantee must not regress: rounding at
+    // source rather than loosening the validator is what keeps === exact.
+    const result = parseInsightsResponse(
+      JSON.stringify({
+        insights: [
+          {
+            type: 'bleeding_money',
+            title: 'Inventado',
+            narrative: 'Número que el modelo se inventó.',
+            amount: 99999.99,
+            currency: 'USD',
+            severity: 'high',
+          },
+        ],
+      }),
+      baseInput
+    )
+
+    expect(result.insights).toHaveLength(1)
+    expect(result.insights[0].amount).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Ports the surviving half of #72 onto the post-#43 all-time Insights model, as planned when #43 landed.

Closes #51

## The bug, still live on `main` after #43

`isKnownAmount` compares model-echoed amounts with `===` against values that reach the model **unrounded** — `insight-prompt.ts` serialises `InsightInput` verbatim, and the values come from `convert()`:

```ts
// insight-generator.ts
input.categoryTotals.some((c) => c.amount === amount) ||
```
```ts
// insight-data.ts, before this PR
amount: d.total,
pctOfTotal: (d.total / grandTotal) * 100,
approxAmount,
```

50000 UYU at 40.5 serialises as `1234.5679012345679`. The model echoes `1234.57`. The comparison fails, the amount is stripped, and the card renders **with no number on it** — no error, no log, indistinguishable from the model choosing not to include one. For the feature whose entire value proposition is trustworthy figures.

#43 rewrote this file but kept the bug verbatim, which is why it needed porting rather than being carried over in the merge.

## Fix

Round every monetary field to cents where `InsightInput` is built — `categoryTotals.amount`/`pctOfTotal`, `topMerchants.amount`, `recurringCharges.approxAmount`, `monthlyTrend.income`/`expense` — so the input, the prompt and the validator all agree on one value.

**Rounding at the boundary rather than loosening the validator is deliberate.** An epsilon comparison would also widen the window for a fabricated amount to slip through. This keeps ADR-0001's anti-hallucination guarantee exact, and the displayed number is now identical to the one the model reasoned over.

## TDD Evidence

### RED
```
FAIL > rounds converted category totals and percentages to 2 decimals
FAIL > rounds merchant totals to 2 decimals
FAIL > rounds recurring-charge amounts to 2 decimals
FAIL > rounds monthly trend income and expense to 2 decimals
→ expected false to be true   ×4
```

### GREEN
A `round2` helper applied at each emission point, with a comment explaining *why* — it looks like harmless arithmetic and the next reader will otherwise "simplify" it back.

### REFACTOR
None needed; the change is four call sites.

## Tests
- each monetary field in `InsightInput` is rounded to 2dp (4 cases, covering the new `recurringCharges` shape #43 introduced)
- **round trip:** a real `buildInsightInput` over 50000 UYU at 40.5 yields exactly `1234.57`, and an insight echoing `1234.57` is **retained** — this is the actual user-visible fix, not just internal rounding
- **anti-hallucination unchanged:** an amount not present in the input is still dropped

## Verification
`npm run ci:check` passes — 77 test files, **885 tests**, lint clean, build succeeds.

## What happened to #72
Closing it. Its prior-period half (#50) is moot — #43 removes `deltaVsPriorPeriod` entirely for the all-time view, so there is no prior period left to compute wrongly.

## Tests
- [x] Added or updated tests for behavior changes
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation