### PR TITLE
dx: enforce Prettier so the formatting contract stops drifting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,9 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
+    // Must stay last: turns off the stylistic rules that would otherwise
+    // fight Prettier over the same lines.
+    'prettier',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@vitest/ui": "^1.0.4",
         "autoprefixer": "^10.4.16",
         "eslint": "^8.55.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
         "jsdom": "^23.0.1",
@@ -5212,6 +5213,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "tdd:watch": "vitest",
-    "tdd:verify": "npm run test:run && npm run lint",
-    "ci:check": "npm run test:run && npm run lint && npm run build",
+    "tdd:verify": "npm run format:check && npm run test:run && npm run lint",
+    "ci:check": "npm run tdd:verify && npm run build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,css,md}\"",
-    "deploy:firebase": "npm run build && npx firebase-tools deploy"
+    "deploy:firebase": "npm run build && npx firebase-tools deploy",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,json,css,md}\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.2",
@@ -57,6 +58,7 @@
     "@vitest/ui": "^1.0.4",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.55.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "jsdom": "^23.0.1",

--- a/src/App.supabase.test.tsx
+++ b/src/App.supabase.test.tsx
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import { transactionStore } from './stores/transaction-store'
 
 const {
@@ -210,7 +216,9 @@ describe('App with supabase enabled', () => {
     fireEvent.change(screen.getByPlaceholderText('email@ejemplo.com'), {
       target: { value: 'test@example.com' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Restablecer contraseña' }))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Restablecer contraseña' })
+    )
 
     await waitFor(() =>
       expect(requestPasswordResetMock).toHaveBeenCalledWith('test@example.com')
@@ -235,9 +243,7 @@ describe('App with supabase enabled', () => {
     await waitFor(() =>
       expect(updatePasswordMock).toHaveBeenCalledWith('new-secret123')
     )
-    await waitFor(() =>
-      expect(signOutMock).toHaveBeenCalledWith(null)
-    )
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledWith(null))
     await waitFor(() =>
       expect(
         screen.getByRole('heading', { name: 'Ingresar a Tatú' })
@@ -306,9 +312,7 @@ describe('App with supabase enabled', () => {
     expect(loadUserTransactionsMock).not.toHaveBeenCalled()
   })
 
-  it(
-    'updates and soft-deletes transactions from transactions view',
-    async () => {
+  it('updates and soft-deletes transactions from transactions view', async () => {
     getCurrentSessionMock.mockReturnValue({
       access_token: 'access',
       refresh_token: 'refresh',
@@ -399,9 +403,7 @@ describe('App with supabase enabled', () => {
     await waitFor(() =>
       expect(screen.queryByText('New merchant')).not.toBeInTheDocument()
     )
-    },
-    15000
-  )
+  }, 15000)
 
   it('applies edit to future matching transactions only', async () => {
     getCurrentSessionMock.mockReturnValue({

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,12 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import App from './App'
 import { transactionStore } from './stores/transaction-store'
 import { listCustomCategories } from './services/categories/category-store'
@@ -116,28 +123,42 @@ describe('App', () => {
 
     // With no transactions, Onboarding is shown after sync completes
     await waitFor(() =>
-      expect(screen.getByRole('heading', { name: /Bienvenido a Tatú/i })).toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: /Bienvenido a Tatú/i })
+      ).toBeInTheDocument()
     )
   })
 
   it('opens import view when clicking the sidebar Importar button', async () => {
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Importar' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Importar' })
+      ).toBeInTheDocument()
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Importar' }))
 
-    expect(screen.getByRole('heading', { name: 'Importar Transacciones' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Importar Transacciones' })
+    ).toBeInTheDocument()
     expect(screen.getByText('Arrastrá tu archivo CSV aquí')).toBeInTheDocument()
   })
 
   it('shows supported file types on import view', async () => {
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Importar' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Importar' })
+      ).toBeInTheDocument()
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Importar' }))
 
     expect(screen.getByText('Tarjeta de Crédito')).toBeInTheDocument()
     expect(screen.getByText('Cuenta USD')).toBeInTheDocument()
     expect(screen.getByText('Cuenta UYU')).toBeInTheDocument()
-    expect(screen.getByText(/Extracto de tarjeta Santander/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Extracto de tarjeta Santander/)
+    ).toBeInTheDocument()
   })
 
   it('switches to transactions view from sidebar navigation', async () => {
@@ -154,11 +175,17 @@ describe('App', () => {
       },
     ])
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
 
     await waitFor(() =>
-      expect(screen.getByRole('heading', { name: 'Transacciones' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: 'Transacciones' })
+      ).toBeInTheDocument()
     )
     expect(screen.getByText(/movimiento.*·/)).toBeInTheDocument()
   })
@@ -178,7 +205,11 @@ describe('App', () => {
     ])
 
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
     await act(async () => {
       fireEvent.click(
@@ -198,9 +229,13 @@ describe('App', () => {
     })
 
     await waitFor(() =>
-      expect(transactionStore.getState().transactions[0].category).toBe('groceries')
+      expect(transactionStore.getState().transactions[0].category).toBe(
+        'groceries'
+      )
     )
-    expect(transactionStore.getState().transactions[0].categoryConfidence).toBeGreaterThan(0)
+    expect(
+      transactionStore.getState().transactions[0].categoryConfidence
+    ).toBeGreaterThan(0)
     expect(screen.getAllByText('Alimentación').length).toBeGreaterThan(0)
     expect(
       screen.getByText('1 transacción auto-categorizada')
@@ -222,7 +257,11 @@ describe('App', () => {
     ])
 
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
 
     await act(async () => {
@@ -244,7 +283,9 @@ describe('App', () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText('No se encontraron categorías automáticas para las transacciones seleccionadas')
+        screen.getByText(
+          'No se encontraron categorías automáticas para las transacciones seleccionadas'
+        )
       ).toBeInTheDocument()
     )
     // Category must not be overwritten when nothing matched — previously a bug
@@ -254,10 +295,16 @@ describe('App', () => {
 
   it('switches to categorías view from sidebar navigation', async () => {
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Categorías' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Categorías' })
+      ).toBeInTheDocument()
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Categorías' }))
 
-    expect(screen.getByRole('heading', { name: 'Categorías y reglas' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Categorías y reglas' })
+    ).toBeInTheDocument()
   })
 
   it('filters Transacciones by category when deep-linking from Resumen', async () => {
@@ -288,28 +335,40 @@ describe('App', () => {
 
     render(<App />)
     await waitFor(() =>
-      expect(screen.getAllByText('Alimentación').length).toBeGreaterThan(0),
+      expect(screen.getAllByText('Alimentación').length).toBeGreaterThan(0)
     )
     // Click the category row in the breakdown list (last occurrence, list is clickable)
     const allAlimentacion = screen.getAllByText('Alimentación')
     const topCategoryLink = allAlimentacion[allAlimentacion.length - 1]
     fireEvent.click(topCategoryLink)
 
-    expect(screen.getByRole('heading', { name: 'Transacciones' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Transacciones' })
+    ).toBeInTheDocument()
   })
 
   it('opens import as a dialog overlay without navigating away from current view', async () => {
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Importar' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Importar' })
+      ).toBeInTheDocument()
+    )
     expect(screen.getByRole('button', { name: 'Importar' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Importar' }))
 
-    expect(screen.getByRole('heading', { name: 'Importar Transacciones' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Importar Transacciones' })
+    ).toBeInTheDocument()
     expect(screen.getByText('Arrastrá tu archivo CSV aquí')).toBeInTheDocument()
   })
 
   it('applies dark theme when user preferences return dark', async () => {
-    loadUserPreferencesMock.mockResolvedValue({ theme: 'dark', currency: 'USD', fxRate: 40.5 })
+    loadUserPreferencesMock.mockResolvedValue({
+      theme: 'dark',
+      currency: 'USD',
+      fxRate: 40.5,
+    })
 
     render(<App />)
 
@@ -320,13 +379,25 @@ describe('App', () => {
 
   it('sidebar nav items are visible and functional', async () => {
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Resumen' })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Resumen' })
+      ).toBeInTheDocument()
+    )
 
     expect(screen.getByRole('button', { name: 'Resumen' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Análisis' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Categorías' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Configuración' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Transacciones' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Análisis' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Categorías' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Configuración' })
+    ).toBeInTheDocument()
   })
 
   it('bulk categorizes selected transactions and updates the store', async () => {
@@ -355,12 +426,18 @@ describe('App', () => {
 
     render(<App />)
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
     )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
 
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0])
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio B' })[0])
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0]
+    )
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio B' })[0]
+    )
 
     await act(async () => {
       fireEvent.click(screen.getAllByRole('button', { name: /Editar/ })[0])
@@ -410,12 +487,18 @@ describe('App', () => {
     ])
     render(<App />)
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
     )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
 
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0])
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio B' })[0])
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0]
+    )
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio B' })[0]
+    )
 
     fireEvent.click(screen.getByRole('button', { name: /^Eliminar$/ }))
 
@@ -448,11 +531,15 @@ describe('App', () => {
 
     render(<App />)
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
     )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
 
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0])
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Seleccionar Comercio A' })[0]
+    )
 
     await act(async () => {
       fireEvent.click(screen.getAllByRole('button', { name: /Editar/ })[0])
@@ -462,14 +549,18 @@ describe('App', () => {
     fireEvent.change(screen.getByLabelText('Buscar o crear etiqueta'), {
       target: { value: 'recurrente' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /Crear etiqueta "recurrente"/ }))
+    fireEvent.click(
+      screen.getByRole('button', { name: /Crear etiqueta "recurrente"/ })
+    )
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }))
     })
 
     await waitFor(() => {
-      const tx = transactionStore.getState().transactions.find((t) => t.id === 'tx-1')
+      const tx = transactionStore
+        .getState()
+        .transactions.find((t) => t.id === 'tx-1')
       expect(tx?.tags).toContain('recurrente')
     })
     expect(updateTransactionMock).toHaveBeenCalledTimes(1)
@@ -491,7 +582,9 @@ describe('App', () => {
 
     render(<App />)
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Transacciones' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Transacciones' })
+      ).toBeInTheDocument()
     )
     fireEvent.click(screen.getByRole('button', { name: 'Transacciones' }))
 
@@ -501,8 +594,12 @@ describe('App', () => {
 
     // No checkboxes selected — the bulk selection toolbar should not be visible
     // (the toolbar is identified by its selection count status span)
-    expect(screen.queryByRole('status', { name: /seleccionada/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Eliminar$/ })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('status', { name: /seleccionada/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /^Eliminar$/ })
+    ).not.toBeInTheDocument()
   })
 
   it('mobile hamburger opens nav sheet and closes on nav item click', async () => {
@@ -519,7 +616,11 @@ describe('App', () => {
       },
     ])
     render(<App />)
-    await waitFor(() => expect(screen.getByRole('button', { name: /abrir menú/i })).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /abrir menú/i })
+      ).toBeInTheDocument()
+    )
 
     const hamburger = screen.getByRole('button', { name: /abrir menú/i })
     expect(hamburger).toBeInTheDocument()
@@ -530,7 +631,9 @@ describe('App', () => {
     })
 
     expect(hamburger).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByRole('dialog', { name: /menú de navegación/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('dialog', { name: /menú de navegación/i })
+    ).toBeInTheDocument()
 
     const dialogNavButtons = screen
       .getByRole('dialog', { name: /menú de navegación/i })
@@ -543,7 +646,9 @@ describe('App', () => {
     })
 
     expect(hamburger).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.getByRole('heading', { name: 'Transacciones' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Transacciones' })
+    ).toBeInTheDocument()
   })
 
   it('clears custom categories from memory on sign out', async () => {
@@ -561,7 +666,9 @@ describe('App', () => {
 
     render(<App />)
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Categorías' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Categorías' })
+      ).toBeInTheDocument()
     )
 
     // After sync, the custom category is in memory

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,9 +34,7 @@ import { Button } from './components/ui/button'
 import { useStore } from 'zustand'
 import { transactionStore } from './stores/transaction-store'
 import { signOut } from './services/supabase/auth'
-import {
-  clearAllCategoryOverrides,
-} from './services/categorizer/category-overrides'
+import { clearAllCategoryOverrides } from './services/categorizer/category-overrides'
 import { clearAllDescriptionOverrides } from './services/descriptions/description-overrides'
 import { replaceCustomCategories } from './services/categories/category-store'
 import { replaceCustomPatterns } from './services/categorizer/custom-patterns'
@@ -52,8 +50,12 @@ function App() {
   const [currentView, setCurrentView] = useState<View>('overview')
   const [importOpen, setImportOpen] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [pendingTxFilter, setPendingTxFilter] = useState<import('./models').TransactionsFilter | null>(null)
-  const [syncStatus, setSyncStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [pendingTxFilter, setPendingTxFilter] = useState<
+    import('./models').TransactionsFilter | null
+  >(null)
+  const [syncStatus, setSyncStatus] = useState<'loading' | 'ready' | 'error'>(
+    'loading'
+  )
   const [syncKey, setSyncKey] = useState(0)
 
   function refetch() {
@@ -170,7 +172,9 @@ function App() {
     setAuthNotice('Datos eliminados correctamente')
   }
 
-  function navigateToTransactions(filter: import('./models').TransactionsFilter) {
+  function navigateToTransactions(
+    filter: import('./models').TransactionsFilter
+  ) {
     setPendingTxFilter(filter)
     setCurrentView('transactions')
   }
@@ -185,7 +189,11 @@ function App() {
     handleBulkDeleteTransactions,
     handleBulkTagTransactions,
     handleAutoCategorizeTransactions,
-  } = useTransactionHandlers({ session, setError: setAuthError, setNotice: setAuthNotice })
+  } = useTransactionHandlers({
+    session,
+    setError: setAuthError,
+    setNotice: setAuthNotice,
+  })
 
   if (!session || authMode === 'reset') {
     return (
@@ -402,11 +410,36 @@ function App() {
                 />
               )}
               {currentView === 'transactions' && transactions.length === 0 && (
-                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 320, gap: 16, padding: '48px 24px', textAlign: 'center' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: 320,
+                    gap: 16,
+                    padding: '48px 24px',
+                    textAlign: 'center',
+                  }}
+                >
                   <Upload size={40} style={{ color: 'var(--text-faint)' }} />
                   <div>
-                    <p style={{ fontSize: 16, fontWeight: 600, marginBottom: 6 }}>No hay transacciones</p>
-                    <p style={{ fontSize: 14, color: 'var(--text-muted)', maxWidth: 280, margin: '0 auto' }}>Importá tu primer extracto CSV de Santander para empezar a ver tus movimientos.</p>
+                    <p
+                      style={{ fontSize: 16, fontWeight: 600, marginBottom: 6 }}
+                    >
+                      No hay transacciones
+                    </p>
+                    <p
+                      style={{
+                        fontSize: 14,
+                        color: 'var(--text-muted)',
+                        maxWidth: 280,
+                        margin: '0 auto',
+                      }}
+                    >
+                      Importá tu primer extracto CSV de Santander para empezar a
+                      ver tus movimientos.
+                    </p>
                   </div>
                   <Button onClick={() => setImportOpen(true)}>
                     <Upload size={16} />
@@ -422,7 +455,9 @@ function App() {
                   fxRate={fxRate}
                   onUpdateTransaction={handleUpdateTransaction}
                   onDeleteTransaction={handleDeleteTransaction}
-                  onAutoCategorizeTransactions={handleAutoCategorizeTransactions}
+                  onAutoCategorizeTransactions={
+                    handleAutoCategorizeTransactions
+                  }
                   onBulkCategorize={handleBulkCategorizeTransactions}
                   onBulkDelete={handleBulkDeleteTransactions}
                   onBulkTag={handleBulkTagTransactions}
@@ -532,12 +567,12 @@ function App() {
           transition: 'background 0.13s, color 0.13s',
         }}
         onMouseOver={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.background =
+          ;(e.currentTarget as HTMLButtonElement).style.background =
             'var(--surface-2)'
           ;(e.currentTarget as HTMLButtonElement).style.color = 'var(--text)'
         }}
         onMouseOut={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.background =
+          ;(e.currentTarget as HTMLButtonElement).style.background =
             'var(--surface)'
           ;(e.currentTarget as HTMLButtonElement).style.color =
             'var(--text-muted)'

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -111,7 +111,9 @@ export function SidebarInner({
   ]
 
   const userEmail = session?.user?.email ?? ''
-  const userName = getFriendlyName(session) || (userEmail ? userEmail.split('@')[0] : 'Usuario')
+  const userName =
+    getFriendlyName(session) ||
+    (userEmail ? userEmail.split('@')[0] : 'Usuario')
   const avatarInitial = userName.charAt(0).toUpperCase()
 
   return (
@@ -257,7 +259,7 @@ export function SidebarInner({
                 }}
                 onMouseOver={(e) => {
                   if (!isActive) {
-                    (e.currentTarget as HTMLButtonElement).style.background =
+                    ;(e.currentTarget as HTMLButtonElement).style.background =
                       'var(--surface-2)'
                     ;(e.currentTarget as HTMLButtonElement).style.color =
                       'var(--text)'
@@ -265,7 +267,7 @@ export function SidebarInner({
                 }}
                 onMouseOut={(e) => {
                   if (!isActive) {
-                    (e.currentTarget as HTMLButtonElement).style.background =
+                    ;(e.currentTarget as HTMLButtonElement).style.background =
                       'transparent'
                     ;(e.currentTarget as HTMLButtonElement).style.color =
                       'var(--text-muted)'
@@ -297,7 +299,9 @@ export function SidebarInner({
                     style={{
                       fontSize: 11,
                       fontFamily: 'var(--font-mono)',
-                      color: isActive ? 'var(--brand-text)' : 'var(--text-faint)',
+                      color: isActive
+                        ? 'var(--brand-text)'
+                        : 'var(--text-faint)',
                       background: isActive
                         ? 'oklch(1 0 0 / 0.35)'
                         : 'var(--surface-2)',
@@ -343,9 +347,7 @@ export function SidebarInner({
           >
             {avatarInitial}
           </span>
-          <div
-            style={{ minWidth: 0, flex: 1 }}
-          >
+          <div style={{ minWidth: 0, flex: 1 }}>
             <div
               style={{
                 fontSize: 13,

--- a/src/components/Categories.test.tsx
+++ b/src/components/Categories.test.tsx
@@ -67,9 +67,7 @@ describe('Categories', () => {
 
   it('opens new category form when clicking Nueva categoría', () => {
     render(<Categories transactions={[]} />)
-    fireEvent.click(
-      screen.getByRole('button', { name: /Nueva categoría/ })
-    )
+    fireEvent.click(screen.getByRole('button', { name: /Nueva categoría/ }))
 
     expect(screen.getByLabelText('Nombre de categoría')).toBeInTheDocument()
     expect(screen.getByLabelText('Color de categoría')).toBeInTheDocument()
@@ -78,9 +76,7 @@ describe('Categories', () => {
 
   it('creates a new custom category', () => {
     render(<Categories transactions={[]} />)
-    fireEvent.click(
-      screen.getByRole('button', { name: /Nueva categoría/ })
-    )
+    fireEvent.click(screen.getByRole('button', { name: /Nueva categoría/ }))
 
     fireEvent.change(screen.getByLabelText('Nombre de categoría'), {
       target: { value: 'Mascotas' },
@@ -92,7 +88,11 @@ describe('Categories', () => {
   })
 
   it('edits custom category color and icon', async () => {
-    const custom = addCustomCategory({ label: 'Coffee', color: '#ff0000', icon: '☕' })
+    const custom = addCustomCategory({
+      label: 'Coffee',
+      color: '#ff0000',
+      icon: '☕',
+    })
 
     render(<Categories transactions={[makeTx({ category: custom.id })]} />)
 
@@ -114,7 +114,11 @@ describe('Categories', () => {
   })
 
   it('deletes a custom category', async () => {
-    const custom = addCustomCategory({ label: 'Yoga', color: '#aabbcc', icon: '🧘' })
+    const custom = addCustomCategory({
+      label: 'Yoga',
+      color: '#aabbcc',
+      icon: '🧘',
+    })
     expect(listCustomCategories()).toHaveLength(1)
 
     render(<Categories transactions={[]} />)

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -68,19 +68,37 @@ export function Categories({ transactions }: CategoriesProps) {
   const isEditing = form.id.length > 0
 
   function resetForm() {
-    setForm({ id: '', label: '', color: DEFAULT_CATEGORY_COLOR, icon: '🏷️', isIgnored: false })
+    setForm({
+      id: '',
+      label: '',
+      color: DEFAULT_CATEGORY_COLOR,
+      icon: '🏷️',
+      isIgnored: false,
+    })
     setShowForm(false)
   }
 
   function openNewForm() {
-    setForm({ id: '', label: '', color: DEFAULT_CATEGORY_COLOR, icon: '🏷️', isIgnored: false })
+    setForm({
+      id: '',
+      label: '',
+      color: DEFAULT_CATEGORY_COLOR,
+      icon: '🏷️',
+      isIgnored: false,
+    })
     setShowForm(true)
   }
 
   function startEdit(categoryId: string) {
     const cat = categoryDefinitions.find((c) => c.id === categoryId)
     if (!cat) return
-    setForm({ id: cat.id, label: cat.label, color: cat.color, icon: cat.icon || '🏷️', isIgnored: cat.isIgnored ?? false })
+    setForm({
+      id: cat.id,
+      label: cat.label,
+      color: cat.color,
+      icon: cat.icon || '🏷️',
+      isIgnored: cat.isIgnored ?? false,
+    })
     setShowForm(true)
   }
 
@@ -287,7 +305,13 @@ export function Categories({ transactions }: CategoriesProps) {
             <div>
               <label
                 htmlFor="cat-label"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Nombre
               </label>
@@ -295,14 +319,22 @@ export function Categories({ transactions }: CategoriesProps) {
                 id="cat-label"
                 aria-label="Nombre de categoría"
                 value={form.label}
-                onChange={(e) => setForm((f) => ({ ...f, label: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, label: e.target.value }))
+                }
                 placeholder="Ej. Café"
               />
             </div>
             <div>
               <label
                 htmlFor="cat-color"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Color
               </label>
@@ -311,14 +343,22 @@ export function Categories({ transactions }: CategoriesProps) {
                 aria-label="Color de categoría"
                 type="color"
                 value={form.color}
-                onChange={(e) => setForm((f) => ({ ...f, color: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, color: e.target.value }))
+                }
                 className="h-10"
               />
             </div>
             <div>
               <label
                 htmlFor="cat-icon"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Icono
               </label>
@@ -326,17 +366,32 @@ export function Categories({ transactions }: CategoriesProps) {
                 id="cat-icon"
                 aria-label="Icono de categoría"
                 value={form.icon}
-                onChange={(e) => setForm((f) => ({ ...f, icon: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, icon: e.target.value }))
+                }
                 placeholder="🏷️"
                 maxLength={2}
               />
             </div>
           </div>
 
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 4 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginTop: 4,
+            }}
+          >
             <label
               htmlFor="cat-ignored"
-              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', userSelect: 'none' }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                cursor: 'pointer',
+                userSelect: 'none',
+              }}
             >
               <Checkbox
                 id="cat-ignored"
@@ -346,9 +401,18 @@ export function Categories({ transactions }: CategoriesProps) {
                 }
               />
               <div>
-                <span style={{ fontSize: 13, fontWeight: 500 }}>Ignorar en totales</span>
-                <span style={{ fontSize: 12, color: 'var(--text-faint)', marginLeft: 6 }}>
-                  Las transacciones de esta categoría no suman en gastos ni ingresos
+                <span style={{ fontSize: 13, fontWeight: 500 }}>
+                  Ignorar en totales
+                </span>
+                <span
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--text-faint)',
+                    marginLeft: 6,
+                  }}
+                >
+                  Las transacciones de esta categoría no suman en gastos ni
+                  ingresos
                 </span>
               </div>
             </label>
@@ -433,7 +497,17 @@ export function Categories({ transactions }: CategoriesProps) {
                   >
                     {cat.label}
                     {cat.isIgnored && (
-                      <span style={{ fontSize: 10, fontWeight: 500, color: 'var(--text-faint)', background: 'var(--border)', borderRadius: 4, padding: '1px 5px', flexShrink: 0 }}>
+                      <span
+                        style={{
+                          fontSize: 10,
+                          fontWeight: 500,
+                          color: 'var(--text-faint)',
+                          background: 'var(--border)',
+                          borderRadius: 4,
+                          padding: '1px 5px',
+                          flexShrink: 0,
+                        }}
+                      >
                         ignorada
                       </span>
                     )}
@@ -504,12 +578,22 @@ export function Categories({ transactions }: CategoriesProps) {
         <h3 style={{ fontSize: 15, fontWeight: 600, marginBottom: 4 }}>
           Reglas de auto-categorización
         </h3>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', marginBottom: 16 }}>
-          Creá reglas para categorizar transacciones automáticamente según el texto de la descripción.
+        <p
+          style={{ fontSize: 13, color: 'var(--text-muted)', marginBottom: 16 }}
+        >
+          Creá reglas para categorizar transacciones automáticamente según el
+          texto de la descripción.
         </p>
 
         {/* Add pattern form */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 16 }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+            marginBottom: 16,
+          }}
+        >
           {/* Row 1: pattern + type + category */}
           <div
             style={{
@@ -522,7 +606,13 @@ export function Categories({ transactions }: CategoriesProps) {
             <div style={{ flex: '1 1 auto', minWidth: 160 }}>
               <label
                 htmlFor="pattern-text"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Patrón
               </label>
@@ -538,7 +628,13 @@ export function Categories({ transactions }: CategoriesProps) {
             <div>
               <label
                 htmlFor="pattern-match"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Tipo
               </label>
@@ -569,7 +665,13 @@ export function Categories({ transactions }: CategoriesProps) {
             <div>
               <label
                 htmlFor="pattern-category"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Categoría
               </label>
@@ -612,7 +714,13 @@ export function Categories({ transactions }: CategoriesProps) {
             <div style={{ flex: '1 1 auto', minWidth: 160 }}>
               <label
                 htmlFor="pattern-description"
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Descripción (opcional)
               </label>
@@ -627,7 +735,13 @@ export function Categories({ transactions }: CategoriesProps) {
             </div>
             <div>
               <label
-                style={{ display: 'block', fontSize: 12, fontWeight: 500, marginBottom: 6, color: 'var(--text-muted)' }}
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  marginBottom: 6,
+                  color: 'var(--text-muted)',
+                }}
               >
                 Aplicar a
               </label>
@@ -657,7 +771,10 @@ export function Categories({ transactions }: CategoriesProps) {
                       fontSize: 13,
                       cursor: 'pointer',
                       border: 'none',
-                      borderRight: value === 'future_only' ? '1px solid var(--border)' : 'none',
+                      borderRight:
+                        value === 'future_only'
+                          ? '1px solid var(--border)'
+                          : 'none',
                       background:
                         patternForm.applyScope === value
                           ? 'var(--brand)'
@@ -785,7 +902,8 @@ export function Categories({ transactions }: CategoriesProps) {
               padding: '16px 0',
             }}
           >
-            No hay reglas personalizadas. Creá una para categorizar automáticamente tus transacciones.
+            No hay reglas personalizadas. Creá una para categorizar
+            automáticamente tus transacciones.
           </p>
         )}
       </div>

--- a/src/components/CategoryBadge.test.tsx
+++ b/src/components/CategoryBadge.test.tsx
@@ -1,52 +1,55 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { CategoryBadge } from './CategoryBadge';
-import { Category } from '../models';
-import { getCategoryDisplay } from '../utils/category-display';
-import { addCustomCategory, replaceCustomCategories } from '../services/categories/category-store';
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CategoryBadge } from './CategoryBadge'
+import { Category } from '../models'
+import { getCategoryDisplay } from '../utils/category-display'
+import {
+  addCustomCategory,
+  replaceCustomCategories,
+} from '../services/categories/category-store'
 
 describe('CategoryBadge', () => {
   beforeEach(() => {
-    replaceCustomCategories([]);
-  });
+    replaceCustomCategories([])
+  })
 
   it('renders readable label for modern categories', () => {
-    render(<CategoryBadge categoryId="groceries" />);
+    render(<CategoryBadge categoryId="groceries" />)
 
-    expect(screen.getByText('Alimentación')).toBeInTheDocument();
-  });
+    expect(screen.getByText('Alimentación')).toBeInTheDocument()
+  })
 
   it('renders readable label for legacy category aliases', () => {
-    render(<CategoryBadge categoryId="food" />);
+    render(<CategoryBadge categoryId="food" />)
 
-    expect(screen.getByText('Alimentación')).toBeInTheDocument();
-  });
+    expect(screen.getByText('Alimentación')).toBeInTheDocument()
+  })
 
   it('falls back to uncategorized label for unknown categories', () => {
-    render(<CategoryBadge categoryId="unknown-category" />);
+    render(<CategoryBadge categoryId="unknown-category" />)
 
-    expect(screen.getByText('Sin categoría')).toBeInTheDocument();
-  });
+    expect(screen.getByText('Sin categoría')).toBeInTheDocument()
+  })
 
   it('renders all built-in categories with a label', () => {
     Object.values(Category).forEach((category) => {
-      const { label } = getCategoryDisplay(category);
-      const { unmount } = render(<CategoryBadge categoryId={category} />);
-      expect(screen.getByText(label)).toBeInTheDocument();
-      unmount();
-    });
-  });
+      const { label } = getCategoryDisplay(category)
+      const { unmount } = render(<CategoryBadge categoryId={category} />)
+      expect(screen.getByText(label)).toBeInTheDocument()
+      unmount()
+    })
+  })
 
   it('renders custom category icon and color', () => {
     const custom = addCustomCategory({
       label: 'Coffee',
       color: '#123456',
       icon: '☕',
-    });
+    })
 
-    render(<CategoryBadge categoryId={custom.id} />);
+    render(<CategoryBadge categoryId={custom.id} />)
 
-    expect(screen.getByText('Coffee')).toBeInTheDocument();
-    expect(screen.getByText('☕')).toBeInTheDocument();
-  });
-});
+    expect(screen.getByText('Coffee')).toBeInTheDocument()
+    expect(screen.getByText('☕')).toBeInTheDocument()
+  })
+})

--- a/src/components/CategoryBadge.tsx
+++ b/src/components/CategoryBadge.tsx
@@ -1,16 +1,20 @@
-import { getCategoryDefinition } from '../services/categories/category-registry';
+import { getCategoryDefinition } from '../services/categories/category-registry'
 
 interface CategoryBadgeProps {
-  categoryId: string;
-  showIcon?: boolean;
-  size?: 'sm' | 'md';
+  categoryId: string
+  showIcon?: boolean
+  size?: 'sm' | 'md'
 }
 
-export function CategoryBadge({ categoryId, showIcon = true, size = 'md' }: CategoryBadgeProps) {
-  const definition = getCategoryDefinition(categoryId);
+export function CategoryBadge({
+  categoryId,
+  showIcon = true,
+  size = 'md',
+}: CategoryBadgeProps) {
+  const definition = getCategoryDefinition(categoryId)
 
-  const padding = size === 'sm' ? 'px-2 py-0.5' : 'px-2.5 py-1';
-  const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
+  const padding = size === 'sm' ? 'px-2 py-0.5' : 'px-2.5 py-1'
+  const textSize = size === 'sm' ? 'text-xs' : 'text-sm'
 
   return (
     <span
@@ -27,5 +31,5 @@ export function CategoryBadge({ categoryId, showIcon = true, size = 'md' }: Cate
       )}
       <span>{definition.label}</span>
     </span>
-  );
+  )
 }

--- a/src/components/CategoryBreakdownList.tsx
+++ b/src/components/CategoryBreakdownList.tsx
@@ -65,7 +65,11 @@ export function CategoryBreakdownList({
               {row.label}
             </span>
             <span
-              style={{ display: 'inline-flex', gap: 10, alignItems: 'baseline' }}
+              style={{
+                display: 'inline-flex',
+                gap: 10,
+                alignItems: 'baseline',
+              }}
             >
               <span className="font-mono" style={{ fontSize: 13 }}>
                 {formatCurrency(row.amount, currency)}

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -32,7 +32,9 @@ describe('Dashboard', () => {
     render(<Dashboard transactions={[]} />)
 
     expect(screen.queryByText(/NaN|Infinity/)).not.toBeInTheDocument()
-    expect(screen.getByText('Empezá importando tu extracto')).toBeInTheDocument()
+    expect(
+      screen.getByText('Empezá importando tu extracto')
+    ).toBeInTheDocument()
     expect(screen.queryByText('Panel General')).not.toBeInTheDocument()
 
     vi.useRealTimers()
@@ -40,14 +42,32 @@ describe('Dashboard', () => {
 
   it('shows converted+combined totals in home currency', () => {
     const transactions = [
-      makeTransaction({ id: 'uyu-debit', currency: 'UYU', type: 'debit', amount: 1000 }),
-      makeTransaction({ id: 'usd-debit', currency: 'USD', type: 'debit', amount: 50 }),
-      makeTransaction({ id: 'usd-credit', currency: 'USD', type: 'credit', amount: 200, category: Category.Income }),
+      makeTransaction({
+        id: 'uyu-debit',
+        currency: 'UYU',
+        type: 'debit',
+        amount: 1000,
+      }),
+      makeTransaction({
+        id: 'usd-debit',
+        currency: 'USD',
+        type: 'debit',
+        amount: 50,
+      }),
+      makeTransaction({
+        id: 'usd-credit',
+        currency: 'USD',
+        type: 'credit',
+        amount: 200,
+        category: Category.Income,
+      }),
     ]
 
     // homeCurrency defaults to 'USD', fxRate defaults to 40.5
     // income = 200 USD (only Category.Income credits count), expenses = 50 USD + 1000/40 ≈ 25 USD
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     // income = 200 USD appears in "Este mes" panel
     expect(screen.getByText('US$ 200,00')).toBeInTheDocument()
@@ -64,7 +84,7 @@ describe('Dashboard', () => {
       (desc) =>
         desc === 'SUPERMERCADO DEVOTO SA 0032'
           ? { friendlyDescription: 'Devoto', updatedAt: '2026-01-01' }
-          : null,
+          : null
     )
 
     const tx = makeTransaction({
@@ -79,7 +99,9 @@ describe('Dashboard', () => {
     render(<Dashboard transactions={[tx]} />)
 
     expect(screen.getAllByText('Devoto').length).toBeGreaterThan(0)
-    expect(screen.queryByText('SUPERMERCADO DEVOTO SA 0032')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('SUPERMERCADO DEVOTO SA 0032')
+    ).not.toBeInTheDocument()
 
     vi.restoreAllMocks()
     vi.useRealTimers()
@@ -104,7 +126,9 @@ describe('Dashboard', () => {
     ]
 
     // homeCurrency=USD, so expense total = 50 (transfer excluded)
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     // 50 appears (native + converted total)
     expect(screen.getAllByText('US$ 50,00').length).toBeGreaterThan(0)
@@ -140,7 +164,9 @@ describe('Dashboard', () => {
       }),
     ]
 
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     expect(screen.queryByText('SUPER PARENT')).not.toBeInTheDocument()
     expect(screen.getAllByText('Super - parte 1').length).toBeGreaterThan(0)
@@ -178,7 +204,9 @@ describe('Dashboard', () => {
       }),
     ]
 
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     expect(screen.getAllByText('2 movimientos').length).toBeGreaterThan(0)
     expect(screen.queryByText('3 movimientos')).not.toBeInTheDocument()
@@ -203,9 +231,21 @@ describe('Dashboard', () => {
 
   it('renders category breakdown from expense data', () => {
     const transactions = [
-      makeTransaction({ id: 'food-1', category: Category.Groceries, amount: 100 }),
-      makeTransaction({ id: 'food-2', category: Category.Groceries, amount: 50 }),
-      makeTransaction({ id: 'transport-1', category: Category.Transport, amount: 30 }),
+      makeTransaction({
+        id: 'food-1',
+        category: Category.Groceries,
+        amount: 100,
+      }),
+      makeTransaction({
+        id: 'food-2',
+        category: Category.Groceries,
+        amount: 50,
+      }),
+      makeTransaction({
+        id: 'transport-1',
+        category: Category.Transport,
+        amount: 30,
+      }),
     ]
 
     render(<Dashboard transactions={transactions} />)
@@ -250,7 +290,7 @@ describe('Dashboard', () => {
         category: Category.Transport,
         amount: 50,
         date: new Date(2026, 0, 20 + i),
-      }),
+      })
     )
     const transactions = [
       makeTransaction({
@@ -318,7 +358,9 @@ describe('Dashboard', () => {
       }),
     ]
 
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     // The legacy transfer is neither listed nor folded into "este mes"
     expect(screen.queryByText('TRASPASO ENTRE CUENTAS')).not.toBeInTheDocument()
@@ -342,16 +384,16 @@ describe('Dashboard', () => {
       <Dashboard
         transactions={transactions}
         onNavigateToCategories={onNavigateToCategories}
-      />,
+      />
     )
 
     expect(
-      screen.getByText('Todas tus transacciones están ignoradas'),
+      screen.getByText('Todas tus transacciones están ignoradas')
     ).toBeInTheDocument()
     // Neither the zeroed dashboard nor the "you have no data" import CTA
     expect(screen.queryByText('Mayores comercios')).not.toBeInTheDocument()
     expect(
-      screen.queryByText('Empezá importando tu extracto'),
+      screen.queryByText('Empezá importando tu extracto')
     ).not.toBeInTheDocument()
   })
 
@@ -370,7 +412,9 @@ describe('Dashboard', () => {
       }),
     ]
 
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     expect(screen.getAllByText(/enero de 2026/i).length).toBeGreaterThan(0)
     expect(screen.queryByText(/agosto de 2026/i)).not.toBeInTheDocument()
@@ -398,7 +442,9 @@ describe('Dashboard', () => {
       }),
     ]
 
-    render(<Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />)
+    render(
+      <Dashboard transactions={transactions} homeCurrency="USD" fxRate={40} />
+    )
 
     expect(screen.getByText('1 transacciones registradas')).toBeInTheDocument()
     expect(screen.getAllByText(/enero de 2026/i).length).toBeGreaterThan(0)
@@ -406,8 +452,16 @@ describe('Dashboard', () => {
 
   it('renders all major section headings', () => {
     const transactions = [
-      makeTransaction({ id: 'food-1', category: Category.Groceries, amount: 200 }),
-      makeTransaction({ id: 'transport-1', category: Category.Transport, amount: 80 }),
+      makeTransaction({
+        id: 'food-1',
+        category: Category.Groceries,
+        amount: 200,
+      }),
+      makeTransaction({
+        id: 'transport-1',
+        category: Category.Transport,
+        amount: 80,
+      }),
       makeTransaction({
         id: 'income-1',
         type: 'credit',

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -84,13 +84,22 @@ function SectionDivider({ label, sub }: { label: string; sub?: string }) {
       </h2>
       {sub && (
         <span
-          style={{ fontSize: 12.5, color: 'var(--text-faint)', whiteSpace: 'nowrap' }}
+          style={{
+            fontSize: 12.5,
+            color: 'var(--text-faint)',
+            whiteSpace: 'nowrap',
+          }}
         >
           {sub}
         </span>
       )}
       <span
-        style={{ flex: 1, height: 1, background: 'var(--border)', alignSelf: 'center' }}
+        style={{
+          flex: 1,
+          height: 1,
+          background: 'var(--border)',
+          alignSelf: 'center',
+        }}
       />
     </div>
   )
@@ -179,7 +188,9 @@ function AccountExpenseCard({
           >
             {label}
           </div>
-          <div style={{ fontSize: 12, color: 'var(--text-faint)' }}>{sublabel}</div>
+          <div style={{ fontSize: 12, color: 'var(--text-faint)' }}>
+            {sublabel}
+          </div>
         </div>
       </div>
 
@@ -280,7 +291,7 @@ export function Dashboard({
   // ignored categories (transfers, user-flagged) and split parents are out.
   const countedTransactions = useMemo(
     () => transactions.filter((tx) => !isExcludedFromTotals(tx)),
-    [transactions],
+    [transactions]
   )
 
   // Data exists but every row is ignored — a zeroed dashboard would look like
@@ -291,11 +302,13 @@ export function Dashboard({
   // Falls back to the raw rows when everything is ignored, so a transfers-only
   // dataset still labels the statement month instead of today's.
   const latestDate = useMemo(() => {
-    const source = countedTransactions.length ? countedTransactions : transactions
+    const source = countedTransactions.length
+      ? countedTransactions
+      : transactions
     if (source.length === 0) return new Date()
     return source.reduce(
       (latest, tx) => (tx.date > latest ? tx.date : latest),
-      source[0].date,
+      source[0].date
     )
   }, [countedTransactions, transactions])
 
@@ -320,13 +333,13 @@ export function Dashboard({
   // Account spend by source
   const acctSpend = useMemo(
     () => spendByAccount(transactions, homeCurrency, fxRate),
-    [transactions, homeCurrency, fxRate],
+    [transactions, homeCurrency, fxRate]
   )
 
   // "Este mes" — converted + combined totals in home currency
   const monthSummary = useMemo(
     () => buildCurrentMonthSummary(transactions, homeCurrency, fxRate),
-    [transactions, homeCurrency, fxRate],
+    [transactions, homeCurrency, fxRate]
   )
 
   // Category breakdown — all history (for donut)
@@ -337,7 +350,11 @@ export function Dashboard({
   }, [])
 
   const categoryData = useMemo(() => {
-    const data = buildCategorySpendingConverted(transactions, homeCurrency, fxRate)
+    const data = buildCategorySpendingConverted(
+      transactions,
+      homeCurrency,
+      fxRate
+    )
     const total = data.reduce((s, r) => s + r.total, 0) || 1
     return data.map((row) => {
       const display = getCategoryDisplay(row.category)
@@ -389,13 +406,13 @@ export function Dashboard({
           gastos: m.expense,
           neto: m.net,
         })),
-    [transactions, homeCurrency, fxRate],
+    [transactions, homeCurrency, fxRate]
   )
 
   // Currency split
   const currencySplit = useMemo(
     () => buildCurrencySplit(transactions, homeCurrency, fxRate),
-    [transactions, homeCurrency, fxRate],
+    [transactions, homeCurrency, fxRate]
   )
 
   // KPI values
@@ -414,7 +431,7 @@ export function Dashboard({
   // ¿Estás ahorrando? values
   const avgNet = Math.round(
     monthlyTrend.reduce((s, m) => s + m.neto, 0) /
-      Math.max(monthlyTrend.length, 1),
+      Math.max(monthlyTrend.length, 1)
   )
   const positiveMonths = monthlyTrend.filter((m) => m.neto >= 0).length
   const saving = avgNet >= 0
@@ -450,7 +467,7 @@ export function Dashboard({
       [...countedTransactions]
         .sort((a, b) => b.date.getTime() - a.date.getTime())
         .slice(0, 6),
-    [countedTransactions],
+    [countedTransactions]
   )
 
   const greeting = userName ? `Hola, ${userName} 👋` : 'Hola 👋'
@@ -479,7 +496,10 @@ export function Dashboard({
           <p style={{ fontWeight: 600, fontSize: 13, marginBottom: 2 }}>
             {label}
           </p>
-          <p className="font-mono" style={{ fontSize: 13, color: 'var(--text-faint)' }}>
+          <p
+            className="font-mono"
+            style={{ fontSize: 13, color: 'var(--text-faint)' }}
+          >
             {formatCurrency(value, homeCurrency)}
           </p>
         </div>
@@ -630,14 +650,18 @@ export function Dashboard({
             <h2 className="mb-2">Todas tus transacciones están ignoradas</h2>
             <p className="text-muted-foreground max-w-md mx-auto">
               Importaste {transactions.length}{' '}
-              {transactions.length === 1 ? 'transacción' : 'transacciones'}, pero
-              todas caen en categorías ignoradas (transferencias u otras que
-              marcaste), así que no suman a ningún total. Cambiales la categoría
-              o desmarcá “ignorar” para verlas acá.
+              {transactions.length === 1 ? 'transacción' : 'transacciones'},
+              pero todas caen en categorías ignoradas (transferencias u otras
+              que marcaste), así que no suman a ningún total. Cambiales la
+              categoría o desmarcá “ignorar” para verlas acá.
             </p>
           </div>
           {onNavigateToCategories && (
-            <Button size="lg" variant="outline" onClick={onNavigateToCategories}>
+            <Button
+              size="lg"
+              variant="outline"
+              onClick={onNavigateToCategories}
+            >
               Revisar categorías
             </Button>
           )}
@@ -652,9 +676,7 @@ export function Dashboard({
               Período analizado: {periodRange}
             </p>
           )}
-          <div
-            className="grid grid-cols-1 sm:grid-cols-3 gap-4"
-          >
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <AccountExpenseCard
               icon={CreditCard}
               label="Tarjeta de crédito"
@@ -732,10 +754,15 @@ export function Dashboard({
                 </div>
                 <div
                   className="font-mono"
-                  style={{ fontSize: 11, color: 'var(--text-faint)', marginTop: 8 }}
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--text-faint)',
+                    marginTop: 8,
+                  }}
                 >
-                  US$ {Math.round(monthSummary.split.USD).toLocaleString('es-UY')}{' '}
-                  + $U{' '}
+                  US${' '}
+                  {Math.round(monthSummary.split.USD).toLocaleString('es-UY')} +
+                  $U{' '}
                   {Math.round(monthSummary.split.UYU).toLocaleString('es-UY')}
                 </div>
               </div>
@@ -750,8 +777,7 @@ export function Dashboard({
                   className="font-mono"
                   style={{
                     fontSize: 22,
-                    color:
-                      monthSummary.net >= 0 ? 'var(--pos)' : 'var(--neg)',
+                    color: monthSummary.net >= 0 ? 'var(--pos)' : 'var(--neg)',
                   }}
                 >
                   {monthSummary.net >= 0 ? '+' : '−'}
@@ -869,9 +895,7 @@ export function Dashboard({
                     >
                       ¿Estás ahorrando?
                     </h2>
-                    <span
-                      style={{ fontSize: 11, color: 'var(--text-faint)' }}
-                    >
+                    <span style={{ fontSize: 11, color: 'var(--text-faint)' }}>
                       Últimos 12 meses
                     </span>
                   </div>
@@ -897,14 +921,18 @@ export function Dashboard({
                     {saving ? (
                       <>
                         Te queda dinero la mayoría de los meses. Ahorrás{' '}
-                        <strong>{formatCurrency(Math.abs(avgNet), homeCurrency)}</strong>{' '}
+                        <strong>
+                          {formatCurrency(Math.abs(avgNet), homeCurrency)}
+                        </strong>{' '}
                         por mes en promedio.
                       </>
                     ) : (
                       <>
                         Estás gastando más de lo que ingresás. En promedio te
                         faltan{' '}
-                        <strong>{formatCurrency(Math.abs(avgNet), homeCurrency)}</strong>{' '}
+                        <strong>
+                          {formatCurrency(Math.abs(avgNet), homeCurrency)}
+                        </strong>{' '}
                         por mes.
                       </>
                     )}
@@ -940,7 +968,9 @@ export function Dashboard({
                       tick={{ fontSize: 11 }}
                       axisLine={false}
                       tickLine={false}
-                      tickFormatter={(v) => formatCurrencyShort(v, homeCurrency)}
+                      tickFormatter={(v) =>
+                        formatCurrencyShort(v, homeCurrency)
+                      }
                       width={60}
                     />
                     <Tooltip content={savingsTooltip} />
@@ -1079,16 +1109,16 @@ export function Dashboard({
                 </div>
 
                 <CategoryBreakdownList
-                  rows={categoryData.slice(0, 7).map<CategoryBreakdownRow>(
-                    (row) => ({
+                  rows={categoryData
+                    .slice(0, 7)
+                    .map<CategoryBreakdownRow>((row) => ({
                       id: row.categoryId,
                       label: row.label,
                       color: row.color,
                       emoji: row.emoji,
                       amount: row.value,
                       pct: row.pct,
-                    }),
-                  )}
+                    }))}
                   currency={homeCurrency}
                   showPercent
                   onClickRow={
@@ -1153,9 +1183,7 @@ export function Dashboard({
                   flexWrap: 'wrap',
                 }}
               >
-                <div
-                  style={{ display: 'flex', alignItems: 'center', gap: 10 }}
-                >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                   <span
                     style={{
                       width: 10,
@@ -1177,9 +1205,7 @@ export function Dashboard({
                     </div>
                   </div>
                 </div>
-                <div
-                  style={{ display: 'flex', alignItems: 'center', gap: 10 }}
-                >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                   <span
                     style={{
                       width: 10,
@@ -1272,11 +1298,19 @@ export function Dashboard({
               >
                 <defs>
                   <linearGradient id="gradIngresos" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="var(--pos)" stopOpacity={0.22} />
+                    <stop
+                      offset="5%"
+                      stopColor="var(--pos)"
+                      stopOpacity={0.22}
+                    />
                     <stop offset="95%" stopColor="var(--pos)" stopOpacity={0} />
                   </linearGradient>
                   <linearGradient id="gradGastos" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="var(--neg)" stopOpacity={0.2} />
+                    <stop
+                      offset="5%"
+                      stopColor="var(--neg)"
+                      stopOpacity={0.2}
+                    />
                     <stop offset="95%" stopColor="var(--neg)" stopOpacity={0} />
                   </linearGradient>
                 </defs>
@@ -1378,7 +1412,7 @@ export function Dashboard({
               <div style={{ display: 'flex', flexDirection: 'column' }}>
                 {recentTransactions.map((tx, i) => {
                   const catDef = getCategoryDefinition(
-                    tx.category ?? 'uncategorized',
+                    tx.category ?? 'uncategorized'
                   )
                   const isCredit = tx.type === 'credit'
                   const showConverted = tx.currency !== homeCurrency

--- a/src/components/EditTransactionDialog.tsx
+++ b/src/components/EditTransactionDialog.tsx
@@ -324,9 +324,7 @@ export function EditTransactionDialog({
             Cancelar
           </Button>
           <Button type="button" onClick={onSave} disabled={isPending}>
-            {isPending && (
-              <Loader2 size={14} className="mr-1.5 animate-spin" />
-            )}
+            {isPending && <Loader2 size={14} className="mr-1.5 animate-spin" />}
             Guardar cambios
           </Button>
         </DialogFooter>

--- a/src/components/ImportCSV.test.tsx
+++ b/src/components/ImportCSV.test.tsx
@@ -92,7 +92,8 @@ describe('ImportCSV', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     DeferredFileReaderMock.instances = []
-    globalThis.FileReader = SuccessfulFileReaderMock as unknown as typeof FileReader
+    globalThis.FileReader =
+      SuccessfulFileReaderMock as unknown as typeof FileReader
   })
 
   afterEach(() => {
@@ -110,7 +111,9 @@ describe('ImportCSV', () => {
     })
 
     expect(screen.getByText('Error al validar archivo')).toBeInTheDocument()
-    expect(screen.getByText('El archivo debe estar en formato CSV')).toBeInTheDocument()
+    expect(
+      screen.getByText('El archivo debe estar en formato CSV')
+    ).toBeInTheDocument()
     expect(parseCSVMock).not.toHaveBeenCalled()
     expect(addTransactionsMock).not.toHaveBeenCalled()
   })
@@ -129,14 +132,17 @@ describe('ImportCSV', () => {
       },
     })
 
-    expect(await screen.findByText('Error al validar archivo')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Error al validar archivo')
+    ).toBeInTheDocument()
     expect(screen.getByText('CSV malformado')).toBeInTheDocument()
     expect(addTransactionsMock).not.toHaveBeenCalled()
     expect(onImportComplete).not.toHaveBeenCalled()
   })
 
   it('shows file read errors and does not persist', async () => {
-    globalThis.FileReader = FailingFileReaderMock as unknown as typeof FileReader
+    globalThis.FileReader =
+      FailingFileReaderMock as unknown as typeof FileReader
     render(<ImportCSV />)
 
     const input = screen.getByLabelText('Seleccionar archivo')
@@ -146,7 +152,9 @@ describe('ImportCSV', () => {
       },
     })
 
-    expect(await screen.findByText('Error al validar archivo')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Error al validar archivo')
+    ).toBeInTheDocument()
     expect(screen.getByText('Error al leer el archivo')).toBeInTheDocument()
     expect(parseCSVMock).not.toHaveBeenCalled()
     expect(addTransactionsMock).not.toHaveBeenCalled()
@@ -158,7 +166,8 @@ describe('ImportCSV', () => {
       added: [makeTx('tx-1'), makeTx('tx-2'), makeTx('tx-3')],
       duplicates: [],
     })
-    globalThis.FileReader = DeferredFileReaderMock as unknown as typeof FileReader
+    globalThis.FileReader =
+      DeferredFileReaderMock as unknown as typeof FileReader
 
     render(<ImportCSV />)
 
@@ -178,7 +187,9 @@ describe('ImportCSV', () => {
       } as unknown as ProgressEvent<FileReader>)
     })
 
-    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Importación completada')
+    ).toBeInTheDocument()
   })
 
   it('persists immediately, reports duplicates, and triggers navigation callback', async () => {
@@ -198,7 +209,9 @@ describe('ImportCSV', () => {
       },
     })
 
-    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Importación completada')
+    ).toBeInTheDocument()
     expect(
       screen.getByText('1 de 3 transacciones guardadas (2 duplicadas omitidas)')
     ).toBeInTheDocument()
@@ -228,7 +241,9 @@ describe('ImportCSV', () => {
       },
     })
 
-    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Importación completada')
+    ).toBeInTheDocument()
     expect(
       screen.getByText('2 de 3 transacciones guardadas (1 duplicadas omitidas)')
     ).toBeInTheDocument()
@@ -263,14 +278,18 @@ describe('ImportCSV', () => {
     })
 
     // The import still succeeded ...
-    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Importación completada')
+    ).toBeInTheDocument()
     expect(
       screen.getByText('2 de 3 transacciones guardadas (1 duplicadas omitidas)')
     ).toBeInTheDocument()
 
     // ... but the user is told the AI step did not run, and why.
     await waitFor(() => expect(toastMock.warning).toHaveBeenCalledTimes(1))
-    expect(toastMock.warning.mock.calls[0][0]).toContain('401 invalid x-api-key')
+    expect(toastMock.warning.mock.calls[0][0]).toContain(
+      '401 invalid x-api-key'
+    )
   })
 
   it('does not warn about AI when the import reports no AI failure', async () => {
@@ -288,7 +307,9 @@ describe('ImportCSV', () => {
       },
     })
 
-    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Importación completada')
+    ).toBeInTheDocument()
     expect(toastMock.warning).not.toHaveBeenCalled()
   })
 
@@ -309,7 +330,9 @@ describe('ImportCSV', () => {
       },
     })
 
-    expect(await screen.findByText('Importación completada')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Importación completada')
+    ).toBeInTheDocument()
     await waitFor(() => expect(toastMock.warning).toHaveBeenCalledTimes(1))
     const message = toastMock.warning.mock.calls[0][0] as string
     expect(message).toContain('incompleta')

--- a/src/components/ImportCSV.tsx
+++ b/src/components/ImportCSV.tsx
@@ -1,110 +1,110 @@
 // CSV Import - Drag and drop file upload with validation
 
-import { Card } from './ui/card';
-import { Button } from './ui/button';
-import { Upload, FileText, Check, CircleAlert, Loader } from 'lucide-react';
-import { useState } from 'react';
-import { toast } from 'sonner';
-import { parseCSV } from '../services/parsers/csv-parser';
-import { transactionStore } from '../stores/transaction-store';
-import type { ParsedData, Transaction } from '../models';
+import { Card } from './ui/card'
+import { Button } from './ui/button'
+import { Upload, FileText, Check, CircleAlert, Loader } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { parseCSV } from '../services/parsers/csv-parser'
+import { transactionStore } from '../stores/transaction-store'
+import type { ParsedData, Transaction } from '../models'
 
-type ImportState = 'idle' | 'validating' | 'success' | 'error';
-type UiFileType = 'credit_card' | 'usd_account' | 'uyu_account';
+type ImportState = 'idle' | 'validating' | 'success' | 'error'
+type UiFileType = 'credit_card' | 'usd_account' | 'uyu_account'
 
 interface ImportCSVProps {
-  onImportComplete?: () => void;
+  onImportComplete?: () => void
   onTransactionsImported?: (
     transactions: Transaction[],
     context?: {
-      parsedData: ParsedData;
-      csvContent: string;
-      fileName: string;
+      parsedData: ParsedData
+      csvContent: string
+      fileName: string
     }
   ) => Promise<{
-    added: Transaction[];
-    duplicates: Transaction[];
+    added: Transaction[]
+    duplicates: Transaction[]
     /**
      * Set when the import succeeded but AI enrichment did not, so the user can
      * tell a dead API key apart from the model categorizing badly.
      */
     /** Enrichment did not run at all. */
-    aiError?: string;
+    aiError?: string
     /** Enrichment ran but some batches failed; the rest were applied. */
-    aiPartial?: string;
-  }>;
+    aiPartial?: string
+  }>
 }
 
 async function readFileAsText(file: File): Promise<string> {
   if (typeof file.text === 'function') {
-    return file.text();
+    return file.text()
   }
 
   return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result ?? ''));
-    reader.onerror = () => reject(new Error('Error al leer el archivo'));
-    reader.readAsText(file);
-  });
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result ?? ''))
+    reader.onerror = () => reject(new Error('Error al leer el archivo'))
+    reader.readAsText(file)
+  })
 }
 
 export function ImportCSV({
   onImportComplete,
   onTransactionsImported,
 }: ImportCSVProps) {
-  const [importState, setImportState] = useState<ImportState>('idle');
-  const [dragActive, setDragActive] = useState(false);
-  const [fileName, setFileName] = useState<string>('');
-  const [fileType, setFileType] = useState<UiFileType | null>(null);
+  const [importState, setImportState] = useState<ImportState>('idle')
+  const [dragActive, setDragActive] = useState(false)
+  const [fileName, setFileName] = useState<string>('')
+  const [fileType, setFileType] = useState<UiFileType | null>(null)
   const [importSummary, setImportSummary] = useState<{
-    total: number;
-    imported: number;
-    duplicates: number;
-  } | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string>('');
+    total: number
+    imported: number
+    duplicates: number
+  } | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string>('')
 
   const handleDrag = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+    e.preventDefault()
+    e.stopPropagation()
     if (e.type === 'dragenter' || e.type === 'dragover') {
-      setDragActive(true);
+      setDragActive(true)
     } else if (e.type === 'dragleave') {
-      setDragActive(false);
+      setDragActive(false)
     }
-  };
+  }
 
   const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDragActive(false);
+    e.preventDefault()
+    e.stopPropagation()
+    setDragActive(false)
 
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      void handleFile(e.dataTransfer.files[0]);
+      void handleFile(e.dataTransfer.files[0])
     }
-  };
+  }
 
   const handleFile = async (file: File) => {
     if (!file.name.endsWith('.csv')) {
-      setImportState('error');
-      setFileName(file.name);
-      setErrorMessage('El archivo debe estar en formato CSV');
-      return;
+      setImportState('error')
+      setFileName(file.name)
+      setErrorMessage('El archivo debe estar en formato CSV')
+      return
     }
 
-    setFileName(file.name);
-    setImportState('validating');
-    setErrorMessage('');
+    setFileName(file.name)
+    setImportState('validating')
+    setErrorMessage('')
 
     try {
-      const csvContent = await readFileAsText(file);
-      const result = parseCSV(csvContent, file.name);
+      const csvContent = await readFileAsText(file)
+      const result = parseCSV(csvContent, file.name)
 
       if (result.fileType === 'credit_card') {
-        setFileType('credit_card');
+        setFileType('credit_card')
       } else if (result.fileType === 'bank_account_usd') {
-        setFileType('usd_account');
+        setFileType('usd_account')
       } else {
-        setFileType('uyu_account');
+        setFileType('uyu_account')
       }
 
       const { added, duplicates, aiError, aiPartial } = onTransactionsImported
@@ -118,18 +118,18 @@ export function ImportCSV({
             // Local-only path never runs AI enrichment.
             aiError: undefined as string | undefined,
             aiPartial: undefined as string | undefined,
-          };
+          }
 
       setImportSummary({
         total: result.transactions.length,
         imported: added.length,
         duplicates: duplicates.length,
-      });
+      })
 
-      setImportState('success');
+      setImportState('success')
       toast.success(
         `${added.length} nueva${added.length === 1 ? '' : 's'} · ${duplicates.length} duplicada${duplicates.length === 1 ? '' : 's'} omitida${duplicates.length === 1 ? '' : 's'}`
-      );
+      )
 
       // The import succeeded, but the AI step did not — say so, otherwise a
       // dead API key looks identical to poor categorization. Total failure
@@ -138,51 +138,51 @@ export function ImportCSV({
       if (aiError) {
         toast.warning(
           `Categorización con IA no disponible: ${aiError}. Se usaron las reglas de categorización.`
-        );
+        )
       } else if (aiPartial) {
         toast.warning(
           `Categorización con IA incompleta: ${aiPartial}. El resto se categorizó con reglas.`
-        );
+        )
       }
 
       if (onImportComplete) {
-        onImportComplete();
+        onImportComplete()
       }
     } catch (error) {
       console.error('import failed:', error)
-      setImportState('error');
+      setImportState('error')
       setErrorMessage(
         error instanceof Error ? error.message : 'Error al procesar el archivo'
-      );
+      )
     }
-  };
+  }
 
   const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
-      void handleFile(e.target.files[0]);
+      void handleFile(e.target.files[0])
     }
-  };
+  }
 
   const resetImport = () => {
-    setImportState('idle');
-    setFileName('');
-    setFileType(null);
-    setImportSummary(null);
-    setErrorMessage('');
-  };
+    setImportState('idle')
+    setFileName('')
+    setFileType(null)
+    setImportSummary(null)
+    setErrorMessage('')
+  }
 
   const getAccountTypeLabel = (type: UiFileType) => {
     switch (type) {
       case 'credit_card':
-        return 'Tarjeta de Crédito';
+        return 'Tarjeta de Crédito'
       case 'usd_account':
-        return 'Cuenta USD';
+        return 'Cuenta USD'
       case 'uyu_account':
-        return 'Cuenta UYU';
+        return 'Cuenta UYU'
       default:
-        return '';
+        return ''
     }
-  };
+  }
 
   return (
     <div className="space-y-6">
@@ -376,10 +376,10 @@ export function ImportCSV({
       <Card className="p-4 bg-primary-50 dark:bg-primary-900/10 border-primary/20">
         <p className="text-sm">
           <strong>Tus datos son tuyos:</strong> Los movimientos se guardan en tu
-          cuenta de Supabase bajo tu propio usuario. Nadie más tiene acceso a
-          tu información financiera.
+          cuenta de Supabase bajo tu propio usuario. Nadie más tiene acceso a tu
+          información financiera.
         </p>
       </Card>
     </div>
-  );
+  )
 }

--- a/src/components/Insights.test.tsx
+++ b/src/components/Insights.test.tsx
@@ -7,15 +7,12 @@ import { Category } from '../models'
 import type { SupabaseSession } from '../services/supabase/client'
 import type { InsightsResult } from '../services/insights/insight-generator'
 
-const {
-  getCachedInsightsMock,
-  saveCachedInsightsMock,
-  generateInsightsMock,
-} = vi.hoisted(() => ({
-  getCachedInsightsMock: vi.fn(),
-  saveCachedInsightsMock: vi.fn(),
-  generateInsightsMock: vi.fn(),
-}))
+const { getCachedInsightsMock, saveCachedInsightsMock, generateInsightsMock } =
+  vi.hoisted(() => ({
+    getCachedInsightsMock: vi.fn(),
+    saveCachedInsightsMock: vi.fn(),
+    generateInsightsMock: vi.fn(),
+  }))
 
 vi.mock('../services/insights/insight-cache', () => ({
   getCachedInsights: getCachedInsightsMock,
@@ -34,7 +31,10 @@ vi.mock('../services/insights/insight-generator', async () => {
 
 const session = { user: { id: 'user-1' } } as unknown as SupabaseSession
 
-function makeTransaction(id: string, overrides: Partial<Transaction> = {}): Transaction {
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
   return {
     id,
     date: new Date('2026-06-10T00:00:00.000Z'),
@@ -65,7 +65,9 @@ const sampleResult: InsightsResult = {
   ],
 }
 
-function renderInsights(overrides: Partial<Parameters<typeof Insights>[0]> = {}) {
+function renderInsights(
+  overrides: Partial<Parameters<typeof Insights>[0]> = {}
+) {
   return render(
     <Insights
       transactions={transactions}
@@ -90,7 +92,9 @@ describe('Insights', () => {
     const onNavigateToImport = vi.fn()
     renderInsights({ transactions: [], onNavigateToImport })
 
-    expect(screen.getByText('Importá tus movimientos primero')).toBeInTheDocument()
+    expect(
+      screen.getByText('Importá tus movimientos primero')
+    ).toBeInTheDocument()
     expect(getCachedInsightsMock).not.toHaveBeenCalled()
   })
 
@@ -98,7 +102,9 @@ describe('Insights', () => {
     const onNavigateToSettings = vi.fn()
     renderInsights({ aiEnabled: false, claudeApiKey: '', onNavigateToSettings })
 
-    expect(screen.getByText('Activá la IA para ver insights')).toBeInTheDocument()
+    expect(
+      screen.getByText('Activá la IA para ver insights')
+    ).toBeInTheDocument()
     expect(getCachedInsightsMock).not.toHaveBeenCalled()
   })
 
@@ -108,7 +114,9 @@ describe('Insights', () => {
     renderInsights()
 
     await waitFor(() =>
-      expect(screen.getByText('Generá tus primeros insights')).toBeInTheDocument()
+      expect(
+        screen.getByText('Generá tus primeros insights')
+      ).toBeInTheDocument()
     )
   })
 
@@ -133,7 +141,9 @@ describe('Insights', () => {
     renderInsights()
 
     await waitFor(() =>
-      expect(screen.getByText('Restaurantes domina tu gasto')).toBeInTheDocument()
+      expect(
+        screen.getByText('Restaurantes domina tu gasto')
+      ).toBeInTheDocument()
     )
     expect(screen.getByText('¿Dónde se fue tu dinero?')).toBeInTheDocument()
     expect(screen.getByText('US$ 100,00')).toBeInTheDocument()
@@ -172,7 +182,9 @@ describe('Insights', () => {
 
     renderInsights()
 
-    await waitFor(() => expect(screen.getByText(/desactualizados/)).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByText(/desactualizados/)).toBeInTheDocument()
+    )
   })
 
   it('generates and caches new insights when the generate button is clicked', async () => {
@@ -189,11 +201,16 @@ describe('Insights', () => {
     await user.click(screen.getByText('Generar insights'))
 
     await waitFor(() =>
-      expect(screen.getByText('Restaurantes domina tu gasto')).toBeInTheDocument()
+      expect(
+        screen.getByText('Restaurantes domina tu gasto')
+      ).toBeInTheDocument()
     )
 
     expect(generateInsightsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ historyStart: '2026-06-10', historyEnd: '2026-06-10' }),
+      expect.objectContaining({
+        historyStart: '2026-06-10',
+        historyEnd: '2026-06-10',
+      }),
       'sk-test'
     )
     expect(saveCachedInsightsMock).toHaveBeenCalledWith(

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -48,7 +48,10 @@ const TYPE_ORDER: InsightType[] = [
   'anomaly',
 ]
 
-const TYPE_META: Record<InsightType, { label: string; icon: typeof TrendingDown }> = {
+const TYPE_META: Record<
+  InsightType,
+  { label: string; icon: typeof TrendingDown }
+> = {
   bleeding_money: { label: '¿Dónde se fue tu dinero?', icon: TrendingDown },
   easiest_cut: { label: 'Fácil de recortar', icon: Scissors },
   recurring: { label: 'Suscripciones y cargos recurrentes', icon: Repeat },
@@ -56,14 +59,20 @@ const TYPE_META: Record<InsightType, { label: string; icon: typeof TrendingDown 
   anomaly: { label: 'Anomalías', icon: AlertTriangle },
 }
 
-const SEVERITY_RANK: Record<InsightSeverity, number> = { high: 0, medium: 1, low: 2 }
+const SEVERITY_RANK: Record<InsightSeverity, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+}
 const SEVERITY_COLOR: Record<InsightSeverity, string> = {
   high: 'var(--neg)',
   medium: 'var(--accent)',
   low: 'var(--text-faint)',
 }
 
-function groupAndSortInsights(insights: Insight[]): Array<{ type: InsightType; items: Insight[] }> {
+function groupAndSortInsights(
+  insights: Insight[]
+): Array<{ type: InsightType; items: Insight[] }> {
   const byType = new Map<InsightType, Insight[]>()
   insights.forEach((insight) => {
     const list = byType.get(insight.type) ?? []
@@ -121,7 +130,9 @@ export function Insights({
       .catch((e) => {
         if (!cancelled) {
           setError(
-            e instanceof Error ? e.message : 'No se pudieron cargar los insights'
+            e instanceof Error
+              ? e.message
+              : 'No se pudieron cargar los insights'
           )
         }
       })
@@ -174,11 +185,19 @@ export function Insights({
             gap: 10,
           }}
         >
-          <Sparkles size={22} style={{ color: 'var(--accent)' }} aria-hidden="true" />
+          <Sparkles
+            size={22}
+            style={{ color: 'var(--accent)' }}
+            aria-hidden="true"
+          />
           Insights
         </h1>
-        <p className="text-muted-foreground" style={{ fontSize: 14, marginTop: 4 }}>
-          ¿Dónde se fue tu dinero? ¿Cómo podés gastar menos? — toda tu historia, de un vistazo.
+        <p
+          className="text-muted-foreground"
+          style={{ fontSize: 14, marginTop: 4 }}
+        >
+          ¿Dónde se fue tu dinero? ¿Cómo podés gastar menos? — toda tu historia,
+          de un vistazo.
         </p>
       </div>
 
@@ -276,7 +295,10 @@ export function Insights({
           {cached.isStale && (
             <Card
               className="p-4"
-              style={{ borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
+              style={{
+                borderColor: 'var(--accent)',
+                background: 'var(--accent-soft)',
+              }}
             >
               <p style={{ fontSize: 13, margin: 0 }}>
                 Tus transacciones cambiaron desde la última vez que generaste
@@ -324,10 +346,16 @@ export function Insights({
                     marginBottom: 12,
                   }}
                 >
-                  <Icon size={16} style={{ color: 'var(--text-muted)' }} aria-hidden="true" />
+                  <Icon
+                    size={16}
+                    style={{ color: 'var(--text-muted)' }}
+                    aria-hidden="true"
+                  />
                   {meta.label}
                 </h3>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <div
+                  style={{ display: 'flex', flexDirection: 'column', gap: 10 }}
+                >
                   {group.items.map((insight, i) => (
                     <Card
                       key={`${group.type}-${i}`}
@@ -346,7 +374,13 @@ export function Insights({
                         }}
                       >
                         <div style={{ flex: 1, minWidth: 200 }}>
-                          <p style={{ fontWeight: 600, fontSize: 14, margin: '0 0 4px' }}>
+                          <p
+                            style={{
+                              fontWeight: 600,
+                              fontSize: 14,
+                              margin: '0 0 4px',
+                            }}
+                          >
                             {insight.title}
                           </p>
                           <p
@@ -357,7 +391,10 @@ export function Insights({
                           </p>
                           {insight.category && (
                             <div style={{ marginTop: 8 }}>
-                              <CategoryBadge categoryId={insight.category} size="sm" />
+                              <CategoryBadge
+                                categoryId={insight.category}
+                                size="sm"
+                              />
                             </div>
                           )}
                         </div>
@@ -365,16 +402,25 @@ export function Insights({
                           {typeof insight.amount === 'number' && (
                             <p
                               className="font-mono"
-                              style={{ fontSize: 16, fontWeight: 600, margin: 0 }}
+                              style={{
+                                fontSize: 16,
+                                fontWeight: 600,
+                                margin: 0,
+                              }}
                             >
                               {insight.amount < 0 ? '−' : ''}
-                              {formatCurrency(Math.abs(insight.amount), insight.currency)}
+                              {formatCurrency(
+                                Math.abs(insight.amount),
+                                insight.currency
+                              )}
                             </p>
                           )}
                           {insight.category && (
                             <button
                               onClick={() =>
-                                onNavigateToTransactions({ category: insight.category })
+                                onNavigateToTransactions({
+                                  category: insight.category,
+                                })
                               }
                               style={{
                                 marginTop: 6,

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -50,8 +50,8 @@ export function Onboarding({ onImport, onDemo, userName }: OnboardingProps) {
         className="text-muted-foreground mx-auto mt-2.5"
         style={{ maxWidth: 460 }}
       >
-        Importá tu primer extracto de Santander y en segundos vas a ver todos tus
-        gastos ordenados, en pesos y dólares.
+        Importá tu primer extracto de Santander y en segundos vas a ver todos
+        tus gastos ordenados, en pesos y dólares.
       </p>
 
       <div className="grid grid-cols-1 gap-3 my-7 text-left sm:grid-cols-3">

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import { Settings } from './Settings'
 import type { Transaction } from '../models'
 import type { SupabaseSession } from '../services/supabase/client'
@@ -51,7 +57,8 @@ describe('Settings', () => {
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
-        transactions={[]} {...defaultAiProps}
+        transactions={[]}
+        {...defaultAiProps}
       />
     )
 
@@ -75,7 +82,8 @@ describe('Settings', () => {
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
-        transactions={[]} {...defaultAiProps}
+        transactions={[]}
+        {...defaultAiProps}
       />
     )
 
@@ -97,7 +105,8 @@ describe('Settings', () => {
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
-        transactions={[]} {...defaultAiProps}
+        transactions={[]}
+        {...defaultAiProps}
       />
     )
 
@@ -115,7 +124,8 @@ describe('Settings', () => {
         session={mockSession}
         supabaseEnabled={true}
         onSignOut={() => {}}
-        transactions={[]} {...defaultAiProps}
+        transactions={[]}
+        {...defaultAiProps}
       />
     )
 
@@ -134,7 +144,8 @@ describe('Settings', () => {
         session={mockSession}
         supabaseEnabled={true}
         onSignOut={onSignOut}
-        transactions={[]} {...defaultAiProps}
+        transactions={[]}
+        {...defaultAiProps}
       />
     )
 
@@ -152,7 +163,8 @@ describe('Settings', () => {
         session={null}
         supabaseEnabled={false}
         onSignOut={() => {}}
-        transactions={[]} {...defaultAiProps}
+        transactions={[]}
+        {...defaultAiProps}
       />
     )
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -34,8 +34,6 @@ interface SettingsProps {
   onSetAiModel: (model: string) => void
 }
 
-
-
 function SettingRow({
   label,
   description,
@@ -186,7 +184,13 @@ export function Settings({
           description="Usado para convertir entre USD y UYU en resúmenes y análisis"
           control={
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span style={{ fontSize: 13, color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>
+              <span
+                style={{
+                  fontSize: 13,
+                  color: 'var(--text-muted)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 1 US$ =
               </span>
               <input
@@ -211,7 +215,9 @@ export function Settings({
                   textAlign: 'right',
                 }}
               />
-              <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>$U</span>
+              <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+                $U
+              </span>
             </div>
           }
         />
@@ -267,8 +273,8 @@ export function Settings({
                 style={{ color: 'var(--brand)', textDecoration: 'underline' }}
               >
                 console.anthropic.com
-              </a>
-              {' '}· El costo de uso es tuyo · Se guarda en tu cuenta
+              </a>{' '}
+              · El costo de uso es tuyo · Se guarda en tu cuenta
             </>
           }
           control={
@@ -312,7 +318,12 @@ export function Settings({
           label="Modelo"
           description="Haiku es más rápido y económico; Sonnet es más preciso"
           control={
-            <div style={{ opacity: aiEnabled ? 1 : 0.5, pointerEvents: aiEnabled ? 'auto' : 'none' }}>
+            <div
+              style={{
+                opacity: aiEnabled ? 1 : 0.5,
+                pointerEvents: aiEnabled ? 'auto' : 'none',
+              }}
+            >
               <SegmentedToggle
                 options={[
                   { label: 'Haiku', value: 'claude-haiku-4-5' as const },
@@ -369,7 +380,13 @@ export function Settings({
                   <div style={{ fontSize: 14, fontWeight: 600 }}>
                     {userName}
                   </div>
-                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--text-muted)',
+                      marginTop: 1,
+                    }}
+                  >
                     {userEmail} · sincronizado en la nube
                   </div>
                 </div>
@@ -429,8 +446,15 @@ export function Settings({
             borderTop: '1px solid var(--border)',
           }}
         >
-          <p style={{ fontSize: 12, color: 'var(--brand-text)', lineHeight: 1.5 }}>
-            Tus movimientos se guardan cifrados en tu cuenta y se sincronizan de forma segura. Nunca compartimos tus datos financieros con terceros.
+          <p
+            style={{
+              fontSize: 12,
+              color: 'var(--brand-text)',
+              lineHeight: 1.5,
+            }}
+          >
+            Tus movimientos se guardan cifrados en tu cuenta y se sincronizan de
+            forma segura. Nunca compartimos tus datos financieros con terceros.
           </p>
         </div>
       </SectionCard>
@@ -444,7 +468,12 @@ export function Settings({
             <Button
               variant="outline"
               onClick={() => handleExport('csv')}
-              style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 6 }}
+              style={{
+                fontSize: 13,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
             >
               <Download size={14} />
               Exportar CSV
@@ -458,7 +487,12 @@ export function Settings({
             <Button
               variant="outline"
               onClick={() => handleExport('pdf')}
-              style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 6 }}
+              style={{
+                fontSize: 13,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
             >
               <Download size={14} />
               Exportar PDF
@@ -478,7 +512,9 @@ export function Settings({
             <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--neg)' }}>
               Eliminar todos los datos
             </div>
-            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>
+            <div
+              style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}
+            >
               Borra todas las transacciones, categorías y reglas guardadas
             </div>
           </div>

--- a/src/components/SplitTransactionDialog.tsx
+++ b/src/components/SplitTransactionDialog.tsx
@@ -79,9 +79,7 @@ export function SplitTransactionDialog({
   const canConfirm = isBalanced && hasAllAmounts && !pending
 
   function updatePart(idx: number, patch: Partial<SplitPartDraft>) {
-    setParts((prev) =>
-      prev.map((p, i) => (i === idx ? { ...p, ...patch } : p))
-    )
+    setParts((prev) => prev.map((p, i) => (i === idx ? { ...p, ...patch } : p)))
   }
 
   function addPart() {

--- a/src/components/StateSkeletons.tsx
+++ b/src/components/StateSkeletons.tsx
@@ -109,9 +109,11 @@ export function TransactionTableSkeleton({ rows = 8 }: { rows?: number }) {
 
       <Card className="overflow-hidden">
         <div className="border-b border-border bg-muted/40 px-4 py-3 hidden md:flex gap-4">
-          {['w-4', 'w-16', 'w-40', 'w-24', 'w-16', 'w-10', 'w-16'].map((w, i) => (
-            <Skeleton key={i} className={`h-3 ${w}`} />
-          ))}
+          {['w-4', 'w-16', 'w-40', 'w-24', 'w-16', 'w-10', 'w-16'].map(
+            (w, i) => (
+              <Skeleton key={i} className={`h-3 ${w}`} />
+            )
+          )}
         </div>
         {Array.from({ length: rows }).map((_, i) => (
           <div
@@ -136,4 +138,3 @@ export function TransactionTableSkeleton({ rows = 8 }: { rows?: number }) {
     </div>
   )
 }
-

--- a/src/components/TransactionFilters.tsx
+++ b/src/components/TransactionFilters.tsx
@@ -362,9 +362,7 @@ export function TransactionFilters({
           }}
         >
           <div>
-            <label
-              className="text-xs font-medium text-muted-foreground uppercase tracking-wider block mb-1.5"
-            >
+            <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider block mb-1.5">
               Monto mínimo
             </label>
             <Input
@@ -376,9 +374,7 @@ export function TransactionFilters({
             />
           </div>
           <div>
-            <label
-              className="text-xs font-medium text-muted-foreground uppercase tracking-wider block mb-1.5"
-            >
+            <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider block mb-1.5">
               Monto máximo
             </label>
             <Input

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -129,7 +129,9 @@ export function TransactionTable({
             borderRadius: 8,
             border: `1px solid ${showIgnored ? 'var(--brand)' : 'var(--border)'}`,
             background: 'transparent',
-            color: showIgnored ? 'var(--brand-text, var(--brand))' : 'var(--text-muted)',
+            color: showIgnored
+              ? 'var(--brand-text, var(--brand))'
+              : 'var(--text-muted)',
             cursor: ignoredCount === 0 ? 'not-allowed' : 'pointer',
             fontSize: 12.5,
             fontWeight: 500,
@@ -605,11 +607,17 @@ export function TransactionTable({
                     ? {
                         opacity: 0.62,
                         ...(isSplitChildM
-                          ? { borderLeft: '2px solid var(--border)', paddingLeft: 20 }
+                          ? {
+                              borderLeft: '2px solid var(--border)',
+                              paddingLeft: 20,
+                            }
                           : {}),
                       }
                     : isSplitChildM
-                      ? { borderLeft: '2px solid var(--border)', paddingLeft: 20 }
+                      ? {
+                          borderLeft: '2px solid var(--border)',
+                          paddingLeft: 20,
+                        }
                       : undefined
                 }
                 className="p-4 space-y-3"
@@ -720,9 +728,7 @@ export function TransactionTable({
 
                 <div className="flex items-center gap-2 flex-wrap">
                   <CategoryBadge
-                    categoryId={
-                      transaction.category || Category.Uncategorized
-                    }
+                    categoryId={transaction.category || Category.Uncategorized}
                     size="sm"
                   />
                   <ConfidenceBadge

--- a/src/components/Transactions.test.tsx
+++ b/src/components/Transactions.test.tsx
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import { Transactions } from './Transactions'
 import type { Transaction } from '../models'
 
@@ -98,22 +105,18 @@ describe('Transactions', () => {
       screen.getByPlaceholderText('Buscar por comercio o descripción...'),
       { target: { value: 'alpha' } }
     )
-    fireEvent.change(
-      screen.getByLabelText('Filtro fecha desde'),
-      { target: { value: '2026-01-12' } }
-    )
-    fireEvent.change(
-      screen.getByLabelText('Filtro fecha hasta'),
-      { target: { value: '2026-01-18' } }
-    )
-    fireEvent.change(
-      screen.getByLabelText('Filtro categoría'),
-      { target: { value: 'groceries' } }
-    )
-    fireEvent.change(
-      screen.getByLabelText('Filtro cuenta'),
-      { target: { value: 'credit_card' } }
-    )
+    fireEvent.change(screen.getByLabelText('Filtro fecha desde'), {
+      target: { value: '2026-01-12' },
+    })
+    fireEvent.change(screen.getByLabelText('Filtro fecha hasta'), {
+      target: { value: '2026-01-18' },
+    })
+    fireEvent.change(screen.getByLabelText('Filtro categoría'), {
+      target: { value: 'groceries' },
+    })
+    fireEvent.change(screen.getByLabelText('Filtro cuenta'), {
+      target: { value: 'credit_card' },
+    })
 
     expect(screen.getAllByText('Alpha Card').length).toBeGreaterThan(0)
     expect(screen.queryByText('Alpha Market')).not.toBeInTheDocument()
@@ -348,9 +351,7 @@ describe('Transactions', () => {
 
     expect(screen.getAllByText('12 seleccionadas').length).toBeGreaterThan(0)
 
-    fireEvent.click(
-      screen.getByText('Seleccionar las 25 transacciones')
-    )
+    fireEvent.click(screen.getByText('Seleccionar las 25 transacciones'))
 
     expect(screen.getAllByText('25 seleccionadas').length).toBeGreaterThan(0)
   })
@@ -592,9 +593,7 @@ describe('Transactions', () => {
     )
 
     await act(async () => {
-      fireEvent.click(
-        screen.getAllByRole('button', { name: /Editar/ })[0]
-      )
+      fireEvent.click(screen.getAllByRole('button', { name: /Editar/ })[0])
     })
 
     fireEvent.click(screen.getByLabelText('Categoría bulk dropdown'))
@@ -697,9 +696,7 @@ describe('Transactions', () => {
     )
 
     await act(async () => {
-      fireEvent.click(
-        screen.getAllByRole('button', { name: /Editar/ })[0]
-      )
+      fireEvent.click(screen.getAllByRole('button', { name: /Editar/ })[0])
     })
 
     fireEvent.click(screen.getByLabelText('Etiquetas bulk dropdown'))
@@ -728,9 +725,7 @@ describe('Transactions', () => {
       screen.getAllByRole('checkbox', { name: 'Seleccionar Devoto' })[0]
     )
 
-    fireEvent.click(
-      screen.getAllByRole('button', { name: /Editar/ })[0]
-    )
+    fireEvent.click(screen.getAllByRole('button', { name: /Editar/ })[0])
 
     fireEvent.click(screen.getByLabelText('Etiquetas bulk dropdown'))
 
@@ -738,7 +733,9 @@ describe('Transactions', () => {
       target: { value: 'new-tag' },
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /Crear etiqueta "new-tag"/ }))
+    fireEvent.click(
+      screen.getByRole('button', { name: /Crear etiqueta "new-tag"/ })
+    )
 
     fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }))
 

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -43,12 +43,32 @@ import type { TransactionsFilter } from '../models'
 
 /* ---- Period helpers ---- */
 const MONTHS_ES = [
-  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
 ]
 const MONTHS_ES_SHORT = [
-  'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
-  'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic',
+  'Ene',
+  'Feb',
+  'Mar',
+  'Abr',
+  'May',
+  'Jun',
+  'Jul',
+  'Ago',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dic',
 ]
 
 type Period =
@@ -72,11 +92,7 @@ function periodRange(period: Period): { from: string; to: string } {
   }
   if (period.mode === 'recent') {
     const to = period.anchor
-    const from = new Date(
-      to.getFullYear(),
-      to.getMonth() - (period.n - 1),
-      1
-    )
+    const from = new Date(to.getFullYear(), to.getMonth() - (period.n - 1), 1)
     return {
       from: isoDay(from),
       to: isoDay(new Date(to.getFullYear(), to.getMonth() + 1, 0)),
@@ -96,9 +112,7 @@ function getPeriodLabel(period: Period): string {
     const f = period.from
       ? period.from.slice(8) + '/' + period.from.slice(5, 7)
       : '…'
-    const t = period.to
-      ? period.to.slice(8) + '/' + period.to.slice(5, 7)
-      : '…'
+    const t = period.to ? period.to.slice(8) + '/' + period.to.slice(5, 7) : '…'
     return `${f} → ${t}`
   }
   return 'Período'
@@ -118,17 +132,13 @@ function MonthNav({
   const ref = useRef<HTMLDivElement>(null)
   useClickOutside(ref, () => setOpen(false))
 
-  const anchorY =
-    period.mode === 'month' ? period.y : newest.getFullYear()
-  const anchorM =
-    period.mode === 'month' ? period.m : newest.getMonth()
+  const anchorY = period.mode === 'month' ? period.y : newest.getFullYear()
+  const anchorM = period.mode === 'month' ? period.m : newest.getMonth()
   const [gridYear, setGridYear] = useState(anchorY)
 
   useEffect(() => {
     if (open) {
-      setGridYear(
-        period.mode === 'month' ? period.y : newest.getFullYear()
-      )
+      setGridYear(period.mode === 'month' ? period.y : newest.getFullYear())
     }
   }, [open, period, newest])
 
@@ -174,12 +184,10 @@ function MonthNav({
             placeItems: 'center',
           }}
           onMouseEnter={(e) =>
-            ((e.currentTarget as HTMLElement).style.background =
-              'var(--muted)')
+            ((e.currentTarget as HTMLElement).style.background = 'var(--muted)')
           }
           onMouseLeave={(e) =>
-            ((e.currentTarget as HTMLElement).style.background =
-              'transparent')
+            ((e.currentTarget as HTMLElement).style.background = 'transparent')
           }
         >
           <ChevronLeft size={17} />
@@ -235,12 +243,10 @@ function MonthNav({
           }}
           onMouseEnter={(e) => {
             if (!nextDisabled)
-              (e.currentTarget as HTMLElement).style.background =
-                'var(--muted)'
+              (e.currentTarget as HTMLElement).style.background = 'var(--muted)'
           }}
           onMouseLeave={(e) =>
-            ((e.currentTarget as HTMLElement).style.background =
-              'transparent')
+            ((e.currentTarget as HTMLElement).style.background = 'transparent')
           }
         >
           <ChevronRight size={17} />
@@ -307,7 +313,13 @@ function MonthNav({
               </Button>
             ))}
           </div>
-          <hr style={{ margin: '0 -14px 12px', border: 'none', borderTop: '1px solid var(--border)' }} />
+          <hr
+            style={{
+              margin: '0 -14px 12px',
+              border: 'none',
+              borderTop: '1px solid var(--border)',
+            }}
+          />
           {/* Year nav */}
           <div
             style={{
@@ -421,7 +433,9 @@ function TotalTile({
           minWidth: 0,
         }}
       >
-        <span style={{ color: 'var(--text-muted)', display: 'grid', flexShrink: 0 }}>
+        <span
+          style={{ color: 'var(--text-muted)', display: 'grid', flexShrink: 0 }}
+        >
           {icon}
         </span>
         <span
@@ -520,7 +534,9 @@ function TotalsStrip({
         label="Transferencias"
         icon={<Slash size={14} />}
         value={String(ignoredCount)}
-        sub={ignoredCount ? 'Ignoradas · no se cuentan' : 'Ninguna en el período'}
+        sub={
+          ignoredCount ? 'Ignoradas · no se cuentan' : 'Ninguna en el período'
+        }
       />
     </div>
   )
@@ -607,9 +623,7 @@ function BulkBar({
           </button>
         )}
 
-        <span
-          style={{ width: 1, height: 22, background: 'var(--border)' }}
-        />
+        <span style={{ width: 1, height: 22, background: 'var(--border)' }} />
 
         <div
           style={{ display: 'flex', gap: 4, position: 'relative' }}
@@ -794,9 +808,7 @@ function BulkBar({
           </button>
         </div>
 
-        <span
-          style={{ width: 1, height: 22, background: 'var(--border)' }}
-        />
+        <span style={{ width: 1, height: 22, background: 'var(--border)' }} />
 
         <button
           onClick={onClear}
@@ -853,10 +865,7 @@ interface TransactionsProps {
     category: string
   ) => Promise<void> | void
   onBulkDelete?: (transactionIds: string[]) => Promise<void> | void
-  onBulkTag?: (
-    transactionIds: string[],
-    tag: string
-  ) => Promise<void> | void
+  onBulkTag?: (transactionIds: string[], tag: string) => Promise<void> | void
   onSplitTransaction?: (
     transactionId: string,
     parts: Array<{ description: string; amount: number; category?: string }>
@@ -1003,9 +1012,7 @@ export function Transactions({
 
   const filteredCategorySuggestions = useMemo(() => {
     const query = newCategoryInput.trim().toLowerCase()
-    const base = categorySuggestions.filter(
-      (c) => c !== Category.Uncategorized
-    )
+    const base = categorySuggestions.filter((c) => c !== Category.Uncategorized)
     if (!query) return base
     return base.filter((category) => {
       const label = getCategoryDisplay(category).label.toLowerCase()
@@ -1224,7 +1231,11 @@ export function Transactions({
   }
 
   async function handleBulkIgnore() {
-    if (!onBulkCategorize || selectedTransactionIds.length === 0 || isBulkOperating)
+    if (
+      !onBulkCategorize ||
+      selectedTransactionIds.length === 0 ||
+      isBulkOperating
+    )
       return
     const count = selectedTransactionIds.length
     setIsBulkOperating(true)
@@ -1305,9 +1316,7 @@ export function Transactions({
 
   const allPageSelected =
     paginatedTransactionIds.length > 0 &&
-    paginatedTransactionIds.every((id) =>
-      selectedTransactionIds.includes(id)
-    )
+    paginatedTransactionIds.every((id) => selectedTransactionIds.includes(id))
   const somePageSelected =
     !allPageSelected &&
     paginatedTransactionIds.some((id) => selectedTransactionIds.includes(id))
@@ -1341,8 +1350,8 @@ export function Transactions({
             Transacciones
           </h1>
           <p className="text-muted-foreground" style={{ fontSize: 14 }}>
-            {filteredTransactions.length}{' '}
-            movimiento{filteredTransactions.length !== 1 ? 's' : ''}
+            {filteredTransactions.length} movimiento
+            {filteredTransactions.length !== 1 ? 's' : ''}
             {hasActiveFilters ? ' · filtrado' : ''} · {periodLabelText}
           </p>
         </div>

--- a/src/components/dev/AiCategorizationPreview.tsx
+++ b/src/components/dev/AiCategorizationPreview.tsx
@@ -105,7 +105,10 @@ export function AiCategorizationPreview({
       // Step 1: rule-based categorization on every transaction (no context,
       // matching what the CSV parsers do at import time)
       const ruleResults = new Map(
-        sample.map((tx) => [tx.id, categorizeTransaction(tx.description, tx.type)])
+        sample.map((tx) => [
+          tx.id,
+          categorizeTransaction(tx.description, tx.type),
+        ])
       )
 
       // Step 2: apply same override filter as production
@@ -134,17 +137,25 @@ export function AiCategorizationPreview({
         source: tx.source,
       }))
 
-      const aiResults = toEnrich.length > 0
-        ? (await enrichTransactionsWithAi(inputs, config, buildCorrectionContext()))
-            .results
-        : new Map()
+      const aiResults =
+        toEnrich.length > 0
+          ? (
+              await enrichTransactionsWithAi(
+                inputs,
+                config,
+                buildCorrectionContext()
+              )
+            ).results
+          : new Map()
 
       // Step 4: build rows
       const built: PreviewRow[] = sample.map((tx) => {
         const ruleCat = getCategoryDefinition(
           ruleResults.get(tx.id)?.category ?? 'uncategorized'
         ).id
-        const storedCat = getCategoryDefinition(tx.category ?? 'uncategorized').id
+        const storedCat = getCategoryDefinition(
+          tx.category ?? 'uncategorized'
+        ).id
         const aiResult = aiResults.get(tx.id)
 
         let finalCategory: string
@@ -181,7 +192,14 @@ export function AiCategorizationPreview({
 
       setRows(built)
       setRunState('done')
-      console.debug('[AI Preview] sample:', sample.length, 'overridden:', overriddenIds.size, 'to AI:', toEnrich.length)
+      console.debug(
+        '[AI Preview] sample:',
+        sample.length,
+        'overridden:',
+        overriddenIds.size,
+        'to AI:',
+        toEnrich.length
+      )
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error desconocido')
       setRunState('error')
@@ -226,7 +244,8 @@ export function AiCategorizationPreview({
             color: 'var(--destructive)',
             margin: 0,
             padding: '8px 12px',
-            background: 'color-mix(in srgb, var(--destructive) 10%, transparent)',
+            background:
+              'color-mix(in srgb, var(--destructive) 10%, transparent)',
             borderRadius: 6,
           }}
         >
@@ -244,10 +263,16 @@ export function AiCategorizationPreview({
             }}
           >
             <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
-              <strong style={{ color: 'var(--foreground)' }}>{diffCount}</strong>{' '}
+              <strong style={{ color: 'var(--foreground)' }}>
+                {diffCount}
+              </strong>{' '}
               diferencia{diffCount !== 1 ? 's' : ''} ·{' '}
-              <strong style={{ color: 'var(--foreground)' }}>{aiCount}</strong> por IA ·{' '}
-              <strong style={{ color: 'var(--foreground)' }}>{overrideCount}</strong> con override
+              <strong style={{ color: 'var(--foreground)' }}>{aiCount}</strong>{' '}
+              por IA ·{' '}
+              <strong style={{ color: 'var(--foreground)' }}>
+                {overrideCount}
+              </strong>{' '}
+              con override
             </span>
             <label
               style={{
@@ -292,23 +317,29 @@ export function AiCategorizationPreview({
                     zIndex: 1,
                   }}
                 >
-                  {['Fecha', 'Descripción', 'Nombre sugerido', 'Almacenada', 'Final', 'Fuente', 'Confianza'].map(
-                    (h) => (
-                      <th
-                        key={h}
-                        style={{
-                          padding: '8px 12px',
-                          textAlign: 'left',
-                          fontWeight: 500,
-                          color: 'var(--text-muted)',
-                          borderBottom: '1px solid var(--border)',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {h}
-                      </th>
-                    )
-                  )}
+                  {[
+                    'Fecha',
+                    'Descripción',
+                    'Nombre sugerido',
+                    'Almacenada',
+                    'Final',
+                    'Fuente',
+                    'Confianza',
+                  ].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        padding: '8px 12px',
+                        textAlign: 'left',
+                        fontWeight: 500,
+                        color: 'var(--text-muted)',
+                        borderBottom: '1px solid var(--border)',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody>
@@ -346,16 +377,21 @@ export function AiCategorizationPreview({
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
-                        color: row.source === 'ai' && row.aiDisplayDescription !== row.originalDescription
-                          ? 'var(--foreground)'
-                          : 'var(--text-muted)',
+                        color:
+                          row.source === 'ai' &&
+                          row.aiDisplayDescription !== row.originalDescription
+                            ? 'var(--foreground)'
+                            : 'var(--text-muted)',
                       }}
                       title={row.aiDisplayDescription}
                     >
                       {row.source === 'ai' ? row.aiDisplayDescription : '—'}
                     </td>
                     <td style={cellStyle}>
-                      <CategoryBadge categoryId={row.storedCategory} size="sm" />
+                      <CategoryBadge
+                        categoryId={row.storedCategory}
+                        size="sm"
+                      />
                     </td>
                     <td style={cellStyle}>
                       <CategoryBadge categoryId={row.finalCategory} size="sm" />

--- a/src/components/dev/AiPatternAnalysis.tsx
+++ b/src/components/dev/AiPatternAnalysis.tsx
@@ -12,7 +12,11 @@ interface Props {
 
 type RunState = 'idle' | 'running' | 'done' | 'error'
 
-export function AiPatternAnalysis({ transactions, claudeApiKey, aiModel }: Props) {
+export function AiPatternAnalysis({
+  transactions,
+  claudeApiKey,
+  aiModel,
+}: Props) {
   const [runState, setRunState] = useState<RunState>('idle')
   const [output, setOutput] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -26,7 +30,11 @@ export function AiPatternAnalysis({ transactions, claudeApiKey, aiModel }: Props
     setOutput('')
 
     try {
-      const config: AiConfig = { apiKey: claudeApiKey, enabled: true, model: aiModel }
+      const config: AiConfig = {
+        apiKey: claudeApiKey,
+        enabled: true,
+        model: aiModel,
+      }
       const result = await analyzeTransactionPatterns(transactions, config)
       setOutput(result)
       setRunState('done')
@@ -67,7 +75,8 @@ export function AiPatternAnalysis({ transactions, claudeApiKey, aiModel }: Props
             color: 'var(--destructive)',
             margin: 0,
             padding: '8px 12px',
-            background: 'color-mix(in srgb, var(--destructive) 10%, transparent)',
+            background:
+              'color-mix(in srgb, var(--destructive) 10%, transparent)',
             borderRadius: 6,
           }}
         >

--- a/src/components/dev/CoverageAnalysis.tsx
+++ b/src/components/dev/CoverageAnalysis.tsx
@@ -65,7 +65,10 @@ async function runAnalysis(session: SupabaseSession): Promise<AnalysisResult> {
     const categoryCounts = new Map<string, number>()
     for (const tx of txs) {
       if (tx.category) {
-        categoryCounts.set(tx.category, (categoryCounts.get(tx.category) ?? 0) + 1)
+        categoryCounts.set(
+          tx.category,
+          (categoryCounts.get(tx.category) ?? 0) + 1
+        )
       }
     }
     const dbCategory = [...categoryCounts.entries()].sort(
@@ -99,13 +102,7 @@ async function runAnalysis(session: SupabaseSession): Promise<AnalysisResult> {
   }
 }
 
-function Pill({
-  label,
-  color,
-}: {
-  label: string
-  color: string
-}) {
+function Pill({ label, color }: { label: string; color: string }) {
   return (
     <span
       style={{
@@ -130,25 +127,68 @@ function MerchantTable({ rows }: { rows: MerchantStat[] }) {
 
   return (
     <div style={{ marginTop: 8 }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+      <table
+        style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}
+      >
         <thead>
-          <tr style={{ borderBottom: '1px solid var(--border)', textAlign: 'left' }}>
-            <th style={{ padding: '6px 8px', color: 'var(--text-muted)', fontWeight: 600 }}>
+          <tr
+            style={{
+              borderBottom: '1px solid var(--border)',
+              textAlign: 'left',
+            }}
+          >
+            <th
+              style={{
+                padding: '6px 8px',
+                color: 'var(--text-muted)',
+                fontWeight: 600,
+              }}
+            >
               Merchant
             </th>
-            <th style={{ padding: '6px 8px', color: 'var(--text-muted)', fontWeight: 600 }}>
+            <th
+              style={{
+                padding: '6px 8px',
+                color: 'var(--text-muted)',
+                fontWeight: 600,
+              }}
+            >
               Classified as
             </th>
-            <th style={{ padding: '6px 8px', color: 'var(--text-muted)', fontWeight: 600 }}>
+            <th
+              style={{
+                padding: '6px 8px',
+                color: 'var(--text-muted)',
+                fontWeight: 600,
+              }}
+            >
               DB category
             </th>
-            <th style={{ padding: '6px 8px', color: 'var(--text-muted)', fontWeight: 600 }}>
+            <th
+              style={{
+                padding: '6px 8px',
+                color: 'var(--text-muted)',
+                fontWeight: 600,
+              }}
+            >
               Conf
             </th>
-            <th style={{ padding: '6px 8px', color: 'var(--text-muted)', fontWeight: 600 }}>
+            <th
+              style={{
+                padding: '6px 8px',
+                color: 'var(--text-muted)',
+                fontWeight: 600,
+              }}
+            >
               Freq
             </th>
-            <th style={{ padding: '6px 8px', color: 'var(--text-muted)', fontWeight: 600 }}>
+            <th
+              style={{
+                padding: '6px 8px',
+                color: 'var(--text-muted)',
+                fontWeight: 600,
+              }}
+            >
               Override
             </th>
           </tr>
@@ -178,10 +218,20 @@ function MerchantTable({ rows }: { rows: MerchantStat[] }) {
               <td style={{ padding: '6px 8px', color: 'var(--text-muted)' }}>
                 {row.dbCategory ?? '—'}
               </td>
-              <td style={{ padding: '6px 8px', fontVariantNumeric: 'tabular-nums' }}>
+              <td
+                style={{
+                  padding: '6px 8px',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
                 {(row.confidence * 100).toFixed(0)}%
               </td>
-              <td style={{ padding: '6px 8px', fontVariantNumeric: 'tabular-nums' }}>
+              <td
+                style={{
+                  padding: '6px 8px',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
                 {row.frequency}
               </td>
               <td style={{ padding: '6px 8px' }}>
@@ -211,7 +261,11 @@ function MerchantTable({ rows }: { rows: MerchantStat[] }) {
   )
 }
 
-export function CoverageAnalysis({ session }: { session: SupabaseSession | null }) {
+export function CoverageAnalysis({
+  session,
+}: {
+  session: SupabaseSession | null
+}) {
   const [result, setResult] = useState<AnalysisResult | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -235,7 +289,14 @@ export function CoverageAnalysis({ session }: { session: SupabaseSession | null 
 
   return (
     <div style={{ padding: '16px 24px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          marginBottom: 16,
+        }}
+      >
         <Button
           variant="outline"
           onClick={() => void handleRun()}
@@ -252,7 +313,14 @@ export function CoverageAnalysis({ session }: { session: SupabaseSession | null 
       {result && (
         <div>
           {/* Summary pills */}
-          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              flexWrap: 'wrap',
+              marginBottom: 16,
+            }}
+          >
             <Pill
               label={`${result.totalUnique} merchants únicos`}
               color="oklch(0.45 0.05 260)"
@@ -286,7 +354,9 @@ export function CoverageAnalysis({ session }: { session: SupabaseSession | null 
             {result.overrideCount} overrides de usuario confirmados.{' '}
             {result.lowInOverrides > 0 && (
               <span style={{ color: 'var(--neg)' }}>
-                {result.lowInOverrides} merchants con override están en la zona baja — ya cubiertos por el usuario, buenos para patrones derivados.
+                {result.lowInOverrides} merchants con override están en la zona
+                baja — ya cubiertos por el usuario, buenos para patrones
+                derivados.
               </span>
             )}
           </div>
@@ -304,11 +374,16 @@ export function CoverageAnalysis({ session }: { session: SupabaseSession | null 
                   border: '1px solid var(--border)',
                   cursor: 'pointer',
                   fontWeight: activeTab === t ? 600 : 400,
-                  background: activeTab === t ? 'var(--surface-2)' : 'transparent',
+                  background:
+                    activeTab === t ? 'var(--surface-2)' : 'transparent',
                   color: 'var(--text)',
                 }}
               >
-                {t === 'low' ? `Baja (${result.low.length})` : t === 'medium' ? `Media (${result.medium.length})` : `Alta (${result.high.length})`}
+                {t === 'low'
+                  ? `Baja (${result.low.length})`
+                  : t === 'medium'
+                    ? `Media (${result.medium.length})`
+                    : `Alta (${result.high.length})`}
               </button>
             ))}
           </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,15 +1,15 @@
-"use client";
+'use client'
 
-import * as React from "react";
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import * as React from 'react'
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
-import { cn } from "./utils";
-import { buttonVariants } from "./button";
+import { cn } from './utils'
+import { buttonVariants } from './button'
 
 function AlertDialog({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
 }
 
 function AlertDialogTrigger({
@@ -17,7 +17,7 @@ function AlertDialogTrigger({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
   return (
     <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  );
+  )
 }
 
 function AlertDialogPortal({
@@ -25,7 +25,7 @@ function AlertDialogPortal({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return (
     <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  );
+  )
 }
 
 function AlertDialogOverlay({
@@ -36,12 +36,12 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className,
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
 function AlertDialogContent({
@@ -54,42 +54,42 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className,
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className
         )}
         {...props}
       />
     </AlertDialogPortal>
-  );
+  )
 }
 
 function AlertDialogHeader({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  );
+  )
 }
 
 function AlertDialogFooter({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className,
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
 function AlertDialogTitle({
@@ -99,10 +99,10 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-lg font-semibold", className)}
+      className={cn('text-lg font-semibold', className)}
       {...props}
     />
-  );
+  )
 }
 
 function AlertDialogDescription({
@@ -112,10 +112,10 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  );
+  )
 }
 
 function AlertDialogAction({
@@ -127,7 +127,7 @@ function AlertDialogAction({
       className={cn(buttonVariants(), className)}
       {...props}
     />
-  );
+  )
 }
 
 function AlertDialogCancel({
@@ -136,10 +136,10 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
       {...props}
     />
-  );
+  )
 }
 
 export {
@@ -154,4 +154,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-};
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,38 +1,38 @@
-import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  },
-);
+  }
+)
 
 function Badge({
   className,
   variant,
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
+}: React.ComponentProps<'span'> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span";
+  const Comp = asChild ? Slot : 'span'
 
   return (
     <Comp
@@ -40,7 +40,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  );
+  )
 }
 
-export { Badge, badgeVariants };
+export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,38 +1,38 @@
-import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          "border bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          'border bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9 rounded-md",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9 rounded-md',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  },
-);
+  }
+)
 
 function Button({
   className,
@@ -40,11 +40,11 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
+    asChild?: boolean
   }) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : 'button'
 
   return (
     <Comp
@@ -52,7 +52,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  );
+  )
 }
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,84 +1,84 @@
-import * as React from "react";
+import * as React from 'react'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border",
-        className,
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
-        className,
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <h4
       data-slot="card-title"
-      className={cn("leading-none", className)}
+      className={cn('leading-none', className)}
       {...props}
     />
-  );
+  )
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <p
       data-slot="card-description"
-      className={cn("text-muted-foreground", className)}
+      className={cn('text-muted-foreground', className)}
       {...props}
     />
-  );
+  )
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
       className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className,
+        'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6 [&:last-child]:pb-6", className)}
+      className={cn('px-6 [&:last-child]:pb-6', className)}
       {...props}
     />
-  );
+  )
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 pb-6 [.border-t]:pt-6", className)}
+      className={cn('flex items-center px-6 pb-6 [.border-t]:pt-6', className)}
       {...props}
     />
-  );
+  )
 }
 
 function SectionCard({
@@ -86,15 +86,15 @@ function SectionCard({
   children,
   className,
   ...props
-}: { title: string; children: React.ReactNode } & React.ComponentProps<"div">) {
+}: { title: string; children: React.ReactNode } & React.ComponentProps<'div'>) {
   return (
-    <Card className={cn("overflow-hidden mb-4", className)} {...props}>
+    <Card className={cn('overflow-hidden mb-4', className)} {...props}>
       <div className="px-6 py-4 border-b border-border">
         <h3 className="text-[15px] font-semibold">{title}</h3>
       </div>
       <div>{children}</div>
     </Card>
-  );
+  )
 }
 
 export {
@@ -106,4 +106,4 @@ export {
   CardDescription,
   CardContent,
   SectionCard,
-};
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client'
 
-import * as React from "react";
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { CheckIcon } from "lucide-react";
+import * as React from 'react'
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { CheckIcon } from 'lucide-react'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
 function Checkbox({
   className,
@@ -14,8 +14,8 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border bg-input-background dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        'peer border bg-input-background dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className
       )}
       {...props}
     >
@@ -26,7 +26,7 @@ function Checkbox({
         <CheckIcon className="size-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
-  );
+  )
 }
 
-export { Checkbox };
+export { Checkbox }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,33 +1,33 @@
-"use client";
+'use client'
 
-import * as React from "react";
-import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { XIcon } from "lucide-react";
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { XIcon } from 'lucide-react'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
 const DialogOverlay = React.forwardRef<
@@ -38,13 +38,13 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     data-slot="dialog-overlay"
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-      className,
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+      className
     )}
     {...props}
   />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 function DialogContent({
   className,
@@ -57,8 +57,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg max-sm:top-0 max-sm:left-0 max-sm:right-0 max-sm:translate-x-0 max-sm:translate-y-0 max-sm:w-full max-sm:max-w-full max-sm:max-h-[100dvh] max-sm:overflow-y-auto max-sm:rounded-t-lg max-sm:rounded-b-none",
-          className,
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg max-sm:top-0 max-sm:left-0 max-sm:right-0 max-sm:translate-x-0 max-sm:translate-y-0 max-sm:w-full max-sm:max-w-full max-sm:max-h-[100dvh] max-sm:overflow-y-auto max-sm:rounded-t-lg max-sm:rounded-b-none',
+          className
         )}
         {...props}
       >
@@ -69,30 +69,30 @@ function DialogContent({
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>
     </DialogPortal>
-  );
+  )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  );
+  )
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className,
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
 function DialogTitle({
@@ -102,10 +102,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
-  );
+  )
 }
 
 function DialogDescription({
@@ -115,10 +115,10 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  );
+  )
 }
 
 export {
@@ -132,4 +132,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-};
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,21 +1,21 @@
-import * as React from "react";
+import * as React from 'react'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className,
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
-export { Input };
+export { Input }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,25 +1,25 @@
-"use client";
+'use client'
 
-import * as React from "react";
-import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from 'react'
+import * as PopoverPrimitive from '@radix-ui/react-popover'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
 function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
 function PopoverContent({
   className,
-  align = "center",
+  align = 'center',
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
@@ -30,25 +30,25 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className,
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          className
         )}
         {...props}
       />
     </PopoverPrimitive.Portal>
-  );
+  )
 }
 
 function PopoverAnchor({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
 function PopoverClose({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Close>) {
-  return <PopoverPrimitive.Close data-slot="popover-close" {...props} />;
+  return <PopoverPrimitive.Close data-slot="popover-close" {...props} />
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverClose };
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverClose }

--- a/src/components/ui/segmented-toggle.test.tsx
+++ b/src/components/ui/segmented-toggle.test.tsx
@@ -21,11 +21,7 @@ describe('SegmentedToggle', () => {
 
   it('marks the active option as selected', () => {
     render(
-      <SegmentedToggle
-        options={OPTIONS}
-        value="auto"
-        onChange={vi.fn()}
-      />
+      <SegmentedToggle options={OPTIONS} value="auto" onChange={vi.fn()} />
     )
     const autoBtn = screen.getByText('Auto')
     expect(autoBtn).toHaveAttribute('aria-pressed', 'true')
@@ -70,7 +66,9 @@ describe('SegmentedToggle', () => {
         aria-label="Elegir tema"
       />
     )
-    expect(screen.getByRole('tablist', { name: 'Elegir tema' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('tablist', { name: 'Elegir tema' })
+    ).toBeInTheDocument()
   })
 
   it('applies sm size', () => {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,31 +1,31 @@
-"use client";
+'use client'
 
-import * as React from "react";
-import * as SheetPrimitive from "@radix-ui/react-dialog";
-import { XIcon } from "lucide-react";
+import * as React from 'react'
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+import { XIcon } from 'lucide-react'
 
-import { cn } from "./utils";
+import { cn } from './utils'
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
 }
 
 function SheetTrigger({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
 }
 
 function SheetClose({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Close>) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
 }
 
 function SheetPortal({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
 }
 
 function SheetOverlay({
@@ -36,21 +36,21 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className,
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
 function SheetContent({
   className,
   children,
-  side = "right",
+  side = 'right',
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
-  side?: "top" | "right" | "bottom" | "left";
+  side?: 'top' | 'right' | 'bottom' | 'left'
 }) {
   return (
     <SheetPortal>
@@ -58,16 +58,16 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-          side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
-          side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
-          side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
-          side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
-          className,
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          side === 'right' &&
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+          side === 'left' &&
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+          side === 'top' &&
+            'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
+          side === 'bottom' &&
+            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+          className
         )}
         {...props}
       >
@@ -78,27 +78,27 @@ function SheetContent({
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>
-  );
+  )
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("flex flex-col gap-1.5 p-4", className)}
+      className={cn('flex flex-col gap-1.5 p-4', className)}
       {...props}
     />
-  );
+  )
 }
 
-function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
       {...props}
     />
-  );
+  )
 }
 
 function SheetTitle({
@@ -108,10 +108,10 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn('text-foreground font-semibold', className)}
       {...props}
     />
-  );
+  )
 }
 
 function SheetDescription({
@@ -121,10 +121,10 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  );
+  )
 }
 
 export {
@@ -136,4 +136,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-};
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,13 +1,13 @@
-import { cn } from "./utils";
+import { cn } from './utils'
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-muted animate-pulse rounded-md", className)}
+      className={cn('bg-muted animate-pulse rounded-md', className)}
       {...props}
     />
-  );
+  )
 }
 
-export { Skeleton };
+export { Skeleton }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,25 +1,25 @@
-"use client";
+'use client'
 
-import { useTheme } from "next-themes";
-import { Toaster as Sonner, ToasterProps } from "sonner";
+import { useTheme } from 'next-themes'
+import { Toaster as Sonner, ToasterProps } from 'sonner'
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const { theme = 'system' } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme as ToasterProps['theme']}
       className="toaster group"
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
         } as React.CSSProperties
       }
       {...props}
     />
-  );
-};
+  )
+}
 
-export { Toaster };
+export { Toaster }

--- a/src/components/ui/utils.ts
+++ b/src/components/ui/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs))
 }

--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -24,8 +24,7 @@ function isPasswordResetMode(): boolean {
     : window.location.hash
   const hashParams = new URLSearchParams(hash)
   const isRecoveryHash =
-    hashParams.get('type') === 'recovery' &&
-    hashParams.has('access_token')
+    hashParams.get('type') === 'recovery' && hashParams.has('access_token')
 
   return (
     new URLSearchParams(window.location.search).get('mode') ===

--- a/src/hooks/useTransactionFiltering.grouping.test.ts
+++ b/src/hooks/useTransactionFiltering.grouping.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import type { Transaction } from '../models'
 
-function makeTransaction(id: string, overrides: Partial<Transaction> = {}): Transaction {
+function makeTransaction(
+  id: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
   return {
     id,
     date: new Date('2025-01-01'),
@@ -67,7 +70,9 @@ describe('split grouping logic (useTransactionFiltering)', () => {
   })
 
   it('renders orphan children (parent not in set) as standalone rows', () => {
-    const child = makeTransaction('child-0', { splitParentId: 'missing-parent' })
+    const child = makeTransaction('child-0', {
+      splitParentId: 'missing-parent',
+    })
     const other = makeTransaction('other')
 
     const result = applyGrouping([other, child])

--- a/src/hooks/useTransactionFiltering.ts
+++ b/src/hooks/useTransactionFiltering.ts
@@ -9,7 +9,6 @@ export type SortDirection = 'asc' | 'desc'
 
 const ITEMS_PER_PAGE = 12
 
-
 export function useTransactionFiltering({
   transactions,
   initialFilter,
@@ -158,9 +157,7 @@ export function useTransactionFiltering({
     () =>
       Array.from(
         new Set(
-          transactions
-            .map((tx) => tx.category?.trim() ?? '')
-            .filter(Boolean)
+          transactions.map((tx) => tx.category?.trim() ?? '').filter(Boolean)
         )
       ).sort((a, b) =>
         getCategoryDisplay(a).label.localeCompare(

--- a/src/hooks/useTransactionHandlers.test.ts
+++ b/src/hooks/useTransactionHandlers.test.ts
@@ -57,8 +57,10 @@ vi.mock('../services/supabase/import-runs', () => ({
 // Override stores are empty, so nothing is filtered out of AI enrichment.
 vi.mock('../services/categorizer/category-overrides', () => ({
   listMerchantCategoryOverrides: () => ({}),
-  clearMerchantCategoryOverrideWithSync: mocks.clearMerchantCategoryOverrideWithSync,
-  setMerchantCategoryOverrideWithSync: mocks.setMerchantCategoryOverrideWithSync,
+  clearMerchantCategoryOverrideWithSync:
+    mocks.clearMerchantCategoryOverrideWithSync,
+  setMerchantCategoryOverrideWithSync:
+    mocks.setMerchantCategoryOverrideWithSync,
   getMerchantCategoryOverride: () => undefined,
 }))
 vi.mock('../services/descriptions/description-overrides', () => ({
@@ -145,7 +147,9 @@ describe('useTransactionHandlers — import with AI enrichment', () => {
   })
 
   it('still stores rule-based results when AI enrichment fails', async () => {
-    mocks.enrichTransactionsWithAi.mockRejectedValue(new Error('401 invalid x-api-key'))
+    mocks.enrichTransactionsWithAi.mockRejectedValue(
+      new Error('401 invalid x-api-key')
+    )
     const { handlers } = setup()
 
     const outcome = await handlers.handleTransactionsImported(
@@ -156,13 +160,17 @@ describe('useTransactionHandlers — import with AI enrichment', () => {
     // The import itself must still succeed with the rule-based categories.
     expect(outcome.added).toHaveLength(1)
     expect(transactionStore.getState().transactions).toHaveLength(1)
-    expect(transactionStore.getState().transactions[0].category).toBe('groceries')
+    expect(transactionStore.getState().transactions[0].category).toBe(
+      'groceries'
+    )
     expect(mocks.persistTransactions).toHaveBeenCalledTimes(1)
     expect(mocks.completeImportRun).toHaveBeenCalledTimes(1)
   })
 
   it('reports the AI failure reason to the caller instead of swallowing it', async () => {
-    mocks.enrichTransactionsWithAi.mockRejectedValue(new Error('401 invalid x-api-key'))
+    mocks.enrichTransactionsWithAi.mockRejectedValue(
+      new Error('401 invalid x-api-key')
+    )
     const { handlers } = setup()
 
     const outcome = await handlers.handleTransactionsImported(
@@ -456,7 +464,10 @@ describe('useTransactionHandlers — split and unsplit', () => {
   }
 
   function splitResult() {
-    const parent = { ...makeTransaction('parent', { amount: 1000 }), isSplitParent: true }
+    const parent = {
+      ...makeTransaction('parent', { amount: 1000 }),
+      isSplitParent: true,
+    }
     const children = [
       makeTransaction('parent_split_0', {
         amount: 600,

--- a/src/hooks/useTransactionHandlers.ts
+++ b/src/hooks/useTransactionHandlers.ts
@@ -198,12 +198,10 @@ export function useTransactionHandlers({
         !!trimmedDisplayDescription &&
         trimmedDisplayDescription !== current.description
       const targetKey = buildDescriptionOverrideKey(current.description)
-      const matchingTransactions = state.transactions.filter(
-        (tx) => {
-          const key = buildDescriptionOverrideKey(tx.description)
-          return key !== null && key === targetKey
-        }
-      )
+      const matchingTransactions = state.transactions.filter((tx) => {
+        const key = buildDescriptionOverrideKey(tx.description)
+        return key !== null && key === targetKey
+      })
 
       try {
         if (
@@ -251,9 +249,7 @@ export function useTransactionHandlers({
 
         state.setTransactions(
           state.transactions.map((tx) => {
-            if (
-              buildDescriptionOverrideKey(tx.description) !== targetKey
-            ) {
+            if (buildDescriptionOverrideKey(tx.description) !== targetKey) {
               return tx
             }
 
@@ -479,7 +475,10 @@ export function useTransactionHandlers({
       if (session) {
         await Promise.all(
           transactionIds.map((id) =>
-            updateRemoteTransaction(session, id, { category, categoryConfidence: 1 })
+            updateRemoteTransaction(session, id, {
+              category,
+              categoryConfidence: 1,
+            })
           )
         )
       }
@@ -515,9 +514,7 @@ export function useTransactionHandlers({
 
     const selectedSet = new Set(transactionIds)
     const childIdsToHardDelete = state.transactions
-      .filter(
-        (tx) => tx.splitParentId && selectedSet.has(tx.splitParentId)
-      )
+      .filter((tx) => tx.splitParentId && selectedSet.has(tx.splitParentId))
       .map((tx) => tx.id)
 
     try {
@@ -596,9 +593,7 @@ export function useTransactionHandlers({
       )
     } catch (error) {
       setError(
-        error instanceof Error
-          ? error.message
-          : 'No se pudo agregar el tag'
+        error instanceof Error ? error.message : 'No se pudo agregar el tag'
       )
       setNotice('')
     }
@@ -620,10 +615,7 @@ export function useTransactionHandlers({
         category: o.category,
       })),
       ...state.transactions
-        .filter(
-          (t) =>
-            t.category && t.category !== 'uncategorized'
-        )
+        .filter((t) => t.category && t.category !== 'uncategorized')
         .map((t) => ({ name: t.description, category: t.category! })),
     ]
 

--- a/src/hooks/useUserPreferences.ts
+++ b/src/hooks/useUserPreferences.ts
@@ -7,8 +7,8 @@ import { setAiConfig } from '../services/ai/ai-config'
 export function useUserPreferences(session: SupabaseSession | null) {
   const prefsLoadedRef = useRef(false)
   const [theme, setTheme] = useState<'light' | 'dark' | 'auto'>('auto')
-  const [systemDark, setSystemDark] = useState(() =>
-    window.matchMedia('(prefers-color-scheme: dark)').matches
+  const [systemDark, setSystemDark] = useState(
+    () => window.matchMedia('(prefers-color-scheme: dark)').matches
   )
   const isDark = theme === 'dark' || (theme === 'auto' && systemDark)
   const [preferredCurrency, setPreferredCurrency] = useState<'UYU' | 'USD'>(

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -30,9 +30,7 @@ describe('main bootstrap', () => {
     await import('./main')
 
     expect(createRootMock).toHaveBeenCalledTimes(1)
-    expect(createRootMock).toHaveBeenCalledWith(
-      document.getElementById('root')
-    )
+    expect(createRootMock).toHaveBeenCalledWith(document.getElementById('root'))
     expect(renderMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/models/category.test.ts
+++ b/src/models/category.test.ts
@@ -90,7 +90,9 @@ describe('Category System', () => {
     })
 
     it('should have user-friendly label for Software', () => {
-      expect(CATEGORY_LABELS[Category.Software]).toBe('Software y suscripciones')
+      expect(CATEGORY_LABELS[Category.Software]).toBe(
+        'Software y suscripciones'
+      )
     })
 
     it('should have user-friendly label for Uncategorized', () => {

--- a/src/models/category.ts
+++ b/src/models/category.ts
@@ -103,4 +103,3 @@ export const CATEGORY_COLORS: Record<Category, string> = {
   [Category.Fees]: '#fb7185',
   [Category.Uncategorized]: '#94a3b8',
 }
-

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -32,4 +32,9 @@ export interface TransactionsFilter {
 export type { CustomCategoryRecord } from './custom-category'
 
 // Category system
-export { Category, CATEGORY_LABELS, CATEGORY_ICONS, CATEGORY_COLORS } from './category'
+export {
+  Category,
+  CATEGORY_LABELS,
+  CATEGORY_ICONS,
+  CATEGORY_COLORS,
+} from './category'

--- a/src/services/ai/prompt-analysis.ts
+++ b/src/services/ai/prompt-analysis.ts
@@ -11,7 +11,9 @@ interface DescriptionSample {
   displayDescription?: string
 }
 
-function deduplicateByDescription(transactions: Transaction[]): DescriptionSample[] {
+function deduplicateByDescription(
+  transactions: Transaction[]
+): DescriptionSample[] {
   const seen = new Set<string>()
   const samples: DescriptionSample[] = []
   for (const tx of transactions) {

--- a/src/services/ai/transaction-ai.test.ts
+++ b/src/services/ai/transaction-ai.test.ts
@@ -23,7 +23,11 @@ import {
 import type { AiEnrichmentResult } from './transaction-ai'
 import type { CustomPattern } from '../categorizer/custom-patterns'
 
-function makeTx(id: string, description: string, overrides: Partial<Transaction> = {}): Transaction {
+function makeTx(
+  id: string,
+  description: string,
+  overrides: Partial<Transaction> = {}
+): Transaction {
   return {
     id,
     date: new Date('2025-01-10'),
@@ -42,7 +46,11 @@ const customCategories: CustomCategory[] = [
   { id: 'coffee', label: 'Coffee', color: '#8B4513' },
 ]
 
-const baseConfig = { apiKey: 'sk-test', enabled: true, model: 'claude-haiku-4-5' }
+const baseConfig = {
+  apiKey: 'sk-test',
+  enabled: true,
+  model: 'claude-haiku-4-5',
+}
 
 // The system prompt is sent as a cacheable block array, so tests read through
 // this rather than assuming a bare string.
@@ -75,13 +83,22 @@ function makeInputs(count: number) {
     source: 'bank_account' as const,
   }))
 }
-const emptyContext = { descriptionExamples: [], categoryExamples: [], customCategories: noCustomCategories, customPatterns: [] }
+const emptyContext = {
+  descriptionExamples: [],
+  categoryExamples: [],
+  customCategories: noCustomCategories,
+  customPatterns: [],
+}
 
 describe('validateCategory', () => {
   it('accepts valid built-in categories', () => {
     expect(validateCategory('groceries', noCustomCategories)).toBe('groceries')
-    expect(validateCategory('internal_transfer', noCustomCategories)).toBe('internal_transfer')
-    expect(validateCategory('uncategorized', noCustomCategories)).toBe('uncategorized')
+    expect(validateCategory('internal_transfer', noCustomCategories)).toBe(
+      'internal_transfer'
+    )
+    expect(validateCategory('uncategorized', noCustomCategories)).toBe(
+      'uncategorized'
+    )
   })
 
   it('accepts valid custom category ids', () => {
@@ -89,13 +106,21 @@ describe('validateCategory', () => {
   })
 
   it('coerces unknown values to uncategorized', () => {
-    expect(validateCategory('food_and_drink', noCustomCategories)).toBe(Category.Uncategorized)
-    expect(validateCategory('', noCustomCategories)).toBe(Category.Uncategorized)
-    expect(validateCategory('coffee', noCustomCategories)).toBe(Category.Uncategorized)
+    expect(validateCategory('food_and_drink', noCustomCategories)).toBe(
+      Category.Uncategorized
+    )
+    expect(validateCategory('', noCustomCategories)).toBe(
+      Category.Uncategorized
+    )
+    expect(validateCategory('coffee', noCustomCategories)).toBe(
+      Category.Uncategorized
+    )
   })
 
   it('trims and lowercases input', () => {
-    expect(validateCategory('  Groceries  ', noCustomCategories)).toBe('groceries')
+    expect(validateCategory('  Groceries  ', noCustomCategories)).toBe(
+      'groceries'
+    )
   })
 })
 
@@ -103,8 +128,24 @@ describe('applyAiEnrichment', () => {
   it('merges AI results onto matching transactions', () => {
     const txs = [makeTx('tx1', 'COMPRA DEVOTO'), makeTx('tx2', 'NETFLIX')]
     const results = new Map<string, AiEnrichmentResult>([
-      ['tx1', { id: 'tx1', category: 'groceries', displayDescription: 'Devoto', confidence: 0.85 }],
-      ['tx2', { id: 'tx2', category: 'entertainment', displayDescription: 'Netflix', confidence: 0.85 }],
+      [
+        'tx1',
+        {
+          id: 'tx1',
+          category: 'groceries',
+          displayDescription: 'Devoto',
+          confidence: 0.85,
+        },
+      ],
+      [
+        'tx2',
+        {
+          id: 'tx2',
+          category: 'entertainment',
+          displayDescription: 'Netflix',
+          confidence: 0.85,
+        },
+      ],
     ])
     const enriched = applyAiEnrichment(txs, results)
     expect(enriched[0].category).toBe('groceries')
@@ -117,7 +158,15 @@ describe('applyAiEnrichment', () => {
   it('leaves non-matched transactions unchanged', () => {
     const txs = [makeTx('tx1', 'DEVOTO'), makeTx('tx2', 'NETFLIX')]
     const results = new Map<string, AiEnrichmentResult>([
-      ['tx1', { id: 'tx1', category: 'groceries', displayDescription: 'Devoto', confidence: 0.85 }],
+      [
+        'tx1',
+        {
+          id: 'tx1',
+          category: 'groceries',
+          displayDescription: 'Devoto',
+          confidence: 0.85,
+        },
+      ],
     ])
     const enriched = applyAiEnrichment(txs, results)
     expect(enriched[1].category).toBe(txs[1].category)
@@ -128,7 +177,15 @@ describe('applyAiEnrichment', () => {
     const txs = [makeTx('tx1', 'DEVOTO')]
     const originalCategory = txs[0].category
     const results = new Map<string, AiEnrichmentResult>([
-      ['tx1', { id: 'tx1', category: 'groceries', displayDescription: 'Devoto', confidence: 0.85 }],
+      [
+        'tx1',
+        {
+          id: 'tx1',
+          category: 'groceries',
+          displayDescription: 'Devoto',
+          confidence: 0.85,
+        },
+      ],
     ])
     applyAiEnrichment(txs, results)
     expect(txs[0].category).toBe(originalCategory)
@@ -142,12 +199,31 @@ describe('enrichTransactionsWithAi', () => {
 
   it('parses valid response and returns map keyed by id', async () => {
     messagesCreateMock.mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify([
-        { id: 'tx1', displayDescription: 'Devoto', category: 'groceries', confidence: 0.9 },
-      ])}],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify([
+            {
+              id: 'tx1',
+              displayDescription: 'Devoto',
+              category: 'groceries',
+              confidence: 0.9,
+            },
+          ]),
+        },
+      ],
     })
     const { results } = await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'SUPERMERCADO DEVOTO', type: 'debit', amount: 500, currency: 'UYU', source: 'bank_account' }],
+      [
+        {
+          id: 'tx1',
+          description: 'SUPERMERCADO DEVOTO',
+          type: 'debit',
+          amount: 500,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
+      ],
       baseConfig,
       emptyContext
     )
@@ -158,12 +234,30 @@ describe('enrichTransactionsWithAi', () => {
 
   it('falls back to 0.7 confidence when AI omits the field', async () => {
     messagesCreateMock.mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify([
-        { id: 'tx1', displayDescription: 'Unknown', category: 'uncategorized' },
-      ])}],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify([
+            {
+              id: 'tx1',
+              displayDescription: 'Unknown',
+              category: 'uncategorized',
+            },
+          ]),
+        },
+      ],
     })
     const { results } = await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'XXXX', type: 'debit', amount: 100, currency: 'UYU', source: 'bank_account' }],
+      [
+        {
+          id: 'tx1',
+          description: 'XXXX',
+          type: 'debit',
+          amount: 100,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
+      ],
       baseConfig,
       emptyContext
     )
@@ -172,15 +266,44 @@ describe('enrichTransactionsWithAi', () => {
 
   it('clamps out-of-range confidence values to [0, 1]', async () => {
     messagesCreateMock.mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify([
-        { id: 'tx1', displayDescription: 'Netflix', category: 'entertainment', confidence: 1.5 },
-        { id: 'tx2', displayDescription: 'Unknown', category: 'uncategorized', confidence: -0.2 },
-      ])}],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify([
+            {
+              id: 'tx1',
+              displayDescription: 'Netflix',
+              category: 'entertainment',
+              confidence: 1.5,
+            },
+            {
+              id: 'tx2',
+              displayDescription: 'Unknown',
+              category: 'uncategorized',
+              confidence: -0.2,
+            },
+          ]),
+        },
+      ],
     })
     const { results } = await enrichTransactionsWithAi(
       [
-        { id: 'tx1', description: 'NETFLIX', type: 'debit', amount: 9.99, currency: 'USD', source: 'credit_card' },
-        { id: 'tx2', description: 'XXXX', type: 'debit', amount: 100, currency: 'UYU', source: 'bank_account' },
+        {
+          id: 'tx1',
+          description: 'NETFLIX',
+          type: 'debit',
+          amount: 9.99,
+          currency: 'USD',
+          source: 'credit_card',
+        },
+        {
+          id: 'tx2',
+          description: 'XXXX',
+          type: 'debit',
+          amount: 100,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
       ],
       baseConfig,
       emptyContext
@@ -191,12 +314,26 @@ describe('enrichTransactionsWithAi', () => {
 
   it('includes custom categories in the system prompt', async () => {
     messagesCreateMock.mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify([
-        { id: 'tx1', displayDescription: 'Starbucks', category: 'coffee' },
-      ])}],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify([
+            { id: 'tx1', displayDescription: 'Starbucks', category: 'coffee' },
+          ]),
+        },
+      ],
     })
     const { results } = await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'STARBUCKS', type: 'debit', amount: 200, currency: 'UYU', source: 'bank_account' }],
+      [
+        {
+          id: 'tx1',
+          description: 'STARBUCKS',
+          type: 'debit',
+          amount: 200,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
+      ],
       baseConfig,
       { ...emptyContext, customCategories }
     )
@@ -207,12 +344,30 @@ describe('enrichTransactionsWithAi', () => {
 
   it('coerces invalid category to uncategorized', async () => {
     messagesCreateMock.mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify([
-        { id: 'tx1', displayDescription: 'Somewhere', category: 'food_and_drink' },
-      ])}],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify([
+            {
+              id: 'tx1',
+              displayDescription: 'Somewhere',
+              category: 'food_and_drink',
+            },
+          ]),
+        },
+      ],
     })
     const { results } = await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'SOMEWHERE', type: 'debit', amount: 100, currency: 'USD', source: 'credit_card' }],
+      [
+        {
+          id: 'tx1',
+          description: 'SOMEWHERE',
+          type: 'debit',
+          amount: 100,
+          currency: 'USD',
+          source: 'credit_card',
+        },
+      ],
       baseConfig,
       emptyContext
     )
@@ -221,15 +376,38 @@ describe('enrichTransactionsWithAi', () => {
 
   it('silently drops items with missing id', async () => {
     messagesCreateMock.mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify([
-        { displayDescription: 'No ID', category: 'groceries' },
-        { id: 'tx2', displayDescription: 'Netflix', category: 'entertainment' },
-      ])}],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify([
+            { displayDescription: 'No ID', category: 'groceries' },
+            {
+              id: 'tx2',
+              displayDescription: 'Netflix',
+              category: 'entertainment',
+            },
+          ]),
+        },
+      ],
     })
     const { results } = await enrichTransactionsWithAi(
       [
-        { id: 'tx1', description: 'DEVOTO', type: 'debit', amount: 100, currency: 'UYU', source: 'bank_account' },
-        { id: 'tx2', description: 'NETFLIX', type: 'debit', amount: 9.99, currency: 'USD', source: 'credit_card' },
+        {
+          id: 'tx1',
+          description: 'DEVOTO',
+          type: 'debit',
+          amount: 100,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
+        {
+          id: 'tx2',
+          description: 'NETFLIX',
+          type: 'debit',
+          amount: 9.99,
+          currency: 'USD',
+          source: 'credit_card',
+        },
       ],
       baseConfig,
       emptyContext
@@ -244,7 +422,16 @@ describe('enrichTransactionsWithAi', () => {
     })
     await expect(
       enrichTransactionsWithAi(
-        [{ id: 'tx1', description: 'DEVOTO', type: 'debit', amount: 100, currency: 'UYU', source: 'bank_account' }],
+        [
+          {
+            id: 'tx1',
+            description: 'DEVOTO',
+            type: 'debit',
+            amount: 100,
+            currency: 'UYU',
+            source: 'bank_account',
+          },
+        ],
         baseConfig,
         emptyContext
       )
@@ -256,11 +443,21 @@ describe('enrichTransactionsWithAi', () => {
       content: [{ type: 'text', text: '[]' }],
     })
     await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'PAGO RECIBIDO', type: 'credit', amount: 1200, currency: 'UYU', source: 'credit_card' }],
+      [
+        {
+          id: 'tx1',
+          description: 'PAGO RECIBIDO',
+          type: 'credit',
+          amount: 1200,
+          currency: 'UYU',
+          source: 'credit_card',
+        },
+      ],
       baseConfig,
       emptyContext
     )
-    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0].content as string
+    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0]
+      .content as string
     expect(userMessage).toContain('"source":"credit_card"')
   })
 
@@ -269,16 +466,28 @@ describe('enrichTransactionsWithAi', () => {
       content: [{ type: 'text', text: '[]' }],
     })
     await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'DEVOTO', type: 'debit', amount: 100, currency: 'UYU', source: 'bank_account' }],
+      [
+        {
+          id: 'tx1',
+          description: 'DEVOTO',
+          type: 'debit',
+          amount: 100,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
+      ],
       baseConfig,
       {
-        descriptionExamples: [{ raw: 'SUPERM DEVOTO', friendly: 'Devoto', category: 'groceries' }],
+        descriptionExamples: [
+          { raw: 'SUPERM DEVOTO', friendly: 'Devoto', category: 'groceries' },
+        ],
         categoryExamples: [{ merchant: 'tintoreria', category: 'personal' }],
         customCategories: noCustomCategories,
         customPatterns: [],
       }
     )
-    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0].content as string
+    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0]
+      .content as string
     expect(userMessage).toContain('SUPERM DEVOTO')
     expect(userMessage).toContain('tintoreria')
   })
@@ -288,16 +497,44 @@ describe('enrichTransactionsWithAi', () => {
       content: [{ type: 'text', text: '[]' }],
     })
     const customPatterns: CustomPattern[] = [
-      { id: 'cp1', pattern: 'farmacia', matchType: 'contains', category: 'healthcare', createdAt: '' },
-      { id: 'cp2', pattern: 'ute ', matchType: 'starts_with', category: 'utilities', createdAt: '' },
-      { id: 'cp3', pattern: 'salario empresa srl', matchType: 'exact', category: 'income', createdAt: '' },
+      {
+        id: 'cp1',
+        pattern: 'farmacia',
+        matchType: 'contains',
+        category: 'healthcare',
+        createdAt: '',
+      },
+      {
+        id: 'cp2',
+        pattern: 'ute ',
+        matchType: 'starts_with',
+        category: 'utilities',
+        createdAt: '',
+      },
+      {
+        id: 'cp3',
+        pattern: 'salario empresa srl',
+        matchType: 'exact',
+        category: 'income',
+        createdAt: '',
+      },
     ]
     await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'FARMACIA DEVOTO', type: 'debit', amount: 200, currency: 'UYU', source: 'bank_account' }],
+      [
+        {
+          id: 'tx1',
+          description: 'FARMACIA DEVOTO',
+          type: 'debit',
+          amount: 200,
+          currency: 'UYU',
+          source: 'bank_account',
+        },
+      ],
       baseConfig,
       { ...emptyContext, customPatterns }
     )
-    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0].content as string
+    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0]
+      .content as string
     expect(userMessage).toContain('USER RULES (always apply these')
     expect(userMessage).toContain('contains "farmacia" → healthcare')
     expect(userMessage).toContain('starts with "ute " → utilities')
@@ -309,11 +546,21 @@ describe('enrichTransactionsWithAi', () => {
       content: [{ type: 'text', text: '[]' }],
     })
     await enrichTransactionsWithAi(
-      [{ id: 'tx1', description: 'NETFLIX', type: 'debit', amount: 9.99, currency: 'USD', source: 'credit_card' }],
+      [
+        {
+          id: 'tx1',
+          description: 'NETFLIX',
+          type: 'debit',
+          amount: 9.99,
+          currency: 'USD',
+          source: 'credit_card',
+        },
+      ],
       baseConfig,
       emptyContext
     )
-    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0].content as string
+    const userMessage = messagesCreateMock.mock.calls[0][0].messages[0]
+      .content as string
     expect(userMessage).not.toContain('USER RULES')
   })
 
@@ -321,7 +568,16 @@ describe('enrichTransactionsWithAi', () => {
     messagesCreateMock.mockRejectedValue(new Error('API error'))
     await expect(
       enrichTransactionsWithAi(
-        [{ id: 'tx1', description: 'DEVOTO', type: 'debit', amount: 100, currency: 'UYU', source: 'bank_account' }],
+        [
+          {
+            id: 'tx1',
+            description: 'DEVOTO',
+            type: 'debit',
+            amount: 100,
+            currency: 'UYU',
+            source: 'bank_account',
+          },
+        ],
         baseConfig,
         emptyContext
       )

--- a/src/services/ai/transaction-ai.ts
+++ b/src/services/ai/transaction-ai.ts
@@ -22,7 +22,11 @@ export interface AiEnrichmentResult {
 }
 
 export interface AiCorrectionContext {
-  descriptionExamples: Array<{ raw: string; friendly: string; category?: string }>
+  descriptionExamples: Array<{
+    raw: string
+    friendly: string
+    category?: string
+  }>
   categoryExamples: Array<{ merchant: string; category: string }>
   customCategories: CustomCategory[]
   customPatterns: CustomPattern[]
@@ -138,7 +142,9 @@ function buildUserMessage(
   const parts: string[] = []
 
   if (context.customPatterns.length > 0) {
-    parts.push('USER RULES (always apply these, they override all other patterns):')
+    parts.push(
+      'USER RULES (always apply these, they override all other patterns):'
+    )
     for (const p of context.customPatterns) {
       const matchLabel = MATCH_TYPE_LABEL[p.matchType] ?? p.matchType
       parts.push(`${matchLabel} "${p.pattern}" → ${p.category}`)
@@ -317,9 +323,7 @@ export async function enrichTransactionsWithAi(
         model: config.model,
         max_tokens: MAX_OUTPUT_TOKENS,
         system: systemPrompt,
-        messages: [
-          { role: 'user', content: buildUserMessage(batch, context) },
-        ],
+        messages: [{ role: 'user', content: buildUserMessage(batch, context) }],
       })) as AiEnrichmentBatchResponse
 
       for (const result of parseBatchResponse(response, inputs, context)) {

--- a/src/services/categories/category-registry.test.ts
+++ b/src/services/categories/category-registry.test.ts
@@ -77,7 +77,12 @@ describe('getCategoryDefinitions', () => {
 
   it('uses default icon for custom categories with no icon', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: 'my-custom', label: 'Mi categoría', color: '#ff0000', icon: undefined },
+      {
+        id: 'my-custom',
+        label: 'Mi categoría',
+        color: '#ff0000',
+        icon: undefined,
+      },
     ])
 
     const defs = getCategoryDefinitions()
@@ -98,7 +103,12 @@ describe('getCategoryDefinitions', () => {
 
   it('marks built-in category as ignored via custom override', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: Category.Shopping, label: 'Compras', color: '#ff0000', isIgnored: true },
+      {
+        id: Category.Shopping,
+        label: 'Compras',
+        color: '#ff0000',
+        isIgnored: true,
+      },
     ])
 
     const defs = getCategoryDefinitions()
@@ -108,7 +118,12 @@ describe('getCategoryDefinitions', () => {
 
   it('uses override icon when a built-in category has a custom icon override', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: Category.Groceries, label: 'Comida', color: '#ff0000', icon: '🛒✨' },
+      {
+        id: Category.Groceries,
+        label: 'Comida',
+        color: '#ff0000',
+        icon: '🛒✨',
+      },
     ])
 
     const defs = getCategoryDefinitions()
@@ -229,7 +244,12 @@ describe('getCategoryDefinition', () => {
 
   it('uses override icon for a built-in when override has an icon', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: Category.InternalTransfer, label: 'Mis transferencias', color: '#0000ff', icon: '💼' },
+      {
+        id: Category.InternalTransfer,
+        label: 'Mis transferencias',
+        color: '#0000ff',
+        icon: '💼',
+      },
     ])
 
     const def = getCategoryDefinition(Category.InternalTransfer)
@@ -238,7 +258,11 @@ describe('getCategoryDefinition', () => {
 
   it('falls back to built-in icon for a built-in override with no icon', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: Category.InternalTransfer, label: 'Mis transferencias', color: '#0000ff' },
+      {
+        id: Category.InternalTransfer,
+        label: 'Mis transferencias',
+        color: '#0000ff',
+      },
     ])
 
     const def = getCategoryDefinition(Category.InternalTransfer)
@@ -276,7 +300,9 @@ describe('accessor agreement', () => {
       getCategoryDefinitions().find((c) => c.id === Category.InternalTransfer)
         ?.isIgnored
     ).toBe(false)
-    expect(getCategoryDefinition(Category.InternalTransfer).isIgnored).toBe(false)
+    expect(getCategoryDefinition(Category.InternalTransfer).isIgnored).toBe(
+      false
+    )
   })
 })
 
@@ -300,7 +326,12 @@ describe('isCategoryIgnored', () => {
 
   it('returns true when custom override sets isIgnored: true', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: Category.Shopping, label: 'Compras', color: '#ff0000', isIgnored: true },
+      {
+        id: Category.Shopping,
+        label: 'Compras',
+        color: '#ff0000',
+        isIgnored: true,
+      },
     ])
 
     expect(isCategoryIgnored(Category.Shopping)).toBe(true)
@@ -308,7 +339,12 @@ describe('isCategoryIgnored', () => {
 
   it('returns false when custom override sets isIgnored: false', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: Category.Shopping, label: 'Compras', color: '#ff0000', isIgnored: false },
+      {
+        id: Category.Shopping,
+        label: 'Compras',
+        color: '#ff0000',
+        isIgnored: false,
+      },
     ])
 
     expect(isCategoryIgnored(Category.Shopping)).toBe(false)

--- a/src/services/categories/category-store.test.ts
+++ b/src/services/categories/category-store.test.ts
@@ -50,7 +50,10 @@ describe('Custom category store', () => {
     const food = addCustomCategory({ label: 'Food', color: '#ff0000' })
     expect(food.id).not.toBe('food')
 
-    const groceries = addCustomCategory({ label: 'Groceries', color: '#00ff00' })
+    const groceries = addCustomCategory({
+      label: 'Groceries',
+      color: '#00ff00',
+    })
     expect(groceries.id).not.toBe('groceries')
 
     // Still a usable, unique id rather than a collision or an empty string

--- a/src/services/categories/category-store.ts
+++ b/src/services/categories/category-store.ts
@@ -72,7 +72,9 @@ export function addCustomCategory(input: {
 
 export function updateCustomCategory(
   id: string,
-  updates: Partial<Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>>
+  updates: Partial<
+    Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>
+  >
 ): void {
   _customCategories = _customCategories.map((c) =>
     c.id === id ? { ...c, ...updates } : c
@@ -91,9 +93,8 @@ export async function syncCustomCategoryToCloud(id: string): Promise<void> {
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { upsertCustomCategory } = await import(
-        '../supabase/custom-categories'
-      )
+      const { upsertCustomCategory } =
+        await import('../supabase/custom-categories')
       await upsertCustomCategory(session, {
         id: category.id,
         label: category.label,
@@ -121,7 +122,9 @@ export async function addCustomCategoryWithSync(input: {
 
 export async function updateCustomCategoryWithSync(
   id: string,
-  updates: Partial<Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>>
+  updates: Partial<
+    Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>
+  >
 ): Promise<void> {
   updateCustomCategory(id, updates)
   const category = _customCategories.find((c) => c.id === id)
@@ -131,9 +134,8 @@ export async function updateCustomCategoryWithSync(
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { upsertCustomCategory } = await import(
-        '../supabase/custom-categories'
-      )
+      const { upsertCustomCategory } =
+        await import('../supabase/custom-categories')
       await upsertCustomCategory(session, {
         id: category.id,
         label: category.label,
@@ -150,7 +152,9 @@ export async function updateCustomCategoryWithSync(
 
 export function upsertBuiltinOverride(
   id: string,
-  updates: Partial<Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>>
+  updates: Partial<
+    Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>
+  >
 ): void {
   const existing = _customCategories.find((c) => c.id === id)
   if (existing) {
@@ -172,7 +176,9 @@ export function upsertBuiltinOverride(
 
 export async function upsertBuiltinOverrideWithSync(
   id: string,
-  updates: Partial<Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>>
+  updates: Partial<
+    Pick<CustomCategory, 'label' | 'color' | 'icon' | 'isIgnored'>
+  >
 ): Promise<void> {
   upsertBuiltinOverride(id, updates)
   await syncCustomCategoryToCloud(id)
@@ -185,9 +191,8 @@ export async function removeCustomCategoryWithSync(id: string): Promise<void> {
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { archiveCustomCategory } = await import(
-        '../supabase/custom-categories'
-      )
+      const { archiveCustomCategory } =
+        await import('../supabase/custom-categories')
       await archiveCustomCategory(session, id)
     }
   } catch {

--- a/src/services/categorizer/category-overrides.test.ts
+++ b/src/services/categorizer/category-overrides.test.ts
@@ -10,12 +10,15 @@ import {
 } from './category-overrides'
 import { Category } from '../../models'
 
-const { getActiveSupabaseSessionMock, upsertCategoryOverrideMock, deleteCategoryOverrideMock } =
-  vi.hoisted(() => ({
-    getActiveSupabaseSessionMock: vi.fn(),
-    upsertCategoryOverrideMock: vi.fn(),
-    deleteCategoryOverrideMock: vi.fn(),
-  }))
+const {
+  getActiveSupabaseSessionMock,
+  upsertCategoryOverrideMock,
+  deleteCategoryOverrideMock,
+} = vi.hoisted(() => ({
+  getActiveSupabaseSessionMock: vi.fn(),
+  upsertCategoryOverrideMock: vi.fn(),
+  deleteCategoryOverrideMock: vi.fn(),
+}))
 
 vi.mock('../supabase/runtime', () => ({
   getActiveSupabaseSession: getActiveSupabaseSessionMock,

--- a/src/services/categorizer/category-overrides.ts
+++ b/src/services/categorizer/category-overrides.ts
@@ -53,9 +53,8 @@ export async function setMerchantCategoryOverrideWithSync(
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { upsertCategoryOverride } = await import(
-        '../supabase/category-overrides'
-      )
+      const { upsertCategoryOverride } =
+        await import('../supabase/category-overrides')
       await upsertCategoryOverride(session, {
         merchantNormalized: normalized,
         merchantOriginal: merchantName,
@@ -92,9 +91,8 @@ export async function clearMerchantCategoryOverrideWithSync(
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { deleteCategoryOverride } = await import(
-        '../supabase/category-overrides'
-      )
+      const { deleteCategoryOverride } =
+        await import('../supabase/category-overrides')
       await deleteCategoryOverride(session, normalized)
     }
   } catch {

--- a/src/services/categorizer/custom-patterns.test.ts
+++ b/src/services/categorizer/custom-patterns.test.ts
@@ -12,12 +12,15 @@ import {
   testPattern,
 } from './custom-patterns'
 
-const { getActiveSupabaseSessionMock, upsertCustomPatternMock, deleteCustomPatternMock } =
-  vi.hoisted(() => ({
-    getActiveSupabaseSessionMock: vi.fn(),
-    upsertCustomPatternMock: vi.fn(),
-    deleteCustomPatternMock: vi.fn(),
-  }))
+const {
+  getActiveSupabaseSessionMock,
+  upsertCustomPatternMock,
+  deleteCustomPatternMock,
+} = vi.hoisted(() => ({
+  getActiveSupabaseSessionMock: vi.fn(),
+  upsertCustomPatternMock: vi.fn(),
+  deleteCustomPatternMock: vi.fn(),
+}))
 
 vi.mock('../supabase/runtime', () => ({
   getActiveSupabaseSession: getActiveSupabaseSessionMock,

--- a/src/services/categorizer/custom-patterns.ts
+++ b/src/services/categorizer/custom-patterns.ts
@@ -43,7 +43,8 @@ async function syncCustomPatternToCloud(pattern: CustomPattern): Promise<void> {
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { upsertCustomPattern } = await import('../supabase/custom-patterns')
+      const { upsertCustomPattern } =
+        await import('../supabase/custom-patterns')
       await upsertCustomPattern(session, pattern)
     }
   } catch (err) {
@@ -68,7 +69,8 @@ async function deleteCustomPatternFromCloud(id: string): Promise<void> {
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { deleteCustomPattern } = await import('../supabase/custom-patterns')
+      const { deleteCustomPattern } =
+        await import('../supabase/custom-patterns')
       await deleteCustomPattern(session, id)
     }
   } catch (err) {
@@ -105,9 +107,7 @@ export function testPattern(
   }
 }
 
-export function matchCustomPattern(
-  description: string
-): PatternMatch | null {
+export function matchCustomPattern(description: string): PatternMatch | null {
   const normalized = normalizeMerchantName(description)
   if (!normalized) return null
 

--- a/src/services/categorizer/learned-patterns.ts
+++ b/src/services/categorizer/learned-patterns.ts
@@ -114,9 +114,7 @@ export function invalidateLearnedPatternsCache(): void {
  * Uses token voting: if multiple tokens match, the category with
  * the most matching tokens wins.
  */
-export function matchLearnedPattern(
-  description: string
-): PatternMatch | null {
+export function matchLearnedPattern(description: string): PatternMatch | null {
   const patterns = getLearnedPatterns()
   if (patterns.size === 0) return null
 
@@ -156,6 +154,9 @@ export function matchLearnedPattern(
   return {
     category: bestCategory,
     confidence,
-    matchedPattern: `learned:${[...patterns.entries()].filter(([, c]) => c === bestCategory).map(([t]) => t).join(',')}`,
+    matchedPattern: `learned:${[...patterns.entries()]
+      .filter(([, c]) => c === bestCategory)
+      .map(([t]) => t)
+      .join(',')}`,
   }
 }

--- a/src/services/categorizer/merchant-patterns.test.ts
+++ b/src/services/categorizer/merchant-patterns.test.ts
@@ -292,7 +292,9 @@ describe('Merchant Pattern Matcher', () => {
     })
 
     it('should strip Tst prefix (Toast POS)', () => {
-      expect(normalizeMerchantName('Tst Local Restaurant')).toBe('local restaurant')
+      expect(normalizeMerchantName('Tst Local Restaurant')).toBe(
+        'local restaurant'
+      )
     })
 
     it('should not strip sq that is part of a word', () => {

--- a/src/services/categorizer/merchant-patterns.ts
+++ b/src/services/categorizer/merchant-patterns.ts
@@ -223,7 +223,9 @@ const MERCHANT_PATTERNS: MerchantPattern[] = [
 function matchesWithBoundary(normalized: string, pattern: string): boolean {
   if (pattern.includes(' ')) return normalized.includes(pattern)
   const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`(?<![a-záéíóúüñ])${escaped}(?![a-záéíóúüñ])`).test(normalized)
+  return new RegExp(`(?<![a-záéíóúüñ])${escaped}(?![a-záéíóúüñ])`).test(
+    normalized
+  )
 }
 
 /**

--- a/src/services/categorizer/similar-merchant.test.ts
+++ b/src/services/categorizer/similar-merchant.test.ts
@@ -24,10 +24,7 @@ describe('Similar Merchant', () => {
   })
 
   it('should return null for completely unknown merchants', () => {
-    const result = findSimilarMerchant(
-      'Xyzzy Plugh Nothing',
-      KNOWN_MERCHANTS
-    )
+    const result = findSimilarMerchant('Xyzzy Plugh Nothing', KNOWN_MERCHANTS)
     expect(result).toBeNull()
   })
 

--- a/src/services/categorizer/temporal-patterns.test.ts
+++ b/src/services/categorizer/temporal-patterns.test.ts
@@ -144,10 +144,7 @@ describe('Temporal Patterns', () => {
     })
 
     it('should return null for empty patterns map', () => {
-      const result = getTemporalSuggestion(
-        'Something',
-        new Map()
-      )
+      const result = getTemporalSuggestion('Something', new Map())
       expect(result).toBeNull()
     })
   })

--- a/src/services/categorizer/temporal-patterns.ts
+++ b/src/services/categorizer/temporal-patterns.ts
@@ -59,9 +59,7 @@ export function analyzeTemporalPatterns(
     if (txs.length < MIN_WEEKLY) continue
 
     // Sort by date ascending
-    const sorted = [...txs].sort(
-      (a, b) => a.date.getTime() - b.date.getTime()
-    )
+    const sorted = [...txs].sort((a, b) => a.date.getTime() - b.date.getTime())
 
     // Check if amounts are consistent (within tolerance)
     const avgAmount =
@@ -81,8 +79,7 @@ export function analyzeTemporalPatterns(
 
     if (intervals.length === 0) continue
 
-    const avgInterval =
-      intervals.reduce((s, d) => s + d, 0) / intervals.length
+    const avgInterval = intervals.reduce((s, d) => s + d, 0) / intervals.length
 
     const pattern = detectFrequency(
       avgInterval,
@@ -115,9 +112,7 @@ function detectFrequency(
     amountsConsistent &&
     avgInterval >= MONTHLY_MIN_DAYS &&
     avgInterval <= MONTHLY_MAX_DAYS &&
-    intervals.every(
-      (d) => d >= MONTHLY_MIN_DAYS && d <= MONTHLY_MAX_DAYS
-    )
+    intervals.every((d) => d >= MONTHLY_MIN_DAYS && d <= MONTHLY_MAX_DAYS)
   ) {
     return {
       frequency: 'monthly',

--- a/src/services/categorizer/tokenizer.test.ts
+++ b/src/services/categorizer/tokenizer.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  tokenize,
-  bigramSimilarity,
-  fuzzyTokenSimilarity,
-} from './tokenizer'
+import { tokenize, bigramSimilarity, fuzzyTokenSimilarity } from './tokenizer'
 
 describe('Tokenizer', () => {
   describe('tokenize', () => {
@@ -29,10 +25,7 @@ describe('Tokenizer', () => {
     })
 
     it('should remove numeric-only tokens', () => {
-      expect(tokenize('Spotify P3d110f721')).toEqual([
-        'spotify',
-        'p3d110f721',
-      ])
+      expect(tokenize('Spotify P3d110f721')).toEqual(['spotify', 'p3d110f721'])
     })
 
     it('should remove short tokens (< 2 chars)', () => {
@@ -86,7 +79,10 @@ describe('Tokenizer', () => {
   describe('fuzzyTokenSimilarity', () => {
     it('should return 1 for identical token sets', () => {
       expect(
-        fuzzyTokenSimilarity(['devoto', 'supermercado'], ['devoto', 'supermercado'])
+        fuzzyTokenSimilarity(
+          ['devoto', 'supermercado'],
+          ['devoto', 'supermercado']
+        )
       ).toBe(1)
     })
 

--- a/src/services/categorizer/transaction-categorizer.test.ts
+++ b/src/services/categorizer/transaction-categorizer.test.ts
@@ -8,10 +8,7 @@ import {
   clearAllDescriptionOverrides,
   setDescriptionOverride,
 } from '../descriptions/description-overrides'
-import {
-  addCustomPattern,
-  clearAllCustomPatterns,
-} from './custom-patterns'
+import { addCustomPattern, clearAllCustomPatterns } from './custom-patterns'
 import { invalidateLearnedPatternsCache } from './learned-patterns'
 import { analyzeTemporalPatterns } from './temporal-patterns'
 import { Category } from '../../models'
@@ -312,11 +309,9 @@ describe('Transaction Categorizer', () => {
       }))
       const temporalPatterns = analyzeTemporalPatterns(txs)
 
-      const result = categorizeTransaction(
-        'Monthly Service XYZ',
-        'debit',
-        { temporalPatterns }
-      )
+      const result = categorizeTransaction('Monthly Service XYZ', 'debit', {
+        temporalPatterns,
+      })
 
       expect(result.category).toBe(Category.Utilities)
       expect(result.confidence).toBeGreaterThan(0.5)

--- a/src/services/categorizer/transaction-categorizer.ts
+++ b/src/services/categorizer/transaction-categorizer.ts
@@ -56,7 +56,9 @@ const INCOME_KEYWORDS = [
 function matchesWord(normalized: string, keyword: string): boolean {
   if (keyword.includes(' ')) return normalized.includes(keyword)
   const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`(?<![a-záéíóúüñ])${escaped}(?![a-záéíóúüñ])`).test(normalized)
+  return new RegExp(`(?<![a-záéíóúüñ])${escaped}(?![a-záéíóúüñ])`).test(
+    normalized
+  )
 }
 
 function matchesAny(normalized: string, keywords: string[]): boolean {
@@ -211,10 +213,7 @@ export function categorizeTransaction(
   }
 
   // 11. Amount heuristics (requires context)
-  if (
-    context?.amount !== undefined &&
-    context?.currency
-  ) {
+  if (context?.amount !== undefined && context?.currency) {
     const amountMatch = categorizeByAmount(
       context.amount,
       context.currency,

--- a/src/services/charts/chart-data.test.ts
+++ b/src/services/charts/chart-data.test.ts
@@ -49,8 +49,18 @@ describe('chart-data multicurrency converting selectors', () => {
   describe('buildCategorySpendingConverted', () => {
     it('converts USD expenses to UYU when home is UYU', () => {
       const txs = [
-        makeTx('1', { amount: 10, currency: 'USD', type: 'debit', category: Category.Groceries }),
-        makeTx('2', { amount: 400, currency: 'UYU', type: 'debit', category: Category.Groceries }),
+        makeTx('1', {
+          amount: 10,
+          currency: 'USD',
+          type: 'debit',
+          category: Category.Groceries,
+        }),
+        makeTx('2', {
+          amount: 400,
+          currency: 'UYU',
+          type: 'debit',
+          category: Category.Groceries,
+        }),
       ]
       const result = buildCategorySpendingConverted(txs, 'UYU', RATE)
       expect(result).toHaveLength(1)
@@ -62,7 +72,11 @@ describe('chart-data multicurrency converting selectors', () => {
       const txs = [
         makeTx('1', { type: 'credit', category: Category.Groceries }),
         makeTx('2', { type: 'debit', category: Category.InternalTransfer }),
-        makeTx('3', { type: 'debit', category: Category.Groceries, amount: 20 }),
+        makeTx('3', {
+          type: 'debit',
+          category: Category.Groceries,
+          amount: 20,
+        }),
       ]
       const result = buildCategorySpendingConverted(txs, 'USD', RATE)
       expect(result).toHaveLength(1)
@@ -73,8 +87,19 @@ describe('chart-data multicurrency converting selectors', () => {
   describe('buildMonthlyTrendsConverted', () => {
     it('combines USD and UYU amounts for same month into home currency', () => {
       const txs = [
-        makeTx('1', { amount: 10, currency: 'USD', type: 'credit', category: Category.Income, date: new Date('2025-01-10T00:00:00.000Z') }),
-        makeTx('2', { amount: 200, currency: 'UYU', type: 'debit', date: new Date('2025-01-20T00:00:00.000Z') }),
+        makeTx('1', {
+          amount: 10,
+          currency: 'USD',
+          type: 'credit',
+          category: Category.Income,
+          date: new Date('2025-01-10T00:00:00.000Z'),
+        }),
+        makeTx('2', {
+          amount: 200,
+          currency: 'UYU',
+          type: 'debit',
+          date: new Date('2025-01-20T00:00:00.000Z'),
+        }),
       ]
       const result = buildMonthlyTrendsConverted(txs, 'UYU', RATE)
       expect(result).toHaveLength(1)
@@ -86,8 +111,18 @@ describe('chart-data multicurrency converting selectors', () => {
 
     it('counts all non-ignored credits as income', () => {
       const txs = [
-        makeTx('income', { amount: 50, currency: 'USD', type: 'credit', category: Category.Income }),
-        makeTx('refund', { amount: 10, currency: 'USD', type: 'credit', category: Category.Groceries }),
+        makeTx('income', {
+          amount: 50,
+          currency: 'USD',
+          type: 'credit',
+          category: Category.Income,
+        }),
+        makeTx('refund', {
+          amount: 10,
+          currency: 'USD',
+          type: 'credit',
+          category: Category.Groceries,
+        }),
         makeTx('unknown', { amount: 5, currency: 'USD', type: 'credit' }),
       ]
       const result = buildMonthlyTrendsConverted(txs, 'USD', RATE)
@@ -105,10 +140,30 @@ describe('chart-data multicurrency converting selectors', () => {
 
     it('computes latest-month totals in home currency', () => {
       const txs = [
-        makeTx('old', { date: new Date('2024-11-01T00:00:00.000Z'), type: 'debit', amount: 999 }),
-        makeTx('inc', { date: new Date('2025-01-15T00:00:00.000Z'), type: 'credit', category: Category.Income, amount: 100, currency: 'USD' }),
-        makeTx('exp-usd', { date: new Date('2025-01-20T00:00:00.000Z'), type: 'debit', amount: 20, currency: 'USD' }),
-        makeTx('exp-uyu', { date: new Date('2025-01-25T00:00:00.000Z'), type: 'debit', amount: 400, currency: 'UYU' }),
+        makeTx('old', {
+          date: new Date('2024-11-01T00:00:00.000Z'),
+          type: 'debit',
+          amount: 999,
+        }),
+        makeTx('inc', {
+          date: new Date('2025-01-15T00:00:00.000Z'),
+          type: 'credit',
+          category: Category.Income,
+          amount: 100,
+          currency: 'USD',
+        }),
+        makeTx('exp-usd', {
+          date: new Date('2025-01-20T00:00:00.000Z'),
+          type: 'debit',
+          amount: 20,
+          currency: 'USD',
+        }),
+        makeTx('exp-uyu', {
+          date: new Date('2025-01-25T00:00:00.000Z'),
+          type: 'debit',
+          amount: 400,
+          currency: 'UYU',
+        }),
       ]
       const result = buildCurrentMonthSummary(txs, 'USD', RATE)
       expect(result.income).toBeCloseTo(100) // 100 USD income
@@ -120,8 +175,17 @@ describe('chart-data multicurrency converting selectors', () => {
 
     it('excludes transfers', () => {
       const txs = [
-        makeTx('t', { date: new Date('2025-01-10T00:00:00.000Z'), type: 'debit', amount: 100, category: Category.InternalTransfer }),
-        makeTx('e', { date: new Date('2025-01-10T00:00:00.000Z'), type: 'debit', amount: 50 }),
+        makeTx('t', {
+          date: new Date('2025-01-10T00:00:00.000Z'),
+          type: 'debit',
+          amount: 100,
+          category: Category.InternalTransfer,
+        }),
+        makeTx('e', {
+          date: new Date('2025-01-10T00:00:00.000Z'),
+          type: 'debit',
+          amount: 50,
+        }),
       ]
       const result = buildCurrentMonthSummary(txs, 'USD', RATE)
       expect(result.expense).toBe(50)
@@ -143,7 +207,11 @@ describe('chart-data multicurrency converting selectors', () => {
     it('excludes credits and transfers from the split', () => {
       const txs = [
         makeTx('credit', { type: 'credit', amount: 100 }),
-        makeTx('transfer', { type: 'debit', category: Category.InternalTransfer, amount: 100 }),
+        makeTx('transfer', {
+          type: 'debit',
+          category: Category.InternalTransfer,
+          amount: 100,
+        }),
         makeTx('real', { type: 'debit', amount: 50, currency: 'USD' }),
       ]
       const result = buildCurrencySplit(txs, 'USD', RATE)
@@ -175,8 +243,16 @@ describe('chart-data multicurrency converting selectors', () => {
 
     it('buckets credit_card source as card regardless of currency', () => {
       const txs = [
-        makeTx('cc-usd', { source: 'credit_card', currency: 'USD', amount: 100 }),
-        makeTx('cc-uyu', { source: 'credit_card', currency: 'UYU', amount: 400 }),
+        makeTx('cc-usd', {
+          source: 'credit_card',
+          currency: 'USD',
+          amount: 100,
+        }),
+        makeTx('cc-uyu', {
+          source: 'credit_card',
+          currency: 'UYU',
+          amount: 400,
+        }),
       ]
       const result = spendByAccount(txs, 'USD', RATE)
       expect(result.card.count).toBe(2)
@@ -188,8 +264,16 @@ describe('chart-data multicurrency converting selectors', () => {
 
     it('buckets bank_account by currency', () => {
       const txs = [
-        makeTx('bank-usd', { source: 'bank_account', currency: 'USD', amount: 50 }),
-        makeTx('bank-uyu', { source: 'bank_account', currency: 'UYU', amount: 200 }),
+        makeTx('bank-usd', {
+          source: 'bank_account',
+          currency: 'USD',
+          amount: 50,
+        }),
+        makeTx('bank-uyu', {
+          source: 'bank_account',
+          currency: 'UYU',
+          amount: 200,
+        }),
       ]
       const result = spendByAccount(txs, 'USD', RATE)
       expect(result.usd.count).toBe(1)
@@ -201,8 +285,16 @@ describe('chart-data multicurrency converting selectors', () => {
 
     it('excludes credits and transfers', () => {
       const txs = [
-        makeTx('income', { type: 'credit', category: Category.Income, amount: 500 }),
-        makeTx('transfer', { type: 'debit', category: Category.InternalTransfer, amount: 100 }),
+        makeTx('income', {
+          type: 'credit',
+          category: Category.Income,
+          amount: 500,
+        }),
+        makeTx('transfer', {
+          type: 'debit',
+          category: Category.InternalTransfer,
+          amount: 100,
+        }),
         makeTx('real', { source: 'credit_card', currency: 'USD', amount: 30 }),
       ]
       const result = spendByAccount(txs, 'USD', RATE)
@@ -214,8 +306,16 @@ describe('chart-data multicurrency converting selectors', () => {
     it('pct values sum to 100 across all buckets', () => {
       const txs = [
         makeTx('cc', { source: 'credit_card', currency: 'USD', amount: 50 }),
-        makeTx('ba-usd', { source: 'bank_account', currency: 'USD', amount: 30 }),
-        makeTx('ba-uyu', { source: 'bank_account', currency: 'UYU', amount: 20 }),
+        makeTx('ba-usd', {
+          source: 'bank_account',
+          currency: 'USD',
+          amount: 30,
+        }),
+        makeTx('ba-uyu', {
+          source: 'bank_account',
+          currency: 'UYU',
+          amount: 20,
+        }),
       ]
       const result = spendByAccount(txs, 'USD', RATE)
       const total = result.card.pct + result.usd.pct + result.uyu.pct

--- a/src/services/descriptions/description-overrides.test.ts
+++ b/src/services/descriptions/description-overrides.test.ts
@@ -83,8 +83,8 @@ describe('Description overrides', () => {
 
     const override = getDescriptionOverride('---- 999999 ----')
     expect(override).toBeNull()
-    expect(getDescriptionOverride('---- 123456 ----')?.friendlyDescription).toBe(
-      'Ajuste bancario'
-    )
+    expect(
+      getDescriptionOverride('---- 123456 ----')?.friendlyDescription
+    ).toBe('Ajuste bancario')
   })
 })

--- a/src/services/descriptions/description-overrides.ts
+++ b/src/services/descriptions/description-overrides.ts
@@ -55,9 +55,8 @@ export async function setDescriptionOverrideWithSync(input: {
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { upsertDescriptionOverride } = await import(
-        '../supabase/description-overrides'
-      )
+      const { upsertDescriptionOverride } =
+        await import('../supabase/description-overrides')
       await upsertDescriptionOverride(session, {
         descriptionNormalized: descriptionKey,
         descriptionOriginal: input.description,
@@ -94,9 +93,8 @@ export async function clearDescriptionOverrideWithSync(
     const { getActiveSupabaseSession } = await import('../supabase/runtime')
     const session = getActiveSupabaseSession()
     if (session) {
-      const { deleteDescriptionOverride } = await import(
-        '../supabase/description-overrides'
-      )
+      const { deleteDescriptionOverride } =
+        await import('../supabase/description-overrides')
       await deleteDescriptionOverride(session, descriptionKey)
     }
   } catch {

--- a/src/services/insights/insight-cache.test.ts
+++ b/src/services/insights/insight-cache.test.ts
@@ -13,7 +13,11 @@ vi.mock('../supabase/ai-insights', () => ({
   saveInsights: saveInsightsMock,
 }))
 
-import { hashInsightInput, getCachedInsights, saveCachedInsights } from './insight-cache'
+import {
+  hashInsightInput,
+  getCachedInsights,
+  saveCachedInsights,
+} from './insight-cache'
 
 const session = {
   user: { id: 'user-1' },
@@ -23,9 +27,7 @@ const input: InsightInput = {
   historyStart: '2026-01-01',
   historyEnd: '2026-06-30',
   homeCurrency: 'USD',
-  categoryTotals: [
-    { category: 'groceries', amount: 100, pctOfTotal: 100 },
-  ],
+  categoryTotals: [{ category: 'groceries', amount: 100, pctOfTotal: 100 }],
   topMerchants: [],
   recurringCharges: [],
   monthlyTrend: [],
@@ -41,9 +43,7 @@ describe('hashInsightInput', () => {
   it('changes when the input changes', () => {
     const changed: InsightInput = {
       ...input,
-      categoryTotals: [
-        { category: 'groceries', amount: 999, pctOfTotal: 100 },
-      ],
+      categoryTotals: [{ category: 'groceries', amount: 999, pctOfTotal: 100 }],
     }
     expect(hashInsightInput(input)).not.toBe(hashInsightInput(changed))
   })

--- a/src/services/insights/insight-data.test.ts
+++ b/src/services/insights/insight-data.test.ts
@@ -37,30 +37,69 @@ describe('buildInsightInput', () => {
 
   it('computes category totals with pctOfTotal across the entire history', () => {
     const transactions = [
-      makeTransaction('g1', { date: new Date('2026-01-05'), amount: 60, category: Category.Groceries }),
-      makeTransaction('g2', { date: new Date('2026-06-15'), amount: 40, category: Category.Groceries }),
-      makeTransaction('r1', { date: new Date('2026-06-20'), amount: 50, category: Category.Restaurants }),
+      makeTransaction('g1', {
+        date: new Date('2026-01-05'),
+        amount: 60,
+        category: Category.Groceries,
+      }),
+      makeTransaction('g2', {
+        date: new Date('2026-06-15'),
+        amount: 40,
+        category: Category.Groceries,
+      }),
+      makeTransaction('r1', {
+        date: new Date('2026-06-20'),
+        amount: 50,
+        category: Category.Restaurants,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
 
-    const groceries = result.categoryTotals.find((c) => c.category === Category.Groceries)
-    const restaurants = result.categoryTotals.find((c) => c.category === Category.Restaurants)
+    const groceries = result.categoryTotals.find(
+      (c) => c.category === Category.Groceries
+    )
+    const restaurants = result.categoryTotals.find(
+      (c) => c.category === Category.Restaurants
+    )
 
     expect(groceries?.amount).toBe(100)
     expect(restaurants?.amount).toBe(50)
-    expect((groceries as { deltaVsPriorPeriod?: unknown }).deltaVsPriorPeriod).toBeUndefined()
+    expect(
+      (groceries as { deltaVsPriorPeriod?: unknown }).deltaVsPriorPeriod
+    ).toBeUndefined()
 
-    const totalPct = result.categoryTotals.reduce((sum, c) => sum + c.pctOfTotal, 0)
+    const totalPct = result.categoryTotals.reduce(
+      (sum, c) => sum + c.pctOfTotal,
+      0
+    )
     expect(totalPct).toBeCloseTo(100, 5)
   })
 
   it('excludes credits, ignored/transfer categories, and split parents from category totals', () => {
     const transactions = [
-      makeTransaction('income', { date: new Date('2026-06-05'), amount: 1000, type: 'credit', category: Category.Income }),
-      makeTransaction('transfer', { date: new Date('2026-06-06'), amount: 200, category: Category.InternalTransfer }),
-      makeTransaction('split-parent', { date: new Date('2026-06-07'), amount: 300, category: Category.Groceries, isSplitParent: true }),
-      makeTransaction('real', { date: new Date('2026-06-08'), amount: 25, category: Category.Groceries }),
+      makeTransaction('income', {
+        date: new Date('2026-06-05'),
+        amount: 1000,
+        type: 'credit',
+        category: Category.Income,
+      }),
+      makeTransaction('transfer', {
+        date: new Date('2026-06-06'),
+        amount: 200,
+        category: Category.InternalTransfer,
+      }),
+      makeTransaction('split-parent', {
+        date: new Date('2026-06-07'),
+        amount: 300,
+        category: Category.Groceries,
+        isSplitParent: true,
+      }),
+      makeTransaction('real', {
+        date: new Date('2026-06-08'),
+        amount: 25,
+        category: Category.Groceries,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
@@ -72,46 +111,117 @@ describe('buildInsightInput', () => {
 
   it('ranks top merchants by converted spend across the entire history', () => {
     const transactions = [
-      makeTransaction('m1', { date: new Date('2026-01-01'), amount: 30, displayDescription: 'Netflix', category: Category.Entertainment }),
-      makeTransaction('m2', { date: new Date('2026-06-01'), amount: 20, displayDescription: 'Netflix', category: Category.Entertainment }),
-      makeTransaction('m3', { date: new Date('2026-06-02'), amount: 15, description: 'UBER TRIP', category: Category.Transport }),
+      makeTransaction('m1', {
+        date: new Date('2026-01-01'),
+        amount: 30,
+        displayDescription: 'Netflix',
+        category: Category.Entertainment,
+      }),
+      makeTransaction('m2', {
+        date: new Date('2026-06-01'),
+        amount: 20,
+        displayDescription: 'Netflix',
+        category: Category.Entertainment,
+      }),
+      makeTransaction('m3', {
+        date: new Date('2026-06-02'),
+        amount: 15,
+        description: 'UBER TRIP',
+        category: Category.Transport,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
 
-    expect(result.topMerchants[0]).toEqual({ merchant: 'Netflix', amount: 50, count: 2 })
-    expect(result.topMerchants[1]).toEqual({ merchant: 'UBER TRIP', amount: 15, count: 1 })
+    expect(result.topMerchants[0]).toEqual({
+      merchant: 'Netflix',
+      amount: 50,
+      count: 2,
+    })
+    expect(result.topMerchants[1]).toEqual({
+      merchant: 'UBER TRIP',
+      amount: 15,
+      count: 1,
+    })
   })
 
   it('detects an active recurring monthly charge with a small monthsSinceLastSeen', () => {
     const transactions = [
-      makeTransaction('s1', { date: new Date('2026-03-10'), amount: 15, displayDescription: 'Spotify', category: Category.Entertainment }),
-      makeTransaction('s2', { date: new Date('2026-04-10'), amount: 15, displayDescription: 'Spotify', category: Category.Entertainment }),
-      makeTransaction('s3', { date: new Date('2026-05-10'), amount: 15, displayDescription: 'Spotify', category: Category.Entertainment }),
-      makeTransaction('s4', { date: new Date('2026-06-10'), amount: 15.5, displayDescription: 'Spotify', category: Category.Entertainment }),
+      makeTransaction('s1', {
+        date: new Date('2026-03-10'),
+        amount: 15,
+        displayDescription: 'Spotify',
+        category: Category.Entertainment,
+      }),
+      makeTransaction('s2', {
+        date: new Date('2026-04-10'),
+        amount: 15,
+        displayDescription: 'Spotify',
+        category: Category.Entertainment,
+      }),
+      makeTransaction('s3', {
+        date: new Date('2026-05-10'),
+        amount: 15,
+        displayDescription: 'Spotify',
+        category: Category.Entertainment,
+      }),
+      makeTransaction('s4', {
+        date: new Date('2026-06-10'),
+        amount: 15.5,
+        displayDescription: 'Spotify',
+        category: Category.Entertainment,
+      }),
       // A single one-off large purchase — must not be flagged as recurring
-      makeTransaction('once', { date: new Date('2026-06-12'), amount: 900, displayDescription: 'Muebles del Este', category: Category.Shopping }),
+      makeTransaction('once', {
+        date: new Date('2026-06-12'),
+        amount: 900,
+        displayDescription: 'Muebles del Este',
+        category: Category.Shopping,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
 
-    const spotify = result.recurringCharges.find((c) => c.merchant === 'Spotify')
+    const spotify = result.recurringCharges.find(
+      (c) => c.merchant === 'Spotify'
+    )
     expect(spotify).toBeDefined()
     expect(spotify?.cadence).toBe('monthly')
     expect(spotify?.monthsSeen).toBe(4)
     expect(spotify?.lastSeenMonth).toBe('2026-06')
     expect(spotify?.monthsSinceLastSeen).toBe(0)
-    expect(result.recurringCharges.some((c) => c.merchant === 'Muebles del Este')).toBe(false)
+    expect(
+      result.recurringCharges.some((c) => c.merchant === 'Muebles del Este')
+    ).toBe(false)
   })
 
   it('detects a recurring charge across an unbounded history (no lookback window) and flags it as lapsed', () => {
     const transactions = [
       // Gym membership, charged monthly for 6 months, cancelled 8 months before the latest transaction
-      makeTransaction('gym1', { date: new Date('2023-01-05'), amount: 40, displayDescription: 'Gimnasio', category: Category.Personal }),
-      makeTransaction('gym2', { date: new Date('2023-02-05'), amount: 40, displayDescription: 'Gimnasio', category: Category.Personal }),
-      makeTransaction('gym3', { date: new Date('2023-03-05'), amount: 40, displayDescription: 'Gimnasio', category: Category.Personal }),
+      makeTransaction('gym1', {
+        date: new Date('2023-01-05'),
+        amount: 40,
+        displayDescription: 'Gimnasio',
+        category: Category.Personal,
+      }),
+      makeTransaction('gym2', {
+        date: new Date('2023-02-05'),
+        amount: 40,
+        displayDescription: 'Gimnasio',
+        category: Category.Personal,
+      }),
+      makeTransaction('gym3', {
+        date: new Date('2023-03-05'),
+        amount: 40,
+        displayDescription: 'Gimnasio',
+        category: Category.Personal,
+      }),
       // Latest transaction in history, 8 months after the gym's last charge
-      makeTransaction('latest', { date: new Date('2023-11-05'), amount: 20, category: Category.Groceries }),
+      makeTransaction('latest', {
+        date: new Date('2023-11-05'),
+        amount: 20,
+        category: Category.Groceries,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
@@ -125,9 +235,24 @@ describe('buildInsightInput', () => {
 
   it('does not flag a merchant with wildly varying amounts as recurring', () => {
     const transactions = [
-      makeTransaction('v1', { date: new Date('2026-03-10'), amount: 10, displayDescription: 'MercadoPago Varios', category: Category.Shopping }),
-      makeTransaction('v2', { date: new Date('2026-04-10'), amount: 200, displayDescription: 'MercadoPago Varios', category: Category.Shopping }),
-      makeTransaction('v3', { date: new Date('2026-05-10'), amount: 5, displayDescription: 'MercadoPago Varios', category: Category.Shopping }),
+      makeTransaction('v1', {
+        date: new Date('2026-03-10'),
+        amount: 10,
+        displayDescription: 'MercadoPago Varios',
+        category: Category.Shopping,
+      }),
+      makeTransaction('v2', {
+        date: new Date('2026-04-10'),
+        amount: 200,
+        displayDescription: 'MercadoPago Varios',
+        category: Category.Shopping,
+      }),
+      makeTransaction('v3', {
+        date: new Date('2026-05-10'),
+        amount: 5,
+        displayDescription: 'MercadoPago Varios',
+        category: Category.Shopping,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
@@ -137,10 +262,28 @@ describe('buildInsightInput', () => {
 
   it('builds a monthly trend using converted income/expense across the entire history', () => {
     const transactions = [
-      makeTransaction('may-income', { date: new Date('2026-05-01'), amount: 1000, type: 'credit', category: Category.Income }),
-      makeTransaction('may-expense', { date: new Date('2026-05-02'), amount: 400, category: Category.Groceries }),
-      makeTransaction('june-income', { date: new Date('2026-06-01'), amount: 1000, type: 'credit', category: Category.Income }),
-      makeTransaction('june-expense', { date: new Date('2026-06-02'), amount: 600, category: Category.Groceries }),
+      makeTransaction('may-income', {
+        date: new Date('2026-05-01'),
+        amount: 1000,
+        type: 'credit',
+        category: Category.Income,
+      }),
+      makeTransaction('may-expense', {
+        date: new Date('2026-05-02'),
+        amount: 400,
+        category: Category.Groceries,
+      }),
+      makeTransaction('june-income', {
+        date: new Date('2026-06-01'),
+        amount: 1000,
+        type: 'credit',
+        category: Category.Income,
+      }),
+      makeTransaction('june-expense', {
+        date: new Date('2026-06-02'),
+        amount: 600,
+        category: Category.Groceries,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
@@ -153,7 +296,12 @@ describe('buildInsightInput', () => {
 
   it('converts amounts to the requested home currency', () => {
     const transactions = [
-      makeTransaction('uyu1', { date: new Date('2026-06-05'), amount: 405, currency: 'UYU', category: Category.Groceries }),
+      makeTransaction('uyu1', {
+        date: new Date('2026-06-05'),
+        amount: 405,
+        currency: 'UYU',
+        category: Category.Groceries,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'USD', 40.5)
@@ -163,8 +311,16 @@ describe('buildInsightInput', () => {
 
   it('stamps historyStart/historyEnd from the earliest/latest transaction and homeCurrency on the result', () => {
     const transactions = [
-      makeTransaction('early', { date: new Date('2025-01-10'), amount: 10, category: Category.Groceries }),
-      makeTransaction('late', { date: new Date('2026-06-30'), amount: 10, category: Category.Groceries }),
+      makeTransaction('early', {
+        date: new Date('2025-01-10'),
+        amount: 10,
+        category: Category.Groceries,
+      }),
+      makeTransaction('late', {
+        date: new Date('2026-06-30'),
+        amount: 10,
+        category: Category.Groceries,
+      }),
     ]
 
     const result = buildInsightInput(transactions, 'UYU', 40.5)

--- a/src/services/insights/insight-data.ts
+++ b/src/services/insights/insight-data.ts
@@ -85,7 +85,7 @@ function merchantOf(tx: Transaction): string {
 function monthKeyDiff(fromMonthKey: string, toMonthKeyStr: string): number {
   const [fromYear, fromMonth] = fromMonthKey.split('-').map(Number)
   const [toYear, toMonth] = toMonthKeyStr.split('-').map(Number)
-  return (toYear * 12 + toMonth) - (fromYear * 12 + fromMonth)
+  return toYear * 12 + toMonth - (fromYear * 12 + fromMonth)
 }
 
 function buildCategoryTotals(

--- a/src/services/insights/insight-generator.test.ts
+++ b/src/services/insights/insight-generator.test.ts
@@ -151,7 +151,9 @@ describe('parseInsightsResponse', () => {
       insights: [{ type: 'trend', title: 'x', narrative: 'y' }],
     })
 
-    expect(parseInsightsResponse(text, baseInput).insights[0].severity).toBe('medium')
+    expect(parseInsightsResponse(text, baseInput).insights[0].severity).toBe(
+      'medium'
+    )
   })
 
   it('throws a descriptive error when the response is not valid JSON', () => {
@@ -162,7 +164,7 @@ describe('parseInsightsResponse', () => {
 })
 
 describe('generateInsights', () => {
-  it('calls Claude with the insights model and the user\'s API key', async () => {
+  it("calls Claude with the insights model and the user's API key", async () => {
     messagesCreateMock.mockResolvedValueOnce({
       content: [{ type: 'text', text: JSON.stringify({ insights: [] }) }],
     })
@@ -172,7 +174,9 @@ describe('generateInsights', () => {
     expect(messagesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'claude-opus-4-8',
-        messages: [{ role: 'user', content: expect.stringContaining('"historyStart"') }],
+        messages: [
+          { role: 'user', content: expect.stringContaining('"historyStart"') },
+        ],
       })
     )
   })

--- a/src/services/insights/insight-generator.ts
+++ b/src/services/insights/insight-generator.ts
@@ -1,7 +1,10 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { Currency } from '../../models'
 import type { InsightInput } from './insight-data'
-import { buildInsightSystemPrompt, buildInsightUserMessage } from './insight-prompt'
+import {
+  buildInsightSystemPrompt,
+  buildInsightUserMessage,
+} from './insight-prompt'
 
 export type InsightType =
   | 'bleeding_money'

--- a/src/services/parsers/bank-account-parser.ts
+++ b/src/services/parsers/bank-account-parser.ts
@@ -60,9 +60,7 @@ function parseCurrency(moneda: string): 'USD' | 'UYU' {
   if (moneda === 'USD' || moneda === 'UYU') {
     return moneda
   }
-  throw new Error(
-    `Moneda no reconocida: "${moneda}". Se esperaba USD o UYU.`
-  )
+  throw new Error(`Moneda no reconocida: "${moneda}". Se esperaba USD o UYU.`)
 }
 
 /**
@@ -188,7 +186,11 @@ function parseRow(
       .trim()
 
     // Auto-categorize based on transaction details
-    const { category, confidence, description: patternDescription } = categorizeTransaction(description, type)
+    const {
+      category,
+      confidence,
+      description: patternDescription,
+    } = categorizeTransaction(description, type)
 
     const transaction: Transaction = {
       id: generateTransactionId(

--- a/src/services/parsers/credit-card-parser.ts
+++ b/src/services/parsers/credit-card-parser.ts
@@ -184,7 +184,11 @@ function parseRow(
       (currency === 'UYU' && pesosAmount < 0)
 
     // Auto-categorize based on transaction details
-    const { category, confidence, description: patternDescription } = categorizeTransaction(
+    const {
+      category,
+      confidence,
+      description: patternDescription,
+    } = categorizeTransaction(
       rawTransaction.descripcion,
       isCredit ? 'credit' : 'debit'
     )

--- a/src/services/parsers/csv-categorization.integration.test.ts
+++ b/src/services/parsers/csv-categorization.integration.test.ts
@@ -1,59 +1,69 @@
-import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { Category } from '../../models';
-import { parseCSV } from './csv-parser';
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { Category } from '../../models'
+import { parseCSV } from './csv-parser'
 
 function parseSample(fileName: string) {
-  const samplePath = join(process.cwd(), 'samples', fileName);
-  const csvContent = readFileSync(samplePath, 'utf-8');
-  return parseCSV(csvContent, fileName);
+  const samplePath = join(process.cwd(), 'samples', fileName)
+  const csvContent = readFileSync(samplePath, 'utf-8')
+  return parseCSV(csvContent, fileName)
 }
 
 function categorizationRate(categories: string[]): number {
-  const categorized = categories.filter((category) => category !== Category.Uncategorized);
-  return categories.length > 0 ? categorized.length / categories.length : 0;
+  const categorized = categories.filter(
+    (category) => category !== Category.Uncategorized
+  )
+  return categories.length > 0 ? categorized.length / categories.length : 0
 }
 
 describe('CSV categorization coverage', () => {
   it('maintains minimum categorization ratio for credit card sample', () => {
-    const result = parseSample('CreditCardsMovementsDetail.csv');
-    const rate = categorizationRate(result.transactions.map((tx) => tx.category || Category.Uncategorized));
+    const result = parseSample('CreditCardsMovementsDetail.csv')
+    const rate = categorizationRate(
+      result.transactions.map((tx) => tx.category || Category.Uncategorized)
+    )
 
-    expect(result.transactions.length).toBeGreaterThan(0);
-    expect(rate).toBeGreaterThanOrEqual(0.6);
-  });
+    expect(result.transactions.length).toBeGreaterThan(0)
+    expect(rate).toBeGreaterThanOrEqual(0.6)
+  })
 
   it('maintains minimum categorization ratio for USD bank sample', () => {
-    const result = parseSample('USDmovements.csv');
-    const rate = categorizationRate(result.transactions.map((tx) => tx.category || Category.Uncategorized));
+    const result = parseSample('USDmovements.csv')
+    const rate = categorizationRate(
+      result.transactions.map((tx) => tx.category || Category.Uncategorized)
+    )
 
-    expect(result.transactions.length).toBeGreaterThan(0);
+    expect(result.transactions.length).toBeGreaterThan(0)
     // Incoming bank transfers (TRANSF INSTANTANEA RECIBIDA, CREDITO POR OPERACION EN SUPERNET
     // from external parties) are now intentionally Uncategorized so they are no longer
     // hidden from the Transactions list. Users can categorize them as Income to include
     // them in income charts; self-transfer pairing is handled by inferInternalTransfers.
-    expect(rate).toBeGreaterThanOrEqual(0.40);
-  });
+    expect(rate).toBeGreaterThanOrEqual(0.4)
+  })
 
   it('maintains minimum categorization ratio for UYU bank sample', () => {
-    const result = parseSample('UYUmovements.csv');
-    const rate = categorizationRate(result.transactions.map((tx) => tx.category || Category.Uncategorized));
+    const result = parseSample('UYUmovements.csv')
+    const rate = categorizationRate(
+      result.transactions.map((tx) => tx.category || Category.Uncategorized)
+    )
 
-    expect(result.transactions.length).toBeGreaterThan(0);
+    expect(result.transactions.length).toBeGreaterThan(0)
     // Same reasoning as USD: received transfers are Uncategorized by the categorizer.
-    expect(rate).toBeGreaterThanOrEqual(0.50);
-  });
+    expect(rate).toBeGreaterThanOrEqual(0.5)
+  })
 
   it('keeps strong overall categorization across all Santander samples', () => {
     const all = [
       ...parseSample('CreditCardsMovementsDetail.csv').transactions,
       ...parseSample('USDmovements.csv').transactions,
       ...parseSample('UYUmovements.csv').transactions,
-    ];
+    ]
 
-    const rate = categorizationRate(all.map((tx) => tx.category || Category.Uncategorized));
-    expect(all.length).toBeGreaterThan(0);
-    expect(rate).toBeGreaterThanOrEqual(0.7);
-  });
-});
+    const rate = categorizationRate(
+      all.map((tx) => tx.category || Category.Uncategorized)
+    )
+    expect(all.length).toBeGreaterThan(0)
+    expect(rate).toBeGreaterThanOrEqual(0.7)
+  })
+})

--- a/src/services/supabase/ai-insights.test.ts
+++ b/src/services/supabase/ai-insights.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SupabaseSession } from './client'
 
-const { selectMock, eqUserMock, singleMock, upsertMock, fromMock } = vi.hoisted(() => ({
-  selectMock: vi.fn(),
-  eqUserMock: vi.fn(),
-  singleMock: vi.fn(),
-  upsertMock: vi.fn(),
-  fromMock: vi.fn(),
-}))
+const { selectMock, eqUserMock, singleMock, upsertMock, fromMock } = vi.hoisted(
+  () => ({
+    selectMock: vi.fn(),
+    eqUserMock: vi.fn(),
+    singleMock: vi.fn(),
+    upsertMock: vi.fn(),
+    fromMock: vi.fn(),
+  })
+)
 
 vi.mock('./client', () => ({
   getSupabaseClient: () => ({

--- a/src/services/supabase/auth.ts
+++ b/src/services/supabase/auth.ts
@@ -90,9 +90,14 @@ export async function signOut(
 export async function requestPasswordReset(email: string): Promise<void> {
   const client = getSupabaseClient()
   const redirectTo = getPasswordRecoveryRedirectUrl()
-  const { error } = await client.auth.resetPasswordForEmail(email, redirectTo ? {
-    redirectTo,
-  } : undefined)
+  const { error } = await client.auth.resetPasswordForEmail(
+    email,
+    redirectTo
+      ? {
+          redirectTo,
+        }
+      : undefined
+  )
   if (error) {
     throw new Error(error.message)
   }

--- a/src/services/supabase/category-overrides.test.ts
+++ b/src/services/supabase/category-overrides.test.ts
@@ -29,7 +29,14 @@ const session: SupabaseSession = {
   token_type: 'bearer',
   expires_in: 3600,
   expires_at: 9999999999,
-  user: { id: 'user-1', email: 'test@example.com', app_metadata: {}, user_metadata: {}, aud: 'authenticated', created_at: '' },
+  user: {
+    id: 'user-1',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '',
+  },
 }
 
 describe('supabase category overrides service', () => {

--- a/src/services/supabase/client.test.ts
+++ b/src/services/supabase/client.test.ts
@@ -16,7 +16,8 @@ describe('supabase client service', () => {
   })
 
   it('stores, loads, and clears session from localStorage', async () => {
-    const { storeSession, loadStoredSession, clearStoredSession } = await import('./client')
+    const { storeSession, loadStoredSession, clearStoredSession } =
+      await import('./client')
 
     const session = {
       access_token: 'token',

--- a/src/services/supabase/custom-categories.test.ts
+++ b/src/services/supabase/custom-categories.test.ts
@@ -31,7 +31,14 @@ const session: SupabaseSession = {
   token_type: 'bearer',
   expires_in: 3600,
   expires_at: 9999999999,
-  user: { id: 'user-1', email: 'test@example.com', app_metadata: {}, user_metadata: {}, aud: 'authenticated', created_at: '' },
+  user: {
+    id: 'user-1',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '',
+  },
 }
 
 describe('supabase custom categories service', () => {

--- a/src/services/supabase/custom-patterns.test.ts
+++ b/src/services/supabase/custom-patterns.test.ts
@@ -193,7 +193,9 @@ describe('supabase custom-patterns service', () => {
     })
 
     it('throws when Supabase returns an error', async () => {
-      eqDeleteUserMock.mockResolvedValue({ error: { message: 'bulk delete failed' } })
+      eqDeleteUserMock.mockResolvedValue({
+        error: { message: 'bulk delete failed' },
+      })
 
       const { deleteAllCustomPatterns } = await import('./custom-patterns')
       await expect(deleteAllCustomPatterns(session)).rejects.toThrow(

--- a/src/services/supabase/description-overrides.test.ts
+++ b/src/services/supabase/description-overrides.test.ts
@@ -87,9 +87,8 @@ describe('supabase description overrides service', () => {
   })
 
   it('upserts an override', async () => {
-    const { upsertDescriptionOverride } = await import(
-      './description-overrides'
-    )
+    const { upsertDescriptionOverride } =
+      await import('./description-overrides')
     await upsertDescriptionOverride(session, {
       descriptionNormalized: 'devoto',
       descriptionOriginal: 'AUT 998877 DEVOTO',
@@ -104,9 +103,8 @@ describe('supabase description overrides service', () => {
   })
 
   it('deletes an override', async () => {
-    const { deleteDescriptionOverride } = await import(
-      './description-overrides'
-    )
+    const { deleteDescriptionOverride } =
+      await import('./description-overrides')
     await deleteDescriptionOverride(session, 'devoto')
 
     expect(deleteMock).toHaveBeenCalledTimes(1)
@@ -117,4 +115,3 @@ describe('supabase description overrides service', () => {
     )
   })
 })
-

--- a/src/services/supabase/description-overrides.ts
+++ b/src/services/supabase/description-overrides.ts
@@ -87,4 +87,3 @@ export async function deleteDescriptionOverride(
     throw new Error(error.message)
   }
 }
-

--- a/src/services/supabase/import-runs.test.ts
+++ b/src/services/supabase/import-runs.test.ts
@@ -29,7 +29,14 @@ const session: SupabaseSession = {
   token_type: 'bearer',
   expires_in: 3600,
   expires_at: 9999999999,
-  user: { id: 'user-1', email: 'test@example.com', app_metadata: {}, user_metadata: {}, aud: 'authenticated', created_at: '' },
+  user: {
+    id: 'user-1',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '',
+  },
 }
 
 describe('supabase import runs service', () => {

--- a/src/services/supabase/transactions.test.ts
+++ b/src/services/supabase/transactions.test.ts
@@ -33,7 +33,14 @@ const session: SupabaseSession = {
   token_type: 'bearer',
   expires_in: 3600,
   expires_at: 9999999999,
-  user: { id: 'user-1', email: 'test@example.com', app_metadata: {}, user_metadata: {}, aud: 'authenticated', created_at: '' },
+  user: {
+    id: 'user-1',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '',
+  },
 }
 
 describe('supabase transactions service', () => {
@@ -151,7 +158,10 @@ describe('supabase transactions service', () => {
     const { restoreTransaction } = await import('./transactions')
     await restoreTransaction(session, 'tx-99')
 
-    expect(updateMock).toHaveBeenCalledWith({ is_deleted: false, deleted_at: null })
+    expect(updateMock).toHaveBeenCalledWith({
+      is_deleted: false,
+      deleted_at: null,
+    })
     expect(eqForUpdateMock).toHaveBeenCalledWith('user_id', 'user-1')
     expect(eqForUpdateIdMock).toHaveBeenCalledWith('transaction_id', 'tx-99')
   })

--- a/src/services/supabase/transactions.ts
+++ b/src/services/supabase/transactions.ts
@@ -238,12 +238,10 @@ export async function splitTransaction(
     tags: [],
   }))
 
-  const { error: childError } = await client
-    .from('transactions')
-    .upsert(
-      children.map((c) => transactionToRow(session.user.id, c)),
-      { onConflict: 'user_id,transaction_id' }
-    )
+  const { error: childError } = await client.from('transactions').upsert(
+    children.map((c) => transactionToRow(session.user.id, c)),
+    { onConflict: 'user_id,transaction_id' }
+  )
 
   if (childError) {
     await client

--- a/src/services/supabase/user-preferences.test.ts
+++ b/src/services/supabase/user-preferences.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SupabaseSession } from './client'
 
-const { fromMock, selectMock, eqMock, singleMock, upsertMock } = vi.hoisted(() => ({
-  fromMock: vi.fn(),
-  selectMock: vi.fn(),
-  eqMock: vi.fn(),
-  singleMock: vi.fn(),
-  upsertMock: vi.fn(),
-}))
+const { fromMock, selectMock, eqMock, singleMock, upsertMock } = vi.hoisted(
+  () => ({
+    fromMock: vi.fn(),
+    selectMock: vi.fn(),
+    eqMock: vi.fn(),
+    singleMock: vi.fn(),
+    upsertMock: vi.fn(),
+  })
+)
 
 vi.mock('./client', () => ({
   getSupabaseClient: () => ({ from: fromMock }),
@@ -52,7 +54,8 @@ describe('user-preferences service', () => {
     upsertMock.mockResolvedValue({ error: null })
 
     fromMock.mockImplementation((table: string) => {
-      if (table !== 'user_preferences') throw new Error(`unexpected table: ${table}`)
+      if (table !== 'user_preferences')
+        throw new Error(`unexpected table: ${table}`)
       return { select: selectMock, upsert: upsertMock }
     })
   })

--- a/src/services/transfers/internal-transfers.test.ts
+++ b/src/services/transfers/internal-transfers.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { Transaction } from '../../models'
 import { Category } from '../../models'
-import { inferInternalTransfers, isTransferCategory } from './internal-transfers'
+import {
+  inferInternalTransfers,
+  isTransferCategory,
+} from './internal-transfers'
 
 function makeTransaction(
   id: string,
@@ -51,7 +54,9 @@ describe('internal transfer inference', () => {
       }),
     ])
 
-    expect(result.every((tx) => tx.category === Category.InternalTransfer)).toBe(true)
+    expect(
+      result.every((tx) => tx.category === Category.InternalTransfer)
+    ).toBe(true)
   })
 
   it('does not override explicit non-transfer category with confidence 1', () => {
@@ -121,7 +126,9 @@ describe('internal transfer inference', () => {
       }),
     ])
 
-    expect(result.every((tx) => tx.category === Category.InternalTransfer)).toBe(true)
+    expect(
+      result.every((tx) => tx.category === Category.InternalTransfer)
+    ).toBe(true)
   })
 
   it('does not mark an unpaired credit supernet as Transfer (external incoming payment)', () => {
@@ -162,7 +169,9 @@ describe('internal transfer inference', () => {
       }),
     ])
 
-    expect(result.every((tx) => tx.category === Category.InternalTransfer)).toBe(true)
+    expect(
+      result.every((tx) => tx.category === Category.InternalTransfer)
+    ).toBe(true)
   })
 
   it('pairs a credit card payment credit (AI-tagged) with a bank account debit', () => {
@@ -190,7 +199,9 @@ describe('internal transfer inference', () => {
       }),
     ])
 
-    expect(result.every((tx) => tx.category === Category.InternalTransfer)).toBe(true)
+    expect(
+      result.every((tx) => tx.category === Category.InternalTransfer)
+    ).toBe(true)
   })
 
   it('does not pair unrelated debit and credit across currencies just because both are transfer descriptions', () => {

--- a/src/services/transfers/internal-transfers.ts
+++ b/src/services/transfers/internal-transfers.ts
@@ -74,11 +74,17 @@ function canAutoAssignTransfer(transaction: Transaction): boolean {
   return true
 }
 
-function markTransfer(transaction: Transaction, confidence: number): Transaction {
+function markTransfer(
+  transaction: Transaction,
+  confidence: number
+): Transaction {
   return {
     ...transaction,
     category: Category.InternalTransfer,
-    categoryConfidence: Math.max(transaction.categoryConfidence ?? 0, confidence),
+    categoryConfidence: Math.max(
+      transaction.categoryConfidence ?? 0,
+      confidence
+    ),
   }
 }
 
@@ -89,7 +95,10 @@ function markExternalTransfer(
   return {
     ...transaction,
     category: Category.ExternalTransfer,
-    categoryConfidence: Math.max(transaction.categoryConfidence ?? 0, confidence),
+    categoryConfidence: Math.max(
+      transaction.categoryConfidence ?? 0,
+      confidence
+    ),
   }
 }
 
@@ -108,7 +117,9 @@ export function isTransferCategory(category: string | undefined): boolean {
  * Heuristically tags internal bank movements as transfers.
  * The pass is idempotent and only updates auto-categorizable rows.
  */
-export function inferInternalTransfers(transactions: Transaction[]): Transaction[] {
+export function inferInternalTransfers(
+  transactions: Transaction[]
+): Transaction[] {
   const next = transactions.map((transaction) => ({ ...transaction }))
   const byId = new Map(next.map((transaction) => [transaction.id, transaction]))
   const pairedIds = new Set<string>()
@@ -267,5 +278,7 @@ export function inferInternalTransfers(transactions: Transaction[]): Transaction
     pairedIds.add(bestMatch.id)
   }
 
-  return transactions.map((transaction) => byId.get(transaction.id) ?? transaction)
+  return transactions.map(
+    (transaction) => byId.get(transaction.id) ?? transaction
+  )
 }

--- a/src/stores/transaction-store.test.ts
+++ b/src/stores/transaction-store.test.ts
@@ -98,7 +98,6 @@ describe('Transaction Store - Duplicates', () => {
 
     expect(duplicates).toEqual(['tx-2'])
   })
-
 })
 
 describe('Transaction Store - addTransactions', () => {
@@ -175,8 +174,12 @@ describe('Transaction Store - addTransactions', () => {
     store.getState().addTransactions([debit, credit])
 
     const txs = store.getState().transactions
-    expect(txs.find((tx) => tx.id === 'tx-debit')?.category).toBe('internal_transfer')
-    expect(txs.find((tx) => tx.id === 'tx-credit')?.category).toBe('internal_transfer')
+    expect(txs.find((tx) => tx.id === 'tx-debit')?.category).toBe(
+      'internal_transfer'
+    )
+    expect(txs.find((tx) => tx.id === 'tx-credit')?.category).toBe(
+      'internal_transfer'
+    )
   })
 })
 

--- a/src/stores/transaction-store.ts
+++ b/src/stores/transaction-store.ts
@@ -22,11 +22,15 @@ interface TransactionStoreActions {
 
 export type TransactionStore = TransactionStoreState & TransactionStoreActions
 
-export function normalizeTransactions(transactions: Transaction[]): Transaction[] {
+export function normalizeTransactions(
+  transactions: Transaction[]
+): Transaction[] {
   return inferInternalTransfers(
     transactions.map((tx) => {
       const date =
-        tx.date instanceof Date ? tx.date : new Date(tx.date as unknown as string)
+        tx.date instanceof Date
+          ? tx.date
+          : new Date(tx.date as unknown as string)
       return { ...tx, date }
     })
   )

--- a/src/styles/category-colors.css
+++ b/src/styles/category-colors.css
@@ -3,26 +3,26 @@
 
 :root {
   /* Light mode category colors */
-  --category-food: var(--accent-500);          /* Terracotta for food */
-  --category-transport: var(--primary-500);    /* Ocean blue for transport */
-  --category-utilities: var(--warning-500);    /* Amber for utilities */
-  --category-entertainment: #8b5cf6;           /* Purple for entertainment */
-  --category-shopping: #ec4899;                /* Pink for shopping */
-  --category-health: var(--success-500);       /* Mate green for health */
-  --category-education: #06b6d4;               /* Cyan for education */
-  --category-income: var(--success-600);       /* Darker green for income */
-  --category-other: var(--neutral-400);        /* Gray for uncategorized */
+  --category-food: var(--accent-500); /* Terracotta for food */
+  --category-transport: var(--primary-500); /* Ocean blue for transport */
+  --category-utilities: var(--warning-500); /* Amber for utilities */
+  --category-entertainment: #8b5cf6; /* Purple for entertainment */
+  --category-shopping: #ec4899; /* Pink for shopping */
+  --category-health: var(--success-500); /* Mate green for health */
+  --category-education: #06b6d4; /* Cyan for education */
+  --category-income: var(--success-600); /* Darker green for income */
+  --category-other: var(--neutral-400); /* Gray for uncategorized */
 }
 
 .dark {
   /* Dark mode category colors - adjusted for visibility */
-  --category-food: var(--accent-400);          /* Lighter terracotta */
-  --category-transport: var(--primary-400);    /* Lighter ocean blue */
-  --category-utilities: var(--warning-400);    /* Lighter amber */
-  --category-entertainment: #a78bfa;           /* Lighter purple */
-  --category-shopping: #f472b6;                /* Lighter pink */
-  --category-health: var(--success-400);       /* Lighter mate green */
-  --category-education: #22d3ee;               /* Lighter cyan */
-  --category-income: var(--success-400);       /* Lighter green */
-  --category-other: var(--neutral-500);        /* Lighter gray */
+  --category-food: var(--accent-400); /* Lighter terracotta */
+  --category-transport: var(--primary-400); /* Lighter ocean blue */
+  --category-utilities: var(--warning-400); /* Lighter amber */
+  --category-entertainment: #a78bfa; /* Lighter purple */
+  --category-shopping: #f472b6; /* Lighter pink */
+  --category-health: var(--success-400); /* Lighter mate green */
+  --category-education: #22d3ee; /* Lighter cyan */
+  --category-income: var(--success-400); /* Lighter green */
+  --category-other: var(--neutral-500); /* Lighter gray */
 }

--- a/src/styles/category-colors.test.ts
+++ b/src/styles/category-colors.test.ts
@@ -43,15 +43,33 @@ describe('Category Colors System', () => {
     it('should define category colors for transactions', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
-      expect(rootStyle.getPropertyValue('--category-food').trim()).toBe('#eb6f47')
-      expect(rootStyle.getPropertyValue('--category-transport').trim()).toBe('#0684f1')
-      expect(rootStyle.getPropertyValue('--category-utilities').trim()).toBe('#f59e0b')
-      expect(rootStyle.getPropertyValue('--category-entertainment').trim()).toBe('#8b5cf6')
-      expect(rootStyle.getPropertyValue('--category-shopping').trim()).toBe('#ec4899')
-      expect(rootStyle.getPropertyValue('--category-health').trim()).toBe('#22c55e')
-      expect(rootStyle.getPropertyValue('--category-education').trim()).toBe('#06b6d4')
-      expect(rootStyle.getPropertyValue('--category-income').trim()).toBe('#16a34a')
-      expect(rootStyle.getPropertyValue('--category-other').trim()).toBe('#94a3b8')
+      expect(rootStyle.getPropertyValue('--category-food').trim()).toBe(
+        '#eb6f47'
+      )
+      expect(rootStyle.getPropertyValue('--category-transport').trim()).toBe(
+        '#0684f1'
+      )
+      expect(rootStyle.getPropertyValue('--category-utilities').trim()).toBe(
+        '#f59e0b'
+      )
+      expect(
+        rootStyle.getPropertyValue('--category-entertainment').trim()
+      ).toBe('#8b5cf6')
+      expect(rootStyle.getPropertyValue('--category-shopping').trim()).toBe(
+        '#ec4899'
+      )
+      expect(rootStyle.getPropertyValue('--category-health').trim()).toBe(
+        '#22c55e'
+      )
+      expect(rootStyle.getPropertyValue('--category-education').trim()).toBe(
+        '#06b6d4'
+      )
+      expect(rootStyle.getPropertyValue('--category-income').trim()).toBe(
+        '#16a34a'
+      )
+      expect(rootStyle.getPropertyValue('--category-other').trim()).toBe(
+        '#94a3b8'
+      )
     })
   })
 
@@ -71,15 +89,33 @@ describe('Category Colors System', () => {
     it('should define adjusted category colors for dark mode', () => {
       const darkStyle = getComputedStyle(darkElement)
 
-      expect(darkStyle.getPropertyValue('--category-food').trim()).toBe('#f2916d')
-      expect(darkStyle.getPropertyValue('--category-transport').trim()).toBe('#30a3ff')
-      expect(darkStyle.getPropertyValue('--category-utilities').trim()).toBe('#fbbf24')
-      expect(darkStyle.getPropertyValue('--category-entertainment').trim()).toBe('#a78bfa')
-      expect(darkStyle.getPropertyValue('--category-shopping').trim()).toBe('#f472b6')
-      expect(darkStyle.getPropertyValue('--category-health').trim()).toBe('#4ade80')
-      expect(darkStyle.getPropertyValue('--category-education').trim()).toBe('#22d3ee')
-      expect(darkStyle.getPropertyValue('--category-income').trim()).toBe('#4ade80')
-      expect(darkStyle.getPropertyValue('--category-other').trim()).toBe('#64748b')
+      expect(darkStyle.getPropertyValue('--category-food').trim()).toBe(
+        '#f2916d'
+      )
+      expect(darkStyle.getPropertyValue('--category-transport').trim()).toBe(
+        '#30a3ff'
+      )
+      expect(darkStyle.getPropertyValue('--category-utilities').trim()).toBe(
+        '#fbbf24'
+      )
+      expect(
+        darkStyle.getPropertyValue('--category-entertainment').trim()
+      ).toBe('#a78bfa')
+      expect(darkStyle.getPropertyValue('--category-shopping').trim()).toBe(
+        '#f472b6'
+      )
+      expect(darkStyle.getPropertyValue('--category-health').trim()).toBe(
+        '#4ade80'
+      )
+      expect(darkStyle.getPropertyValue('--category-education').trim()).toBe(
+        '#22d3ee'
+      )
+      expect(darkStyle.getPropertyValue('--category-income').trim()).toBe(
+        '#4ade80'
+      )
+      expect(darkStyle.getPropertyValue('--category-other').trim()).toBe(
+        '#64748b'
+      )
     })
   })
 })

--- a/src/styles/chart-colors.css
+++ b/src/styles/chart-colors.css
@@ -3,20 +3,20 @@
 
 :root {
   /* Light mode chart colors */
-  --chart-1: var(--primary-500);       /* Ocean blue */
-  --chart-2: var(--accent-500);        /* Terracotta */
-  --chart-3: var(--success-500);       /* Mate green */
-  --chart-4: var(--warning-500);       /* Amber */
-  --chart-5: #8b5cf6;                  /* Purple */
-  --chart-6: #ec4899;                  /* Pink */
+  --chart-1: var(--primary-500); /* Ocean blue */
+  --chart-2: var(--accent-500); /* Terracotta */
+  --chart-3: var(--success-500); /* Mate green */
+  --chart-4: var(--warning-500); /* Amber */
+  --chart-5: #8b5cf6; /* Purple */
+  --chart-6: #ec4899; /* Pink */
 }
 
 .dark {
   /* Dark mode chart colors - lighter shades for better visibility */
-  --chart-1: var(--primary-400);       /* Lighter ocean blue */
-  --chart-2: var(--accent-400);        /* Lighter terracotta */
-  --chart-3: var(--success-400);       /* Lighter mate green */
-  --chart-4: var(--warning-400);       /* Lighter amber */
-  --chart-5: #a78bfa;                  /* Lighter purple */
-  --chart-6: #f472b6;                  /* Lighter pink */
+  --chart-1: var(--primary-400); /* Lighter ocean blue */
+  --chart-2: var(--accent-400); /* Lighter terracotta */
+  --chart-3: var(--success-400); /* Lighter mate green */
+  --chart-4: var(--warning-400); /* Lighter amber */
+  --chart-5: #a78bfa; /* Lighter purple */
+  --chart-6: #f472b6; /* Lighter pink */
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,12 +2,12 @@
 
 :root {
   /* Border Radius */
-  --radius-xs: 0.25rem;  /* 4px */
+  --radius-xs: 0.25rem; /* 4px */
   --radius-sm: 0.375rem; /* 6px */
-  --radius-md: 0.5rem;   /* 8px */
-  --radius-lg: 0.75rem;  /* 12px */
-  --radius-xl: 1rem;     /* 16px */
-  --radius-2xl: 1.5rem;  /* 24px */
+  --radius-md: 0.5rem; /* 8px */
+  --radius-lg: 0.75rem; /* 12px */
+  --radius-xl: 1rem; /* 16px */
+  --radius-2xl: 1.5rem; /* 24px */
   --radius-full: 9999px;
 
   /* Shadows - Light mode */
@@ -22,7 +22,9 @@
   /* Shadows - Dark mode (stronger for better visibility on dark backgrounds) */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.5);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.5);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
-  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.5), 0 8px 10px -6px rgb(0 0 0 / 0.5);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
+  --shadow-xl:
+    0 20px 25px -5px rgb(0 0 0 / 0.5), 0 8px 10px -6px rgb(0 0 0 / 0.5);
   --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.5);
 }

--- a/src/styles/layout.test.ts
+++ b/src/styles/layout.test.ts
@@ -58,11 +58,21 @@ describe('Layout System', () => {
     it('should define shadow scale from sm to 2xl', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
-      expect(rootStyle.getPropertyValue('--shadow-sm').trim()).toContain('0 1px 2px')
-      expect(rootStyle.getPropertyValue('--shadow-md').trim()).toContain('0 4px 6px')
-      expect(rootStyle.getPropertyValue('--shadow-lg').trim()).toContain('0 10px 15px')
-      expect(rootStyle.getPropertyValue('--shadow-xl').trim()).toContain('0 20px 25px')
-      expect(rootStyle.getPropertyValue('--shadow-2xl').trim()).toContain('0 25px 50px')
+      expect(rootStyle.getPropertyValue('--shadow-sm').trim()).toContain(
+        '0 1px 2px'
+      )
+      expect(rootStyle.getPropertyValue('--shadow-md').trim()).toContain(
+        '0 4px 6px'
+      )
+      expect(rootStyle.getPropertyValue('--shadow-lg').trim()).toContain(
+        '0 10px 15px'
+      )
+      expect(rootStyle.getPropertyValue('--shadow-xl').trim()).toContain(
+        '0 20px 25px'
+      )
+      expect(rootStyle.getPropertyValue('--shadow-2xl').trim()).toContain(
+        '0 25px 50px'
+      )
     })
   })
 

--- a/src/styles/spacing.css
+++ b/src/styles/spacing.css
@@ -1,15 +1,15 @@
 /* Spacing System - 4px base unit */
 
 :root {
-  --space-1: 0.25rem;   /* 4px */
-  --space-2: 0.5rem;    /* 8px */
-  --space-3: 0.75rem;   /* 12px */
-  --space-4: 1rem;      /* 16px */
-  --space-5: 1.25rem;   /* 20px */
-  --space-6: 1.5rem;    /* 24px */
-  --space-8: 2rem;      /* 32px */
-  --space-10: 2.5rem;   /* 40px */
-  --space-12: 3rem;     /* 48px */
-  --space-16: 4rem;     /* 64px */
-  --space-20: 5rem;     /* 80px */
+  --space-1: 0.25rem; /* 4px */
+  --space-2: 0.5rem; /* 8px */
+  --space-3: 0.75rem; /* 12px */
+  --space-4: 1rem; /* 16px */
+  --space-5: 1.25rem; /* 20px */
+  --space-6: 1.5rem; /* 24px */
+  --space-8: 2rem; /* 32px */
+  --space-10: 2.5rem; /* 40px */
+  --space-12: 3rem; /* 48px */
+  --space-16: 4rem; /* 64px */
+  --space-20: 5rem; /* 80px */
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -2,102 +2,107 @@
 
 :root {
   /* ── Prototype design tokens (warm bone canvas) ─────────────── */
-  --bg:            oklch(0.984 0.006 80);
-  --surface:       oklch(0.997 0.003 80);
-  --surface-2:     oklch(0.963 0.007 80);
-  --surface-3:     oklch(0.94 0.008 78);
-  --border:        oklch(0.905 0.008 75);
+  --bg: oklch(0.984 0.006 80);
+  --surface: oklch(0.997 0.003 80);
+  --surface-2: oklch(0.963 0.007 80);
+  --surface-3: oklch(0.94 0.008 78);
+  --border: oklch(0.905 0.008 75);
   --border-strong: oklch(0.84 0.01 75);
-  --text:          oklch(0.24 0.012 60);
-  --text-muted:    oklch(0.52 0.012 65);
-  --text-faint:    oklch(0.66 0.01 70);
+  --text: oklch(0.24 0.012 60);
+  --text-muted: oklch(0.52 0.012 65);
+  --text-faint: oklch(0.66 0.01 70);
 
-  --brand:         oklch(0.5 0.085 197);
-  --brand-hover:   oklch(0.44 0.085 197);
-  --brand-soft:    oklch(0.95 0.028 197);
-  --brand-text:    oklch(0.42 0.08 199);
+  --brand: oklch(0.5 0.085 197);
+  --brand-hover: oklch(0.44 0.085 197);
+  --brand-soft: oklch(0.95 0.028 197);
+  --brand-text: oklch(0.42 0.08 199);
 
-  --pos:           oklch(0.53 0.12 153);
-  --pos-soft:      oklch(0.952 0.04 153);
-  --neg:           oklch(0.55 0.16 25);
-  --neg-soft:      oklch(0.955 0.03 30);
-  --accent:        oklch(0.7 0.13 62);
-  --accent-soft:   oklch(0.95 0.05 70);
+  --pos: oklch(0.53 0.12 153);
+  --pos-soft: oklch(0.952 0.04 153);
+  --neg: oklch(0.55 0.16 25);
+  --neg-soft: oklch(0.955 0.03 30);
+  --accent: oklch(0.7 0.13 62);
+  --accent-soft: oklch(0.95 0.05 70);
 
   /* ── Typography ──────────────────────────────────────────────── */
-  --font-sans:    'Hanken Grotesk', system-ui, -apple-system, sans-serif;
+  --font-sans: 'Hanken Grotesk', system-ui, -apple-system, sans-serif;
   --font-display: 'Spectral', Georgia, serif;
-  --font-mono:    'JetBrains Mono', ui-monospace, monospace;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
   /* Font sizes */
-  --text-xs:   0.75rem;
-  --text-sm:   0.875rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
   --text-base: 1rem;
-  --text-lg:   1.125rem;
-  --text-xl:   1.25rem;
-  --text-2xl:  1.5rem;
-  --text-3xl:  1.875rem;
-  --text-4xl:  2.25rem;
-  --text-5xl:  3rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+  --text-5xl: 3rem;
 
-  --font-weight-normal:   400;
-  --font-weight-medium:   500;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
   --font-weight-semibold: 600;
-  --font-weight-bold:     700;
+  --font-weight-bold: 700;
 
   /* ── Spacing ─────────────────────────────────────────────────── */
-  --space-1:  0.25rem;
-  --space-2:  0.5rem;
-  --space-3:  0.75rem;
-  --space-4:  1rem;
-  --space-5:  1.25rem;
-  --space-6:  1.5rem;
-  --space-8:  2rem;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
   --space-10: 2.5rem;
   --space-12: 3rem;
   --space-16: 4rem;
   --space-20: 5rem;
 
   /* ── Border radius ───────────────────────────────────────────── */
-  --radius-xs:   0.25rem;   /* 4px  */
-  --radius-sm:   0.5625rem; /* 9px  */
-  --radius-md:   0.75rem;   /* 12px */
-  --radius-lg:   1.125rem;  /* 18px */
-  --radius-xl:   1.375rem;  /* 22px */
-  --radius-2xl:  1.5rem;    /* 24px */
+  --radius-xs: 0.25rem; /* 4px  */
+  --radius-sm: 0.5625rem; /* 9px  */
+  --radius-md: 0.75rem; /* 12px */
+  --radius-lg: 1.125rem; /* 18px */
+  --radius-xl: 1.375rem; /* 22px */
+  --radius-2xl: 1.5rem; /* 24px */
   --radius-full: 9999px;
-  --radius:      var(--radius-md);  /* default: 12px */
+  --radius: var(--radius-md); /* default: 12px */
 
   /* ── Shadows ─────────────────────────────────────────────────── */
-  --shadow-sm: 0 1px 2px oklch(0.3 0.02 70 / 0.05), 0 1px 3px oklch(0.3 0.02 70 / 0.04);
-  --shadow-md: 0 2px 4px oklch(0.3 0.02 70 / 0.05), 0 6px 16px oklch(0.3 0.02 70 / 0.06);
-  --shadow-lg: 0 8px 24px oklch(0.3 0.02 70 / 0.1), 0 24px 48px oklch(0.3 0.02 70 / 0.1);
-  --shadow-xl: 0 10px 30px oklch(0.3 0.02 70 / 0.12), 0 28px 56px oklch(0.3 0.02 70 / 0.12);
-  --shadow-2xl: 0 20px 48px oklch(0.3 0.02 70 / 0.18), 0 40px 80px oklch(0.3 0.02 70 / 0.16);
+  --shadow-sm:
+    0 1px 2px oklch(0.3 0.02 70 / 0.05), 0 1px 3px oklch(0.3 0.02 70 / 0.04);
+  --shadow-md:
+    0 2px 4px oklch(0.3 0.02 70 / 0.05), 0 6px 16px oklch(0.3 0.02 70 / 0.06);
+  --shadow-lg:
+    0 8px 24px oklch(0.3 0.02 70 / 0.1), 0 24px 48px oklch(0.3 0.02 70 / 0.1);
+  --shadow-xl:
+    0 10px 30px oklch(0.3 0.02 70 / 0.12), 0 28px 56px oklch(0.3 0.02 70 / 0.12);
+  --shadow-2xl:
+    0 20px 48px oklch(0.3 0.02 70 / 0.18), 0 40px 80px oklch(0.3 0.02 70 / 0.16);
 
   /* ── Sidebar width ───────────────────────────────────────────── */
   --sidebar-w: 252px;
 
   /* ── Semantic aliases (used by existing Tailwind utilities) ───── */
-  --background:          var(--bg);
-  --foreground:          var(--text);
-  --card:                var(--surface);
-  --card-foreground:     var(--text);
-  --popover:             var(--surface);
-  --popover-foreground:  var(--text);
-  --primary:             var(--brand);
-  --primary-foreground:  #ffffff;
-  --secondary:           var(--surface-2);
+  --background: var(--bg);
+  --foreground: var(--text);
+  --card: var(--surface);
+  --card-foreground: var(--text);
+  --popover: var(--surface);
+  --popover-foreground: var(--text);
+  --primary: var(--brand);
+  --primary-foreground: #ffffff;
+  --secondary: var(--surface-2);
   --secondary-foreground: var(--text);
-  --muted:               var(--surface-2);
-  --muted-foreground:    var(--text-muted);
-  --accent-foreground:   var(--text);
-  --destructive:         var(--neg);
+  --muted: var(--surface-2);
+  --muted-foreground: var(--text-muted);
+  --accent-foreground: var(--text);
+  --destructive: var(--neg);
   --destructive-foreground: #ffffff;
-  --input:               var(--border);
-  --input-background:    var(--surface);
-  --switch-background:   var(--surface-3);
-  --ring:                var(--brand);
+  --input: var(--border);
+  --input-background: var(--surface);
+  --switch-background: var(--surface-3);
+  --ring: var(--brand);
 
   /* Chart colors */
   --chart-1: var(--brand);
@@ -109,7 +114,7 @@
 
   /* ── Numbered palette scales (kept for backward compat) ──────── */
   /* Primary / brand teal scale */
-  --primary-50:  oklch(0.97 0.02 197);
+  --primary-50: oklch(0.97 0.02 197);
   --primary-100: oklch(0.94 0.04 197);
   --primary-200: oklch(0.88 0.06 197);
   --primary-300: oklch(0.79 0.07 197);
@@ -121,7 +126,7 @@
   --primary-900: oklch(0.3 0.07 197);
 
   /* Accent / warm amber scale */
-  --accent-50:  oklch(0.97 0.02 70);
+  --accent-50: oklch(0.97 0.02 70);
   --accent-100: oklch(0.94 0.04 70);
   --accent-200: oklch(0.88 0.07 70);
   --accent-300: oklch(0.81 0.09 70);
@@ -133,7 +138,7 @@
   --accent-900: oklch(0.37 0.08 55);
 
   /* Success / income green scale */
-  --success-50:  oklch(0.97 0.02 153);
+  --success-50: oklch(0.97 0.02 153);
   --success-100: oklch(0.95 0.04 153);
   --success-200: oklch(0.9 0.07 153);
   --success-300: oklch(0.82 0.09 153);
@@ -145,7 +150,7 @@
   --success-900: oklch(0.3 0.08 153);
 
   /* Warning / amber scale */
-  --warning-50:  oklch(0.98 0.02 70);
+  --warning-50: oklch(0.98 0.02 70);
   --warning-100: oklch(0.95 0.05 70);
   --warning-200: oklch(0.9 0.09 70);
   --warning-300: oklch(0.84 0.12 70);
@@ -157,7 +162,7 @@
   --warning-900: oklch(0.38 0.1 55);
 
   /* Neutral / warm gray scale */
-  --neutral-50:  oklch(0.98 0.003 80);
+  --neutral-50: oklch(0.98 0.003 80);
   --neutral-100: oklch(0.963 0.007 80);
   --neutral-200: oklch(0.94 0.008 78);
   --neutral-300: oklch(0.905 0.008 75);
@@ -169,25 +174,25 @@
   --neutral-900: oklch(0.2 0.008 65);
 
   /* Category colors (kept from existing palette) */
-  --category-food:          #f97316;
-  --category-transport:     #3b82f6;
-  --category-utilities:     #f59e0b;
+  --category-food: #f97316;
+  --category-transport: #3b82f6;
+  --category-utilities: #f59e0b;
   --category-entertainment: #8b5cf6;
-  --category-shopping:      #ec4899;
-  --category-health:        #22c55e;
-  --category-education:     #06b6d4;
-  --category-income:        oklch(0.53 0.12 153);
-  --category-other:         oklch(0.66 0.01 70);
+  --category-shopping: #ec4899;
+  --category-health: #22c55e;
+  --category-education: #06b6d4;
+  --category-income: oklch(0.53 0.12 153);
+  --category-other: oklch(0.66 0.01 70);
 
   /* Sidebar tokens */
-  --sidebar:                    var(--surface);
-  --sidebar-foreground:         var(--text);
-  --sidebar-primary:            var(--brand);
+  --sidebar: var(--surface);
+  --sidebar-foreground: var(--text);
+  --sidebar-primary: var(--brand);
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent:             var(--surface-2);
-  --sidebar-accent-foreground:  var(--text);
-  --sidebar-border:             var(--border);
-  --sidebar-ring:               var(--brand);
+  --sidebar-accent: var(--surface-2);
+  --sidebar-accent-foreground: var(--text);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--brand);
 
   --font-size: 15px;
 }
@@ -200,27 +205,27 @@
 
 .dark {
   /* ── Dark mode prototype tokens (warm espresso charcoal) ─────── */
-  --bg:            oklch(0.162 0.008 65);
-  --surface:       oklch(0.205 0.009 66);
-  --surface-2:     oklch(0.246 0.01 66);
-  --surface-3:     oklch(0.285 0.011 66);
-  --border:        oklch(0.3 0.012 66);
+  --bg: oklch(0.162 0.008 65);
+  --surface: oklch(0.205 0.009 66);
+  --surface-2: oklch(0.246 0.01 66);
+  --surface-3: oklch(0.285 0.011 66);
+  --border: oklch(0.3 0.012 66);
   --border-strong: oklch(0.38 0.014 66);
-  --text:          oklch(0.95 0.006 80);
-  --text-muted:    oklch(0.69 0.012 72);
-  --text-faint:    oklch(0.54 0.01 70);
+  --text: oklch(0.95 0.006 80);
+  --text-muted: oklch(0.69 0.012 72);
+  --text-faint: oklch(0.54 0.01 70);
 
-  --brand:         oklch(0.74 0.09 196);
-  --brand-hover:   oklch(0.8 0.09 196);
-  --brand-soft:    oklch(0.31 0.045 200);
-  --brand-text:    oklch(0.82 0.085 196);
+  --brand: oklch(0.74 0.09 196);
+  --brand-hover: oklch(0.8 0.09 196);
+  --brand-soft: oklch(0.31 0.045 200);
+  --brand-text: oklch(0.82 0.085 196);
 
-  --pos:           oklch(0.74 0.13 153);
-  --pos-soft:      oklch(0.3 0.05 153);
-  --neg:           oklch(0.7 0.15 28);
-  --neg-soft:      oklch(0.32 0.06 28);
-  --accent:        oklch(0.8 0.12 70);
-  --accent-soft:   oklch(0.33 0.05 70);
+  --pos: oklch(0.74 0.13 153);
+  --pos-soft: oklch(0.3 0.05 153);
+  --neg: oklch(0.7 0.15 28);
+  --neg-soft: oklch(0.32 0.06 28);
+  --accent: oklch(0.8 0.12 70);
+  --accent-soft: oklch(0.33 0.05 70);
 
   /* Dark mode shadows */
   --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.3), 0 1px 3px oklch(0 0 0 / 0.25);
@@ -230,7 +235,7 @@
   --shadow-2xl: 0 20px 48px oklch(0 0 0 / 0.6), 0 40px 80px oklch(0 0 0 / 0.55);
 
   /* Neutral warm dark scale */
-  --neutral-50:  oklch(0.28 0.01 65);
+  --neutral-50: oklch(0.28 0.01 65);
   --neutral-100: oklch(0.285 0.011 66);
   --neutral-200: oklch(0.3 0.012 66);
   --neutral-300: oklch(0.38 0.014 66);
@@ -384,8 +389,12 @@
     font-weight: 500;
     letter-spacing: -0.01em;
   }
-  .amt-pos { color: var(--pos); }
-  .amt-neg { color: var(--text); }
+  .amt-pos {
+    color: var(--pos);
+  }
+  .amt-neg {
+    color: var(--text);
+  }
 
   ::selection {
     background: var(--brand-soft);
@@ -393,23 +402,38 @@
   }
 
   /* Scrollbar */
-  ::-webkit-scrollbar { width: 11px; height: 11px; }
-  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar {
+    width: 11px;
+    height: 11px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
   ::-webkit-scrollbar-thumb {
     background: var(--border-strong);
     border-radius: 999px;
     border: 3px solid var(--bg);
   }
-  ::-webkit-scrollbar-thumb:hover { background: var(--text-faint); }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--text-faint);
+  }
 }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateX(-50%) translateY(12px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;

--- a/src/styles/theme.test.ts
+++ b/src/styles/theme.test.ts
@@ -73,49 +73,63 @@ describe('Theme System', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--card').trim()).toBe('#ffffff')
-      expect(rootStyle.getPropertyValue('--card-foreground').trim()).toBe('#0f172a')
+      expect(rootStyle.getPropertyValue('--card-foreground').trim()).toBe(
+        '#0f172a'
+      )
     })
 
     it('should define popover tokens', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--popover').trim()).toBe('#ffffff')
-      expect(rootStyle.getPropertyValue('--popover-foreground').trim()).toBe('#0f172a')
+      expect(rootStyle.getPropertyValue('--popover-foreground').trim()).toBe(
+        '#0f172a'
+      )
     })
 
     it('should define primary semantic tokens', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--primary').trim()).toBe('#0066ce')
-      expect(rootStyle.getPropertyValue('--primary-foreground').trim()).toBe('#ffffff')
+      expect(rootStyle.getPropertyValue('--primary-foreground').trim()).toBe(
+        '#ffffff'
+      )
     })
 
     it('should define secondary semantic tokens', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--secondary').trim()).toBe('#f1f5f9')
-      expect(rootStyle.getPropertyValue('--secondary-foreground').trim()).toBe('#0f172a')
+      expect(rootStyle.getPropertyValue('--secondary-foreground').trim()).toBe(
+        '#0f172a'
+      )
     })
 
     it('should define muted tokens', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--muted').trim()).toBe('#f1f5f9')
-      expect(rootStyle.getPropertyValue('--muted-foreground').trim()).toBe('#64748b')
+      expect(rootStyle.getPropertyValue('--muted-foreground').trim()).toBe(
+        '#64748b'
+      )
     })
 
     it('should define accent semantic tokens', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--accent').trim()).toBe('#eb6f47')
-      expect(rootStyle.getPropertyValue('--accent-foreground').trim()).toBe('#ffffff')
+      expect(rootStyle.getPropertyValue('--accent-foreground').trim()).toBe(
+        '#ffffff'
+      )
     })
 
     it('should define destructive tokens', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
       expect(rootStyle.getPropertyValue('--destructive').trim()).toBe('#dc2626')
-      expect(rootStyle.getPropertyValue('--destructive-foreground').trim()).toBe('#ffffff')
+      expect(
+        rootStyle.getPropertyValue('--destructive-foreground').trim()
+      ).toBe('#ffffff')
     })
 
     it('should define input and border tokens', () => {
@@ -123,7 +137,9 @@ describe('Theme System', () => {
 
       expect(rootStyle.getPropertyValue('--border').trim()).toBe('#e2e8f0')
       expect(rootStyle.getPropertyValue('--input').trim()).toBe('#e2e8f0')
-      expect(rootStyle.getPropertyValue('--input-background').trim()).toBe('#ffffff')
+      expect(rootStyle.getPropertyValue('--input-background').trim()).toBe(
+        '#ffffff'
+      )
     })
 
     it('should define ring token for focus states', () => {
@@ -157,49 +173,63 @@ describe('Theme System', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--card').trim()).toBe('#1e293b')
-      expect(darkStyle.getPropertyValue('--card-foreground').trim()).toBe('#f8fafc')
+      expect(darkStyle.getPropertyValue('--card-foreground').trim()).toBe(
+        '#f8fafc'
+      )
     })
 
     it('should define dark mode popover tokens', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--popover').trim()).toBe('#1e293b')
-      expect(darkStyle.getPropertyValue('--popover-foreground').trim()).toBe('#f8fafc')
+      expect(darkStyle.getPropertyValue('--popover-foreground').trim()).toBe(
+        '#f8fafc'
+      )
     })
 
     it('should define dark mode primary semantic tokens', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--primary').trim()).toBe('#30a3ff')
-      expect(darkStyle.getPropertyValue('--primary-foreground').trim()).toBe('#0f172a')
+      expect(darkStyle.getPropertyValue('--primary-foreground').trim()).toBe(
+        '#0f172a'
+      )
     })
 
     it('should define dark mode secondary semantic tokens', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--secondary').trim()).toBe('#1e293b')
-      expect(darkStyle.getPropertyValue('--secondary-foreground').trim()).toBe('#f8fafc')
+      expect(darkStyle.getPropertyValue('--secondary-foreground').trim()).toBe(
+        '#f8fafc'
+      )
     })
 
     it('should define dark mode muted tokens', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--muted').trim()).toBe('#1e293b')
-      expect(darkStyle.getPropertyValue('--muted-foreground').trim()).toBe('#94a3b8')
+      expect(darkStyle.getPropertyValue('--muted-foreground').trim()).toBe(
+        '#94a3b8'
+      )
     })
 
     it('should define dark mode accent semantic tokens', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--accent').trim()).toBe('#f2916d')
-      expect(darkStyle.getPropertyValue('--accent-foreground').trim()).toBe('#0f172a')
+      expect(darkStyle.getPropertyValue('--accent-foreground').trim()).toBe(
+        '#0f172a'
+      )
     })
 
     it('should define dark mode destructive tokens', () => {
       const darkStyle = getComputedStyle(darkElement)
 
       expect(darkStyle.getPropertyValue('--destructive').trim()).toBe('#ef4444')
-      expect(darkStyle.getPropertyValue('--destructive-foreground').trim()).toBe('#ffffff')
+      expect(
+        darkStyle.getPropertyValue('--destructive-foreground').trim()
+      ).toBe('#ffffff')
     })
 
     it('should define dark mode input and border tokens', () => {
@@ -207,7 +237,9 @@ describe('Theme System', () => {
 
       expect(darkStyle.getPropertyValue('--border').trim()).toBe('#334155')
       expect(darkStyle.getPropertyValue('--input').trim()).toBe('#334155')
-      expect(darkStyle.getPropertyValue('--input-background').trim()).toBe('#1e293b')
+      expect(darkStyle.getPropertyValue('--input-background').trim()).toBe(
+        '#1e293b'
+      )
     })
 
     it('should define dark mode ring token', () => {

--- a/src/styles/typography.test.ts
+++ b/src/styles/typography.test.ts
@@ -77,9 +77,13 @@ describe('Typography System', () => {
     it('should define font family variables', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
-      expect(rootStyle.getPropertyValue('--font-sans')).toContain('Hanken Grotesk')
+      expect(rootStyle.getPropertyValue('--font-sans')).toContain(
+        'Hanken Grotesk'
+      )
       expect(rootStyle.getPropertyValue('--font-display')).toContain('Spectral')
-      expect(rootStyle.getPropertyValue('--font-mono')).toContain('JetBrains Mono')
+      expect(rootStyle.getPropertyValue('--font-mono')).toContain(
+        'JetBrains Mono'
+      )
     })
 
     it('should define font size scale from xs to 5xl', () => {
@@ -99,10 +103,18 @@ describe('Typography System', () => {
     it('should define font weight variables', () => {
       const rootStyle = getComputedStyle(document.documentElement)
 
-      expect(rootStyle.getPropertyValue('--font-weight-normal').trim()).toBe('400')
-      expect(rootStyle.getPropertyValue('--font-weight-medium').trim()).toBe('500')
-      expect(rootStyle.getPropertyValue('--font-weight-semibold').trim()).toBe('600')
-      expect(rootStyle.getPropertyValue('--font-weight-bold').trim()).toBe('700')
+      expect(rootStyle.getPropertyValue('--font-weight-normal').trim()).toBe(
+        '400'
+      )
+      expect(rootStyle.getPropertyValue('--font-weight-medium').trim()).toBe(
+        '500'
+      )
+      expect(rootStyle.getPropertyValue('--font-weight-semibold').trim()).toBe(
+        '600'
+      )
+      expect(rootStyle.getPropertyValue('--font-weight-bold').trim()).toBe(
+        '700'
+      )
     })
   })
 

--- a/src/utils/auth-errors.test.ts
+++ b/src/utils/auth-errors.test.ts
@@ -33,9 +33,9 @@ describe('mapAuthError', () => {
   })
 
   it('maps password too short', () => {
-    expect(mapAuthError(new Error('Password should be at least 6 characters'))).toBe(
-      'La contraseña debe tener al menos 6 caracteres.'
-    )
+    expect(
+      mapAuthError(new Error('Password should be at least 6 characters'))
+    ).toBe('La contraseña debe tener al menos 6 caracteres.')
   })
 
   it('maps too many requests', () => {

--- a/src/utils/auth-errors.ts
+++ b/src/utils/auth-errors.ts
@@ -4,9 +4,15 @@ const MAPPINGS: Array<[pattern: string, message: string]> = [
   ['invalid login credentials', 'Email o contraseña incorrectos.'],
   ['user already registered', 'Ya existe una cuenta con ese email.'],
   ['already exists', 'Ya existe una cuenta con ese email.'],
-  ['anonymous sign-ins are disabled', 'El registro no está disponible por el momento.'],
+  [
+    'anonymous sign-ins are disabled',
+    'El registro no está disponible por el momento.',
+  ],
   ['email not confirmed', 'Revisá tu casilla y confirmá tu email.'],
-  ['password should be at least', 'La contraseña debe tener al menos 6 caracteres.'],
+  [
+    'password should be at least',
+    'La contraseña debe tener al menos 6 caracteres.',
+  ],
   ['too many requests', 'Demasiados intentos. Esperá unos minutos.'],
   ['rate limit', 'Demasiados intentos. Esperá unos minutos.'],
 ]

--- a/src/utils/category-display.test.ts
+++ b/src/utils/category-display.test.ts
@@ -83,7 +83,11 @@ describe('getCategoryDisplay', () => {
 
   it('returns correct label and color for a custom (non-built-in) category', () => {
     listCustomCategoriesMock.mockReturnValue([
-      { id: 'transferencias-internas', label: 'Transferencias internas', color: '#0284c7' },
+      {
+        id: 'transferencias-internas',
+        label: 'Transferencias internas',
+        color: '#0284c7',
+      },
     ])
 
     const result = getCategoryDisplay('transferencias-internas')

--- a/src/utils/category-display.ts
+++ b/src/utils/category-display.ts
@@ -1,8 +1,8 @@
-import { Category, CATEGORY_COLORS, CATEGORY_LABELS } from '../models';
+import { Category, CATEGORY_COLORS, CATEGORY_LABELS } from '../models'
 import {
   getCategoryDefinition,
   ID_ALIASES,
-} from '../services/categories/category-registry';
+} from '../services/categories/category-registry'
 
 export type CategoryIconName =
   | 'groceries'
@@ -22,13 +22,13 @@ export type CategoryIconName =
   | 'internal_transfer'
   | 'external_transfer'
   | 'fees'
-  | 'uncategorized';
+  | 'uncategorized'
 
 export interface CategoryDisplay {
-  id: string;
-  label: string;
-  color: string;
-  icon: CategoryIconName;
+  id: string
+  label: string
+  color: string
+  icon: CategoryIconName
 }
 
 const MODERN_META: Record<Category, { icon: CategoryIconName }> = {
@@ -50,10 +50,10 @@ const MODERN_META: Record<Category, { icon: CategoryIconName }> = {
   [Category.ExternalTransfer]: { icon: 'external_transfer' },
   [Category.Fees]: { icon: 'fees' },
   [Category.Uncategorized]: { icon: 'uncategorized' },
-};
+}
 
 function isModernCategory(id: string): id is Category {
-  return Object.values(Category).includes(id as Category);
+  return Object.values(Category).includes(id as Category)
 }
 
 function humanizeCategoryId(categoryId: string): string {
@@ -62,28 +62,30 @@ function humanizeCategoryId(categoryId: string): string {
     .replace(/[_-]+/g, ' ')
     .split(/\s+/)
     .filter(Boolean)
-    .map((word) => word.toLowerCase());
+    .map((word) => word.toLowerCase())
 
   if (words.length === 0) {
-    return CATEGORY_LABELS[Category.Uncategorized];
+    return CATEGORY_LABELS[Category.Uncategorized]
   }
 
-  const humanized = words.join(' ');
-  return humanized.charAt(0).toUpperCase() + humanized.slice(1);
+  const humanized = words.join(' ')
+  return humanized.charAt(0).toUpperCase() + humanized.slice(1)
 }
 
-export function getCategoryDisplay(categoryId?: string | null): CategoryDisplay {
-  const normalizedId = (categoryId || Category.Uncategorized).toLowerCase();
+export function getCategoryDisplay(
+  categoryId?: string | null
+): CategoryDisplay {
+  const normalizedId = (categoryId || Category.Uncategorized).toLowerCase()
 
-  const modernId = ID_ALIASES[normalizedId] ?? normalizedId;
+  const modernId = ID_ALIASES[normalizedId] ?? normalizedId
   if (isModernCategory(modernId)) {
-    const def = getCategoryDefinition(modernId);
+    const def = getCategoryDefinition(modernId)
     return {
       id: modernId,
       label: def.label,
       color: def.color,
       icon: MODERN_META[modernId].icon,
-    };
+    }
   }
 
   const customDef = getCategoryDefinition(normalizedId)
@@ -101,5 +103,5 @@ export function getCategoryDisplay(categoryId?: string | null): CategoryDisplay 
     label: humanizeCategoryId(normalizedId),
     color: CATEGORY_COLORS[Category.Uncategorized],
     icon: MODERN_META[Category.Uncategorized].icon,
-  };
+  }
 }

--- a/src/utils/date-utils.test.ts
+++ b/src/utils/date-utils.test.ts
@@ -1,102 +1,102 @@
 // Tests for date utility functions
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest'
 import {
   getDateRangeForPeriod,
   isDateInPeriod,
   filterByPeriod,
   generatePeriodOptions,
-} from './date-utils';
+} from './date-utils'
 
 describe('date-utils', () => {
   describe('getDateRangeForPeriod', () => {
     it('should return correct range for week period', () => {
       // Wednesday, Jan 15, 2025
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const range = getDateRangeForPeriod('week', referenceDate);
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const range = getDateRangeForPeriod('week', referenceDate)
 
       // Week starts on Monday
-      expect(range.start.getDay()).toBe(1); // Monday
-      expect(range.end.getDay()).toBe(0); // Sunday
-    });
+      expect(range.start.getDay()).toBe(1) // Monday
+      expect(range.end.getDay()).toBe(0) // Sunday
+    })
 
     it('should return correct range for month period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const range = getDateRangeForPeriod('month', referenceDate);
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const range = getDateRangeForPeriod('month', referenceDate)
 
-      expect(range.start.getDate()).toBe(1); // First day of month
-      expect(range.end.getDate()).toBe(31); // Last day of January
-      expect(range.start.getMonth()).toBe(0); // January
-      expect(range.end.getMonth()).toBe(0); // January
-    });
+      expect(range.start.getDate()).toBe(1) // First day of month
+      expect(range.end.getDate()).toBe(31) // Last day of January
+      expect(range.start.getMonth()).toBe(0) // January
+      expect(range.end.getMonth()).toBe(0) // January
+    })
 
     it('should return correct range for quarter period', () => {
-      const referenceDate = new Date('2025-02-15T12:00:00');
-      const range = getDateRangeForPeriod('quarter', referenceDate);
+      const referenceDate = new Date('2025-02-15T12:00:00')
+      const range = getDateRangeForPeriod('quarter', referenceDate)
 
       // Q1 is Jan-Mar
-      expect(range.start.getMonth()).toBe(0); // January
-      expect(range.end.getMonth()).toBe(2); // March
-      expect(range.start.getDate()).toBe(1);
-      expect(range.end.getDate()).toBe(31); // March 31
-    });
+      expect(range.start.getMonth()).toBe(0) // January
+      expect(range.end.getMonth()).toBe(2) // March
+      expect(range.start.getDate()).toBe(1)
+      expect(range.end.getDate()).toBe(31) // March 31
+    })
 
     it('should return correct range for year period', () => {
-      const referenceDate = new Date('2025-06-15T12:00:00');
-      const range = getDateRangeForPeriod('year', referenceDate);
+      const referenceDate = new Date('2025-06-15T12:00:00')
+      const range = getDateRangeForPeriod('year', referenceDate)
 
-      expect(range.start.getMonth()).toBe(0); // January
-      expect(range.start.getDate()).toBe(1);
-      expect(range.end.getMonth()).toBe(11); // December
-      expect(range.end.getDate()).toBe(31);
-      expect(range.start.getFullYear()).toBe(2025);
-      expect(range.end.getFullYear()).toBe(2025);
-    });
+      expect(range.start.getMonth()).toBe(0) // January
+      expect(range.start.getDate()).toBe(1)
+      expect(range.end.getMonth()).toBe(11) // December
+      expect(range.end.getDate()).toBe(31)
+      expect(range.start.getFullYear()).toBe(2025)
+      expect(range.end.getFullYear()).toBe(2025)
+    })
 
     it('should use current date as default reference', () => {
-      const range = getDateRangeForPeriod('month');
-      const now = new Date();
+      const range = getDateRangeForPeriod('month')
+      const now = new Date()
 
-      expect(range.start.getMonth()).toBe(now.getMonth());
-      expect(range.end.getMonth()).toBe(now.getMonth());
-    });
-  });
+      expect(range.start.getMonth()).toBe(now.getMonth())
+      expect(range.end.getMonth()).toBe(now.getMonth())
+    })
+  })
 
   describe('isDateInPeriod', () => {
     it('should return true for date within week period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00'); // Wednesday
-      const testDate = new Date('2025-01-14T12:00:00'); // Tuesday (same week)
+      const referenceDate = new Date('2025-01-15T12:00:00') // Wednesday
+      const testDate = new Date('2025-01-14T12:00:00') // Tuesday (same week)
 
-      expect(isDateInPeriod(testDate, 'week', referenceDate)).toBe(true);
-    });
+      expect(isDateInPeriod(testDate, 'week', referenceDate)).toBe(true)
+    })
 
     it('should return false for date outside week period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00'); // Wednesday
-      const testDate = new Date('2025-01-20T12:00:00'); // Next week
+      const referenceDate = new Date('2025-01-15T12:00:00') // Wednesday
+      const testDate = new Date('2025-01-20T12:00:00') // Next week
 
-      expect(isDateInPeriod(testDate, 'week', referenceDate)).toBe(false);
-    });
+      expect(isDateInPeriod(testDate, 'week', referenceDate)).toBe(false)
+    })
 
     it('should return true for date within month period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const testDate = new Date('2025-01-25T12:00:00');
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const testDate = new Date('2025-01-25T12:00:00')
 
-      expect(isDateInPeriod(testDate, 'month', referenceDate)).toBe(true);
-    });
+      expect(isDateInPeriod(testDate, 'month', referenceDate)).toBe(true)
+    })
 
     it('should return false for date outside month period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const testDate = new Date('2025-02-15T12:00:00');
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const testDate = new Date('2025-02-15T12:00:00')
 
-      expect(isDateInPeriod(testDate, 'month', referenceDate)).toBe(false);
-    });
-  });
+      expect(isDateInPeriod(testDate, 'month', referenceDate)).toBe(false)
+    })
+  })
 
   describe('filterByPeriod', () => {
     interface TestItem {
-      id: number;
-      date: Date;
-      value: string;
+      id: number
+      date: Date
+      value: string
     }
 
     const testItems: TestItem[] = [
@@ -105,110 +105,126 @@ describe('date-utils', () => {
       { id: 3, date: new Date('2025-01-25'), value: 'item3' },
       { id: 4, date: new Date('2025-02-05'), value: 'item4' },
       { id: 5, date: new Date('2025-03-15'), value: 'item5' },
-    ];
+    ]
 
     it('should filter items by month period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const filtered = filterByPeriod(testItems, 'date', 'month', referenceDate);
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const filtered = filterByPeriod(testItems, 'date', 'month', referenceDate)
 
-      expect(filtered).toHaveLength(3);
-      expect(filtered.map(i => i.id)).toEqual([1, 2, 3]);
-    });
+      expect(filtered).toHaveLength(3)
+      expect(filtered.map((i) => i.id)).toEqual([1, 2, 3])
+    })
 
     it('should filter items by quarter period', () => {
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const filtered = filterByPeriod(testItems, 'date', 'quarter', referenceDate);
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const filtered = filterByPeriod(
+        testItems,
+        'date',
+        'quarter',
+        referenceDate
+      )
 
       // Q1 includes Jan, Feb, Mar
-      expect(filtered).toHaveLength(5);
-      expect(filtered.map(i => i.id)).toEqual([1, 2, 3, 4, 5]);
-    });
+      expect(filtered).toHaveLength(5)
+      expect(filtered.map((i) => i.id)).toEqual([1, 2, 3, 4, 5])
+    })
 
     it('should return empty array when no items match period', () => {
-      const referenceDate = new Date('2024-12-15T12:00:00');
-      const filtered = filterByPeriod(testItems, 'date', 'month', referenceDate);
+      const referenceDate = new Date('2024-12-15T12:00:00')
+      const filtered = filterByPeriod(testItems, 'date', 'month', referenceDate)
 
-      expect(filtered).toHaveLength(0);
-    });
+      expect(filtered).toHaveLength(0)
+    })
 
     it('should handle items with non-date values', () => {
       const invalidItems = [
         { id: 1, date: new Date('2025-01-15'), value: 'valid' },
         { id: 2, date: 'not-a-date' as unknown as Date, value: 'invalid' },
-      ];
+      ]
 
-      const referenceDate = new Date('2025-01-15T12:00:00');
-      const filtered = filterByPeriod(invalidItems, 'date', 'month', referenceDate);
+      const referenceDate = new Date('2025-01-15T12:00:00')
+      const filtered = filterByPeriod(
+        invalidItems,
+        'date',
+        'month',
+        referenceDate
+      )
 
-      expect(filtered).toHaveLength(1);
-      expect(filtered[0].id).toBe(1);
-    });
-  });
-});
+      expect(filtered).toHaveLength(1)
+      expect(filtered[0].id).toBe(1)
+    })
+  })
+})
 
 describe('generatePeriodOptions', () => {
   // Fixed reference: Sunday 15 June 2025 (Q2)
-  const TODAY = new Date('2025-06-15T12:00:00');
+  const TODAY = new Date('2025-06-15T12:00:00')
 
   it('always returns "all" as the first option with label "Todo"', () => {
-    const options = generatePeriodOptions([], TODAY);
-    expect(options[0].id).toBe('all');
-    expect(options[0].label).toBe('Todo');
-    expect(options[0].period).toBe('all');
-  });
+    const options = generatePeriodOptions([], TODAY)
+    expect(options[0].id).toBe('all')
+    expect(options[0].label).toBe('Todo')
+    expect(options[0].period).toBe('all')
+  })
 
   it('always includes week, current month, previous month, current quarter, and current year', () => {
-    const options = generatePeriodOptions([], TODAY);
-    const ids = options.map((o) => o.id);
-    expect(ids).toContain('this-week');
-    expect(ids).toContain('this-month');
-    expect(ids).toContain('prev-month');
-    expect(ids).toContain('q2-2025');
-    expect(ids).toContain('year-2025');
-  });
+    const options = generatePeriodOptions([], TODAY)
+    const ids = options.map((o) => o.id)
+    expect(ids).toContain('this-week')
+    expect(ids).toContain('this-month')
+    expect(ids).toContain('prev-month')
+    expect(ids).toContain('q2-2025')
+    expect(ids).toContain('year-2025')
+  })
 
   it('includes the previous quarter when it differs from the current quarter', () => {
     // June is Q2; previous quarter is Q1 2025
-    const options = generatePeriodOptions([], TODAY);
-    const ids = options.map((o) => o.id);
-    expect(ids).toContain('q1-2025');
-  });
+    const options = generatePeriodOptions([], TODAY)
+    const ids = options.map((o) => o.id)
+    expect(ids).toContain('q1-2025')
+  })
 
   it('labels current and previous month in Spanish', () => {
-    const options = generatePeriodOptions([], TODAY);
-    const thisMonth = options.find((o) => o.id === 'this-month');
-    const prevMonth = options.find((o) => o.id === 'prev-month');
-    expect(thisMonth?.label).toMatch(/Este mes \(jun/i);
-    expect(prevMonth?.label).toMatch(/Mes anterior \(may/i);
-  });
+    const options = generatePeriodOptions([], TODAY)
+    const thisMonth = options.find((o) => o.id === 'this-month')
+    const prevMonth = options.find((o) => o.id === 'prev-month')
+    expect(thisMonth?.label).toMatch(/Este mes \(jun/i)
+    expect(prevMonth?.label).toMatch(/Mes anterior \(may/i)
+  })
 
   it('includes previous year when transactionDates has a date from that year', () => {
-    const dates = [new Date('2024-11-01T12:00:00'), new Date('2025-03-15T12:00:00')];
-    const options = generatePeriodOptions(dates, TODAY);
-    const ids = options.map((o) => o.id);
-    expect(ids).toContain('year-2024');
-  });
+    const dates = [
+      new Date('2024-11-01T12:00:00'),
+      new Date('2025-03-15T12:00:00'),
+    ]
+    const options = generatePeriodOptions(dates, TODAY)
+    const ids = options.map((o) => o.id)
+    expect(ids).toContain('year-2024')
+  })
 
   it('does not include previous year when no transaction dates from that year', () => {
     // Use noon to avoid UTC-offset dates crossing the year boundary
-    const dates = [new Date('2025-03-15T12:00:00'), new Date('2025-05-15T12:00:00')];
-    const options = generatePeriodOptions(dates, TODAY);
-    const ids = options.map((o) => o.id);
-    expect(ids).not.toContain('year-2024');
-  });
+    const dates = [
+      new Date('2025-03-15T12:00:00'),
+      new Date('2025-05-15T12:00:00'),
+    ]
+    const options = generatePeriodOptions(dates, TODAY)
+    const ids = options.map((o) => o.id)
+    expect(ids).not.toContain('year-2024')
+  })
 
   it('does not include previous year for an empty transactionDates array', () => {
-    const options = generatePeriodOptions([], TODAY);
-    const ids = options.map((o) => o.id);
-    expect(ids).not.toContain('year-2024');
-  });
+    const options = generatePeriodOptions([], TODAY)
+    const ids = options.map((o) => o.id)
+    expect(ids).not.toContain('year-2024')
+  })
 
   it('respects the referenceDate parameter — January reference uses Jan/Dec labels', () => {
-    const january = new Date('2025-01-15T12:00:00');
-    const options = generatePeriodOptions([], january);
-    const thisMonth = options.find((o) => o.id === 'this-month');
-    const prevMonth = options.find((o) => o.id === 'prev-month');
-    expect(thisMonth?.label).toMatch(/ene/i);
-    expect(prevMonth?.label).toMatch(/dic/i);
-  });
-});
+    const january = new Date('2025-01-15T12:00:00')
+    const options = generatePeriodOptions([], january)
+    const thisMonth = options.find((o) => o.id === 'this-month')
+    const prevMonth = options.find((o) => o.id === 'prev-month')
+    expect(thisMonth?.label).toMatch(/ene/i)
+    expect(prevMonth?.label).toMatch(/dic/i)
+  })
+})

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -13,21 +13,21 @@ import {
   getQuarter,
   subMonths,
   format,
-} from 'date-fns';
-import { es } from 'date-fns/locale';
+} from 'date-fns'
+import { es } from 'date-fns/locale'
 
-export type Period = 'week' | 'month' | 'quarter' | 'year' | 'all';
+export type Period = 'week' | 'month' | 'quarter' | 'year' | 'all'
 
 export interface PeriodOption {
-  id: string;
-  label: string;
-  period: Period;
-  referenceDate?: Date;
+  id: string
+  label: string
+  period: Period
+  referenceDate?: Date
 }
 
 export interface DateRange {
-  start: Date;
-  end: Date;
+  start: Date
+  end: Date
 }
 
 /**
@@ -45,29 +45,29 @@ export function getDateRangeForPeriod(
       return {
         start: startOfWeek(referenceDate, { weekStartsOn: 1 }), // Monday
         end: endOfWeek(referenceDate, { weekStartsOn: 1 }),
-      };
+      }
     case 'month':
       return {
         start: startOfMonth(referenceDate),
         end: endOfMonth(referenceDate),
-      };
+      }
     case 'quarter':
       return {
         start: startOfQuarter(referenceDate),
         end: endOfQuarter(referenceDate),
-      };
+      }
     case 'year':
       return {
         start: startOfYear(referenceDate),
         end: endOfYear(referenceDate),
-      };
+      }
     case 'all':
       return {
         start: new Date(0),
         end: new Date(8640000000000000), // Max date
-      };
+      }
     default:
-      throw new Error(`Invalid period: ${period}`);
+      throw new Error(`Invalid period: ${period}`)
   }
 }
 
@@ -83,8 +83,8 @@ export function isDateInPeriod(
   period: Period,
   referenceDate: Date = new Date()
 ): boolean {
-  const range = getDateRangeForPeriod(period, referenceDate);
-  return isWithinInterval(date, { start: range.start, end: range.end });
+  const range = getDateRangeForPeriod(period, referenceDate)
+  return isWithinInterval(date, { start: range.start, end: range.end })
 }
 
 /**
@@ -102,18 +102,18 @@ export function filterByPeriod<T>(
   referenceDate: Date = new Date()
 ): T[] {
   if (period === 'all') {
-    return items;
+    return items
   }
 
-  const range = getDateRangeForPeriod(period, referenceDate);
+  const range = getDateRangeForPeriod(period, referenceDate)
 
   return items.filter((item) => {
-    const itemDate = item[dateKey];
+    const itemDate = item[dateKey]
     if (!(itemDate instanceof Date)) {
-      return false;
+      return false
     }
-    return isWithinInterval(itemDate, { start: range.start, end: range.end });
-  });
+    return isWithinInterval(itemDate, { start: range.start, end: range.end })
+  })
 }
 
 /**
@@ -126,14 +126,14 @@ export function generatePeriodOptions(
   transactionDates: Date[],
   today: Date = new Date()
 ): PeriodOption[] {
-  const options: PeriodOption[] = [];
+  const options: PeriodOption[] = []
 
   // Always show "All" option
   options.push({
     id: 'all',
     label: 'Todo',
     period: 'all',
-  });
+  })
 
   // Current week
   options.push({
@@ -141,48 +141,48 @@ export function generatePeriodOptions(
     label: 'Esta semana',
     period: 'week',
     referenceDate: today,
-  });
+  })
 
   // Current month
-  const currentMonthLabel = format(today, 'MMM yyyy', { locale: es });
+  const currentMonthLabel = format(today, 'MMM yyyy', { locale: es })
   options.push({
     id: 'this-month',
     label: `Este mes (${currentMonthLabel})`,
     period: 'month',
     referenceDate: today,
-  });
+  })
 
   // Previous month
-  const prevMonth = subMonths(today, 1);
-  const prevMonthLabel = format(prevMonth, 'MMM yyyy', { locale: es });
+  const prevMonth = subMonths(today, 1)
+  const prevMonthLabel = format(prevMonth, 'MMM yyyy', { locale: es })
   options.push({
     id: 'prev-month',
     label: `Mes anterior (${prevMonthLabel})`,
     period: 'month',
     referenceDate: prevMonth,
-  });
+  })
 
   // Current quarter
-  const currentQuarter = getQuarter(today);
-  const currentYear = today.getFullYear();
+  const currentQuarter = getQuarter(today)
+  const currentYear = today.getFullYear()
   options.push({
     id: `q${currentQuarter}-${currentYear}`,
     label: `Q${currentQuarter} ${currentYear}`,
     period: 'quarter',
     referenceDate: today,
-  });
+  })
 
   // Previous quarter (if different from current)
-  const prevQuarterDate = subMonths(today, 3);
-  const prevQuarter = getQuarter(prevQuarterDate);
-  const prevQuarterYear = prevQuarterDate.getFullYear();
+  const prevQuarterDate = subMonths(today, 3)
+  const prevQuarter = getQuarter(prevQuarterDate)
+  const prevQuarterYear = prevQuarterDate.getFullYear()
   if (prevQuarter !== currentQuarter || prevQuarterYear !== currentYear) {
     options.push({
       id: `q${prevQuarter}-${prevQuarterYear}`,
       label: `Q${prevQuarter} ${prevQuarterYear}`,
       period: 'quarter',
       referenceDate: prevQuarterDate,
-    });
+    })
   }
 
   // Current year
@@ -191,23 +191,23 @@ export function generatePeriodOptions(
     label: `${currentYear}`,
     period: 'year',
     referenceDate: today,
-  });
+  })
 
   // Previous year (if transactions exist from that year)
-  const prevYear = currentYear - 1;
+  const prevYear = currentYear - 1
   const hasTransactionsFromPrevYear = transactionDates.some(
     (d) => d.getFullYear() === prevYear
-  );
+  )
   if (hasTransactionsFromPrevYear) {
     options.push({
       id: `year-${prevYear}`,
       label: `${prevYear}`,
       period: 'year',
       referenceDate: new Date(prevYear, 6, 1), // Mid-year as reference
-    });
+    })
   }
 
-  return options;
+  return options
 }
 
 export function toDateKey(date: Date): string {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -14,7 +14,10 @@ export function formatCurrency(amount: number, currency: Currency): string {
   return `${symbol} ${formatted}`
 }
 
-export function formatCurrencyShort(amount: number, currency: Currency): string {
+export function formatCurrencyShort(
+  amount: number,
+  currency: Currency
+): string {
   const abs = Math.abs(toSafeNumber(amount))
   const sym = currency === 'UYU' ? '$U' : 'US$'
   if (abs >= 1_000_000) return `${sym} ${(abs / 1_000_000).toFixed(1)}M`

--- a/src/utils/user-display.test.ts
+++ b/src/utils/user-display.test.ts
@@ -19,11 +19,15 @@ function makeSession(overrides: {
 
 describe('getFriendlyName', () => {
   it('returns the first name from full_name metadata', () => {
-    expect(getFriendlyName(makeSession({ full_name: 'Maria Perez' }))).toBe('Maria')
+    expect(getFriendlyName(makeSession({ full_name: 'Maria Perez' }))).toBe(
+      'Maria'
+    )
   })
 
   it('capitalizes the first letter of full_name', () => {
-    expect(getFriendlyName(makeSession({ full_name: 'jose gazzano' }))).toBe('Jose')
+    expect(getFriendlyName(makeSession({ full_name: 'jose gazzano' }))).toBe(
+      'Jose'
+    )
   })
 
   it('handles single-word full_name', () => {
@@ -31,19 +35,27 @@ describe('getFriendlyName', () => {
   })
 
   it('derives name from email local-part when no full_name', () => {
-    expect(getFriendlyName(makeSession({ email: 'jose@example.com' }))).toBe('Jose')
+    expect(getFriendlyName(makeSession({ email: 'jose@example.com' }))).toBe(
+      'Jose'
+    )
   })
 
   it('strips trailing digits from email local-part', () => {
-    expect(getFriendlyName(makeSession({ email: 'jgazzano10@example.com' }))).toBe('Jgazzano')
+    expect(
+      getFriendlyName(makeSession({ email: 'jgazzano10@example.com' }))
+    ).toBe('Jgazzano')
   })
 
   it('takes first dot-separated segment from email', () => {
-    expect(getFriendlyName(makeSession({ email: 'maria.perez@example.com' }))).toBe('Maria')
+    expect(
+      getFriendlyName(makeSession({ email: 'maria.perez@example.com' }))
+    ).toBe('Maria')
   })
 
   it('takes first underscore-separated segment from email', () => {
-    expect(getFriendlyName(makeSession({ email: 'maria_perez@example.com' }))).toBe('Maria')
+    expect(
+      getFriendlyName(makeSession({ email: 'maria_perez@example.com' }))
+    ).toBe('Maria')
   })
 
   it('returns empty string when session is null', () => {


### PR DESCRIPTION
## Summary

`.prettierrc` defines the formatting contract CLAUDE.md documents, and `npm run format` implements it — but nothing ever verified it, so **109 files had drifted out of compliance**.

Closes #47

Deliberately sequenced last: this touches 109 files, so doing it while PRs were open would have put a conflict in front of every one of them. With all of them merged, it conflicts with nothing.

## Two commits, kept separate on purpose

**1. `style: apply Prettier across src`** — the reformat, with nothing else in it, so `git blame` stays usable and reviewers can skip it wholesale.

**2. `dx: enforce Prettier`** — the tooling change, reviewable on its own.

## The reformat is verified behavior-preserving, not assumed

A 109-file mechanical rewrite deserves more than "tests still pass":

1. **Test inventory identical** before and after — 77 files, 885 tests.
2. **Compiled every changed file with `esbuild --minify`** (output is formatting-independent, so any difference is semantic). **106 of 109 byte-identical.**
3. **The other 3 needed real investigation.** `Dashboard.tsx`, `Transactions.tsx` and `dev/AiCategorizationPreview.tsx` differed because Prettier moved a `{' '}` across a line break, redistributing a space between adjacent JSX text nodes:

   ```
   before: ["US$ ", {USD}, " ", "+ $U", " ", {UYU}]
   after:  ["US$",  " ", {USD}, " + $U", " ", {UYU}]
   ```

   Concatenation is the same, but I rendered both shapes and compared `textContent` rather than reasoning about JSX whitespace rules. All three identical — the dashboard currency split still reads exactly `US$ 1.234 + $U 5.678`.

   Worth noting none of these labels had test coverage, which is why the automated suite couldn't have caught a regression here. That gap is #66's territory.

## Enforcement

```json
"format:check": "prettier --check \"src/**/*.{ts,tsx,json,css,md}\"",
"tdd:verify":   "npm run format:check && npm run test:run && npm run lint",
"ci:check":     "npm run tdd:verify && npm run build"
```

- `tdd:verify` is what `.github/workflows/ci.yml` already runs, so this gates CI **and** local runs without touching the workflow file.
- `format:check` runs **first** — it is the fastest of the three to diagnose, so there is no reason to wait out the test suite for it.
- **`ci:check` now delegates to `tdd:verify`** instead of repeating test+lint. The two had already silently diverged: `ci:check` would have passed on unformatted code that CI rejects. Mirroring the workflow means a green local `ci:check` actually predicts a green CI run.
- **`eslint-config-prettier`**, last in `extends` — without it ESLint's stylistic rules and Prettier can disagree about the same line and fight each other.

## The gate was tested failing, not just passing

```
$ printf 'const   x   =    1;;' >> src/utils/memo.ts
$ npm run format:check   → exit 1, [warn] src/utils/memo.ts
$ git checkout -- src/utils/memo.ts
$ npm run format:check   → exit 0
```

A gate nobody has seen fail isn't a gate.

## Verification
`npm run ci:check` passes — format clean, 77 test files, 885 tests, lint clean, build succeeds.

## Tests
- [x] Added or updated tests for behavior changes — n/a, no behavior change (verified above)
- [x] `npm run test:run` passes
- [x] `npm run lint` passes

## Checklist
- [x] Follows project commit message format
- [x] No unrelated changes
- [x] No skipped tests without explanation